### PR TITLE
Fix resource loading and return default values

### DIFF
--- a/boto3/resources/action.py
+++ b/boto3/resources/action.py
@@ -50,7 +50,8 @@ class ServiceAction(object):
         response_resource_def = action_def.get('resource', {})
         if response_resource_def:
             self.response_handler = ResourceHandler(search_path, factory,
-                resource_defs, service_model, response_resource_def)
+                resource_defs, service_model, response_resource_def,
+                action_def.get('request', {}).get('operation'))
         else:
             self.response_handler = RawHandler(search_path)
 

--- a/boto3/resources/response.py
+++ b/boto3/resources/response.py
@@ -79,7 +79,7 @@ def build_empty_response(search_path, operation_name, service_model):
     :param operation_name: Name of the underlying service operation
     :type service_model: :ref:`botocore.model.ServiceModel`
     :param service_model: The Botocore service model
-    :rtype: dict, list, string, or None
+    :rtype: dict, list, or None
     :return: An appropriate empty value
     """
     response = None
@@ -109,8 +109,8 @@ def build_empty_response(search_path, operation_name, service_model):
         response = {}
     elif shape.type_name == 'list':
         response = []
-    elif shape.type_name == 'string':
-        response = ''
+    elif shape.type_name == 'map':
+        response = {}
 
     return response
 
@@ -233,7 +233,7 @@ class ResourceHandler(object):
                 parent, identifiers, search_response)
         else:
             # The response is should be empty, but that may mean an
-            # empty dict, list, string, or None.
+            # empty dict, list, or None.
             response = build_empty_response(self.search_path,
                 self.operation_name, self.service_model)
 

--- a/tests/unit/resources/test_action.py
+++ b/tests/unit/resources/test_action.py
@@ -111,5 +111,6 @@ class TestServiceActionCall(BaseTestCase):
         action(resource)
 
         handler_mock.assert_called_with('Container', factory, resource_defs,
-            service_model, self.action_def['resource'])
+            service_model, self.action_def['resource'],
+            self.action_def['request']['operation'])
         handler_mock.return_value.assert_called_with(resource, {}, 'response')

--- a/tests/unit/resources/test_response.py
+++ b/tests/unit/resources/test_response.py
@@ -187,15 +187,23 @@ class TestBuildEmptyResponse(BaseTestCase):
         self.assertFalse(len(response),
             'List should be empty')
 
+    def test_empty_map(self):
+        self.output_shape.type_name = 'map'
+
+        response = self.get_response()
+
+        self.assertIsInstance(response, dict,
+            'Map should default to empty dictionary')
+        self.assertFalse(response.items(),
+            'Dictionary should be empty')
+
     def test_empty_string(self):
         self.output_shape.type_name = 'string'
 
         response = self.get_response()
 
-        self.assertIsInstance(response, str,
-            'String should default to empty string')
-        self.assertFalse(len(response),
-            'String should be empty')
+        self.assertIsNone(response,
+            'String should default to None')
 
     def test_empty_integer(self):
         self.output_shape.type_name = 'integer'


### PR DESCRIPTION
This change fixes the resource data loading logic to use the identifiers
for determining plurality, and implements a function to build empty
responses given a service model and search path. The following now
work correctly:

``` python
>>> sqs = boto3.resource('sqs')
>>> queue = sqs.get_queue_by_name(QueueName='test')
>>> print(queue.url)
'http://...'
>>> print(queue.attributes)
{...}
```

Assuming you have zero messages in the queue, this now works as well:

``` python
>>> messages = queue.receive_messages()
>>> print(isinstanc(messages, list))
True
```

This means that code using the SDK can assume that `receive_messages`
will **always** return a list. Empty response handling tests have
moved into their own class; all other related tests have been updated.

cc @jamesls, @kyleknap 
