### PR TITLE
Fix installation via setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include README.rst
+include LICENSE
+include requirements.txt
+recursive-include boto3/data *.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git://github.com/boto/botocore.git#egg=botocore
+botocore==0.65.0
 jmespath==0.4.1
 six==1.7.3
 nose==1.3.3

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ packages = [
 ]
 
 requires = [
-    'botocore==0.62.0',
+    'botocore==0.65.0',
     'jmespath==0.4.1',
     'six==1.7.3',
 ]
@@ -41,12 +41,12 @@ setup(
     url='https://github.com/boto/boto3',
     scripts=[],
     packages=packages,
-    # package_data={
-    #     'boto3': [
-    #         'data/aws/resources/*.json',
-    #     ]
-    # },
-    # include_package_data=True,
+    package_data={
+        'boto3': [
+            'data/aws/resources/*.json',
+        ]
+    },
+    include_package_data=True,
     install_requires=requires,
     license=open("LICENSE").read(),
     classifiers=[


### PR DESCRIPTION
This fixes the currently broken installation of running `python setup.py
install` by updating the requirements to use Botocore 0.65.0 and making
sure the resource descriptions are included in the release tarball.

cc @kyleknap, thanks for pointing this out.
