### PR TITLE
Operate on unique data for each instance

### DIFF
--- a/boto3/resources/base.py
+++ b/boto3/resources/base.py
@@ -22,6 +22,10 @@ class ServiceResource(object):
     :param client: A low-level Botocore client instance
     """
     def __init__(self, *args, **kwargs):
+        # Always work on a copy of meta, otherwise we would affect other
+        # instances of the same subclass.
+        self.meta = self.meta.copy()
+
         # Create a default client if none was passed
         if kwargs.get('client') is not None:
             self.meta['client'] = kwargs.get('client')

--- a/tests/unit/resources/test_factory.py
+++ b/tests/unit/resources/test_factory.py
@@ -294,6 +294,25 @@ class TestResourceFactory(BaseTestCase):
         self.assertEqual(message.receipt_handle, 'receipt',
             'Wrong receipt handle set on the message resource instance')
 
+    def test_resource_meta_unique(self):
+        queue_cls = self.load('test', 'Queue', {}, {}, None)
+
+        queue1 = queue_cls()
+        queue2 = queue_cls()
+
+        self.assertNotEqual(queue1, queue2)
+
+        self.assertEqual(queue1.meta, queue2.meta,
+            'Queue meta copies not equal after creation')
+
+        queue1.meta['data'] = {'id': 'foo'}
+        queue2.meta['data'] = {'id': 'bar'}
+
+        self.assertNotEqual(queue_cls.meta, queue1.meta,
+            'Modified queue instance data should not modify the class data')
+        self.assertNotEqual(queue1.meta, queue2.meta,
+            'Queue data should be unique to queue instance')
+
     @mock.patch('boto3.resources.factory.ServiceAction')
     def test_resource_calls_action(self, action_cls):
         model = {


### PR DESCRIPTION
This fixes the following bug:

```
>>> s3 = boto3.resource('s3')
>>> obj1 = s3.Object('my-bucket', 'my-key')
>>> obj2 = s3.Object('my-bucket', 'my-key')
>>> obj1.load()
>>> print(obj2.meta['data'])
{ ... }
```

The data from `obj1` was shared with `obj2` which prevented making
multiple unique instances of resources. This fixes the issue by
making each resource operate on a copy of the data, created at
instantiation time. Adds a test to ensure this works as expected.

cc @jamesls, @kyleknap 
