### PR TITLE
Add a resource model abstraction.

### DIFF
--- a/boto3/resources/model.py
+++ b/boto3/resources/model.py
@@ -1,0 +1,294 @@
+# Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""
+The models defined in this file represent the resource JSON description
+format and provide a layer of abstraction from the raw JSON. The advantages
+of this are:
+
+* Pythonic interface (e.g. ``action.request.operation``)
+* Consumers need not change for minor JSON changes (e.g. renamed field)
+
+These models are used both by the resource factory to generate resource
+classes as well as by the documentation generator.
+"""
+
+
+class Identifier(object):
+    """
+    A resource identifier, given by its name.
+
+    :type name: string
+    :param name: The name of the identifier
+    """
+    def __init__(self, name):
+        #: (``string``) The name of the identifier
+        self.name = name
+
+
+class Action(object):
+    """
+    A service operation action.
+
+    :type name: string
+    :param name: The name of the action
+    :type definition: dict
+    :param definition: The JSON definition
+    :type resource_defs: dict
+    :param resource_defs: All resources defined in the service
+    """
+    def __init__(self, name, definition, resource_defs):
+        self._definition = definition
+
+        #: (``string``) The name of the action
+        self.name = name
+        #: (:py:class:`Request`) This action's request or ``None``
+        self.request = None
+        if 'request' in definition:
+            self.request = Request(definition.get('request', {}))
+        #: (:py:class:`ResponseResource`) This action's resource or ``None``
+        self.resource = None
+        if 'resource' in definition:
+            self.resource = ResponseResource(definition.get('resource', {}),
+                                             resource_defs)
+        #: (``string``) The JMESPath search path or ``None``
+        self.path = definition.get('path')
+
+
+class Request(object):
+    """
+    A service operation action request.
+
+    :type definition: dict
+    :param definition: The JSON definition
+    """
+    def __init__(self, definition):
+        self._definition = definition
+
+        #: (``string``) The name of the low-level service operation
+        self.operation = definition.get('operation')
+
+    @property
+    def params(self):
+        """
+        Get a list of auto-filled parameters for this request.
+
+        :type: list(:py:class:`Parameter`)
+        """
+        params = []
+
+        for item in self._definition.get('params', []):
+            params.append(
+                Parameter(item['target'], item['sourceType'], item['source']))
+
+        return params
+
+
+class Parameter(object):
+    """
+    An auto-filled parameter which has a source and target. For example,
+    the ``QueueUrl`` may be auto-filled from a resource's ``url`` identifier
+    when making calls to ``queue.receive_messages``.
+
+    :type target: string
+    :param target: The destination parameter name, e.g. ``QueueUrl``
+    :type source_type: string
+    :param source_type: Where the source is defined.
+    :type source: string
+    :param source: The source name, e.g. ``Url``
+    """
+    def __init__(self, target, source_type, source):
+        #: (``string``) The destination parameter name
+        self.target = target
+        #: (``string``) Where the source is defined
+        self.source_type = source_type
+        #: (``string``) The source name
+        self.source = source
+
+
+class ResponseResource(object):
+    """
+    A resource response to create after performing an action.
+
+    :type definition: dict
+    :param definition: The JSON definition
+    :type resource_defs: dict
+    :param resource_defs: All resources defined in the service
+    """
+    def __init__(self, definition, resource_defs):
+        self._definition = definition
+        self._resource_defs = resource_defs
+
+        #: (``string``) The name of the response resource type
+        self.type = definition.get('type')
+
+    @property
+    def identifiers(self):
+        """
+        A list of resource identifiers.
+
+        :type: list(:py:class:`Identifier`)
+        """
+        identifiers = []
+
+        for item in self._definition.get('identifiers', []):
+            identifiers.append(
+                Parameter(item['target'], item['sourceType'], item['source']))
+
+        return identifiers
+
+    @property
+    def model(self):
+        """
+        Get the resource model for the response resource.
+
+        :type: :py:class:`ResourceModel`
+        """
+        return ResourceModel(self.type, self._resource_defs[self.type],
+                             self._resource_defs)
+
+
+class Collection(Action):
+    """
+    A group of resources. See :py:class:`Action`.
+
+    :type name: string
+    :param name: The name of the collection
+    :type definition: dict
+    :param definition: The JSON definition
+    :type resource_defs: dict
+    :param resource_defs: All resources defined in the service
+    """
+    pass
+
+
+class SubResourceList(object):
+    """
+    A list of information about sub-resources. It includes access
+    to identifiers as well as resource names and models.
+
+    :type definition: dict
+    :param definition: The JSON definition
+    :type resource_defs: dict
+    :param resource_defs: All resources defined in the service
+    """
+    def __init__(self, definition, resource_defs):
+        self._definition = definition
+        self._resource_defs = resource_defs
+
+        #: (``dict``) Identifier key:value pairs
+        self.identifiers = definition.get('identifiers', {})
+        #: (``list``) A list of resource names
+        self.resource_names = definition.get('resources', [])
+
+    @property
+    def resources(self):
+        """
+        Get a list of resource models contained in this sub-resource
+        entry.
+
+        :type: list(:py:class:`ResourceModel`)
+        """
+        resources = []
+
+        for name in self.resource_names:
+            resources.append(
+                ResourceModel(name, self._resource_defs.get(name, {}),
+                              self._resource_defs))
+
+        return resources
+
+
+class ResourceModel(object):
+    """
+    A model representing a resource, defined via a JSON description
+    format. A resource has identifiers, attributes, actions,
+    sub-resources, references and collections. For more information
+    on resources, see :ref:`guide_resources`.
+
+    :type name: string
+    :param name: The name of this resource, e.g. ``sqs`` or ``Queue``
+    :type definition: dict
+    :param definition: The JSON definition
+    :type resource_defs: dict
+    :param resource_defs: All resources defined in the service
+    """
+    def __init__(self, name, definition, resource_defs):
+        self._definition = definition
+        self._resource_defs = resource_defs
+
+        #: (``string``) The name of this resource
+        self.name = name
+        #: (``string``) The service shape name for this resource or ``None``
+        self.shape = definition.get('shape')
+        #: (:py:class:`SubResourceList`) Sub-resource information or ``None``
+        self.sub_resources = None
+        if 'subResources' in definition:
+            self.sub_resources = SubResourceList(
+                definition.get('subResources', {}), resource_defs)
+
+    @property
+    def identifiers(self):
+        """
+        Get a list of resource identifiers.
+
+        :type: list(:py:class:`Identifier`)
+        """
+        identifiers = []
+
+        for item in self._definition.get('identifiers', []):
+            identifiers.append(Identifier(item['name']))
+
+        return identifiers
+
+    @property
+    def load(self):
+        """
+        Get the load action for this resource, if it is defined.
+
+        :type: :py:class:`Action` or ``None``
+        """
+        action = self._definition.get('load')
+
+        if action is not None:
+            action = Action('load', action, self._resource_defs)
+
+        return action
+
+    @property
+    def actions(self):
+        """
+        Get a list of actions for this resource.
+
+        :type: list(:py:class:`Action`)
+        """
+        actions = []
+
+        for name, item in self._definition.get('actions', {}).items():
+            actions.append(Action(name, item, self._resource_defs))
+
+        return actions
+
+    @property
+    def collections(self):
+        """
+        Get a list of collections for this resource.
+
+        :type: list(:py:class:`Collection`)
+        """
+        collections = []
+
+        for name, item in self._definition.get('hasMany', {}).items():
+            collections.append(Collection(name, item, self._resource_defs))
+
+        return collections

--- a/boto3/resources/params.py
+++ b/boto3/resources/params.py
@@ -14,24 +14,24 @@
 from botocore import xform_name
 
 
-def create_request_parameters(parent, request_def):
+def create_request_parameters(parent, request_model):
     """
     Handle request parameters that can be filled in from identifiers,
     resource data members or constants.
 
     :type parent: ServiceResource
     :param parent: The resource instance to which this action is attached.
-    :type request_def: dict
-    :param request_def: The action request definition.
+    :type request_model: :py:class:`~boto3.resources.model.Request`
+    :param request_model: The action request model.
     :rtype: dict
     :return: Pre-filled parameters to be sent to the request operation.
     """
     params = {}
 
-    for param in request_def.get('params', []):
-        source = param.get('source', '')
-        source_type = param.get('sourceType', '')
-        target = param.get('target', '')
+    for param in request_model.params:
+        source = param.source
+        source_type = param.source_type
+        target = param.target
 
         if source_type in ['identifier', 'dataMember']:
             # Resource identifier, e.g. queue.url

--- a/docs/source/reference/core/resources.rst
+++ b/docs/source/reference/core/resources.rst
@@ -4,6 +4,13 @@
 Resources Reference
 ===================
 
+Resource Model
+--------------
+
+.. automodule:: boto3.resources.model
+   :members:
+   :undoc-members:
+
 Request Parameters
 ------------------
 

--- a/tests/unit/resources/test_action.py
+++ b/tests/unit/resources/test_action.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 
 from boto3.resources.action import ServiceAction
+from boto3.resources.model import Action
 from tests import BaseTestCase, mock
 
 
@@ -26,6 +27,10 @@ class TestServiceActionCall(BaseTestCase):
             }
         }
 
+    @property
+    def action(self):
+        return Action('test', self.action_def, {})
+
     @mock.patch('boto3.resources.action.create_request_parameters',
                 return_value={})
     def test_service_action_creates_params(self, params_mock):
@@ -35,7 +40,7 @@ class TestServiceActionCall(BaseTestCase):
             'client': mock.Mock(),
         }
 
-        action = ServiceAction(self.action_def)
+        action = ServiceAction(self.action)
 
         action(resource, foo=1)
 
@@ -53,7 +58,7 @@ class TestServiceActionCall(BaseTestCase):
         operation = resource.meta['client'].get_frobs
         operation.return_value = 'response'
 
-        action = ServiceAction(self.action_def)
+        action = ServiceAction(self.action)
 
         response = action(resource, foo=1)
 
@@ -73,7 +78,7 @@ class TestServiceActionCall(BaseTestCase):
         operation = resource.meta['client'].get_frobs
         operation.return_value = 'response'
 
-        action = ServiceAction(self.action_def)
+        action = ServiceAction(self.action)
 
         handler_mock.return_value.return_value = 'response'
 
@@ -103,7 +108,9 @@ class TestServiceActionCall(BaseTestCase):
         resource_defs = {}
         service_model = mock.Mock()
 
-        action = ServiceAction(self.action_def, factory=factory,
+        action_model = self.action
+
+        action = ServiceAction(action_model, factory=factory,
             resource_defs=resource_defs, service_model=service_model)
 
         handler_mock.return_value.return_value = 'response'
@@ -111,6 +118,6 @@ class TestServiceActionCall(BaseTestCase):
         action(resource)
 
         handler_mock.assert_called_with('Container', factory, resource_defs,
-            service_model, self.action_def['resource'],
+            service_model, action_model.resource,
             self.action_def['request']['operation'])
         handler_mock.return_value.assert_called_with(resource, {}, 'response')

--- a/tests/unit/resources/test_collection.py
+++ b/tests/unit/resources/test_collection.py
@@ -14,6 +14,7 @@
 from botocore.model import ServiceModel
 from boto3.resources.collection import CollectionManager
 from boto3.resources.factory import ResourceFactory
+from boto3.resources.model import Collection
 from tests import BaseTestCase, mock
 
 
@@ -21,7 +22,15 @@ class TestResourceCollection(BaseTestCase):
     def setUp(self):
         super(TestResourceCollection, self).setUp()
 
-        self.collection_def = {}
+        # Minimal definition so things like repr work
+        self.collection_def = {
+            'request': {
+                'operation': 'TestOperation'
+            },
+            'resource': {
+                'type': 'Frob'
+            }
+        }
         self.client = mock.Mock()
         self.client.can_paginate.return_value = False
         meta = {
@@ -51,8 +60,11 @@ class TestResourceCollection(BaseTestCase):
             resource_defs['Frob']['identifiers'].append(
                 {'name': identifier['target']})
 
+        collection_model = Collection(
+            'test', self.collection_def, resource_defs)
+
         collection = CollectionManager(
-            self.collection_def, self.parent, self.factory,
+            collection_model, self.parent, self.factory,
             resource_defs, self.service_model)
         return collection
 

--- a/tests/unit/resources/test_factory.py
+++ b/tests/unit/resources/test_factory.py
@@ -430,7 +430,8 @@ class TestResourceFactory(BaseTestCase):
             resource.last_modified
 
     @mock.patch('boto3.resources.factory.CollectionManager')
-    def test_resource_loads_collections(self, collection_cls):
+    @mock.patch('boto3.resources.model.Collection')
+    def test_resource_loads_collections(self, mock_model, collection_cls):
         model = {
             'hasMany': {
                 u'Queues': {
@@ -447,6 +448,7 @@ class TestResourceFactory(BaseTestCase):
             'Queue': {}
         }
         service_model = ServiceModel({})
+        mock_model.return_value.name = 'Queues'
 
         resource = self.load('test', 'test', model, defs, service_model)()
 
@@ -455,5 +457,5 @@ class TestResourceFactory(BaseTestCase):
         self.assertEqual(resource.queues, collection_cls.return_value,
             'Queues collection should be a collection manager')
 
-        collection_cls.assert_called_with(model['hasMany']['Queues'],
+        collection_cls.assert_called_with(mock_model.return_value,
             resource, self.factory, defs, service_model)

--- a/tests/unit/resources/test_model.py
+++ b/tests/unit/resources/test_model.py
@@ -1,0 +1,146 @@
+# Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the 'license' file accompanying this file. This file is
+# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from boto3.resources.model import ResourceModel, Action, SubResourceList,\
+                                  Collection
+from tests import BaseTestCase
+
+
+class TestModels(BaseTestCase):
+    def test_resource_name(self):
+        model = ResourceModel('test', {}, {})
+
+        self.assertEqual(model.name, 'test')
+
+    def test_resource_shape(self):
+        model = ResourceModel('test', {
+            'shape': 'Frob'
+        }, {})
+
+        self.assertEqual(model.shape, 'Frob')
+
+    def test_resource_identifiers(self):
+        model = ResourceModel('test', {
+            'identifiers': [
+                {'name': 'one'},
+                {'name': 'two'}
+            ]
+        }, {})
+
+        self.assertEqual(model.identifiers[0].name, 'one')
+        self.assertEqual(model.identifiers[1].name, 'two')
+
+    def test_resource_action_raw(self):
+        model = ResourceModel('test', {
+            'actions': {
+                'GetFrobs': {
+                    'request': {
+                        'operation': 'GetFrobsOperation',
+                        'params': [
+                            {'target': 'FrobId', 'sourceType': 'identifier',
+                             'source': 'Id'}
+                        ]
+                    },
+                    'path': 'Container.Frobs[]'
+                }
+            }
+        }, {})
+
+        self.assertIsInstance(model.actions, list)
+        self.assertEqual(len(model.actions), 1)
+
+        action = model.actions[0]
+        self.assertIsInstance(action, Action)
+        self.assertEqual(action.request.operation, 'GetFrobsOperation')
+        self.assertIsInstance(action.request.params, list)
+        self.assertEqual(len(action.request.params), 1)
+        self.assertEqual(action.request.params[0].target, 'FrobId')
+        self.assertEqual(action.request.params[0].source_type, 'identifier')
+        self.assertEqual(action.request.params[0].source, 'Id')
+        self.assertEqual(action.path, 'Container.Frobs[]')
+
+    def test_resource_action_response_resource(self):
+        model = ResourceModel('test', {
+            'actions': {
+                'GetFrobs': {
+                    'resource': {
+                        'type': 'Frob'
+                    }
+                }
+            }
+        }, {
+            'Frob': {}
+        })
+
+        action = model.actions[0]
+        self.assertEqual(action.resource.type, 'Frob')
+        self.assertIsInstance(action.resource.model, ResourceModel)
+        self.assertEqual(action.resource.model.name, 'Frob')
+
+    def test_resource_load_action(self):
+        model = ResourceModel('test', {
+            'load': {
+                'request': {
+                    'operation': 'GetFrobInfo'
+                },
+                'path': '$'
+            }
+        }, {})
+
+        self.assertIsInstance(model.load, Action)
+        self.assertEqual(model.load.request.operation, 'GetFrobInfo')
+        self.assertEqual(model.load.path, '$')
+
+    def test_sub_resources(self):
+        model = ResourceModel('test', {
+            'subResources': {
+                'identifiers': {
+                    'FrobId': 'Id'
+                },
+                'resources': ['Frob']
+            }
+        }, {
+            'Frob': {}
+        })
+
+        self.assertIsInstance(model.sub_resources, SubResourceList)
+        self.assertEqual(model.sub_resources.identifiers['FrobId'], 'Id')
+        self.assertEqual(model.sub_resources.resource_names[0], 'Frob')
+
+        resource = model.sub_resources.resources[0]
+        self.assertEqual(resource.name, 'Frob')
+
+    def test_resource_collections(self):
+        model = ResourceModel('test', {
+            'hasMany': {
+                'Frobs': {
+                    'request': {
+                        'operation': 'GetFrobList'
+                    },
+                    'resource': {
+                        'type': 'Frob'
+                    },
+                    'path': 'FrobList[]'
+                }
+            }
+        }, {
+            'Frob': {}
+        })
+
+        self.assertIsInstance(model.collections, list)
+        self.assertEqual(len(model.collections), 1)
+        self.assertIsInstance(model.collections[0], Collection)
+        self.assertEqual(model.collections[0].request.operation, 'GetFrobList')
+        self.assertEqual(model.collections[0].resource.type, 'Frob')
+        self.assertEqual(model.collections[0].resource.model.name, 'Frob')
+        self.assertEqual(model.collections[0].path, 'FrobList[]')

--- a/tests/unit/resources/test_params.py
+++ b/tests/unit/resources/test_params.py
@@ -11,79 +11,74 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+from boto3.resources.model import Request
 from boto3.resources.params import create_request_parameters
 from tests import BaseTestCase, mock
 
 class TestServiceActionParams(BaseTestCase):
     def test_service_action_params_identifier(self):
-        action_def = {
-            'request': {
-                'operation': 'GetFrobs',
-                'params': [
-                    {
-                        'target': 'WarehouseUrl',
-                        'sourceType': 'identifier',
-                        'source': 'Url'
-                    }
-                ]
-            }
-        }
+        request_model = Request({
+            'operation': 'GetFrobs',
+            'params': [
+                {
+                    'target': 'WarehouseUrl',
+                    'sourceType': 'identifier',
+                    'source': 'Url'
+                }
+            ]
+        })
 
         parent = mock.Mock()
         parent.url = 'w-url'
 
-        params = create_request_parameters(parent, action_def['request'])
+        params = create_request_parameters(parent, request_model)
 
         self.assertEqual(params['WarehouseUrl'], 'w-url',
             'Parameter not set from resource identifier')
 
     def test_service_action_params_data_member(self):
-        action_def = {
-            'request': {
-                'operation': 'GetFrobs',
-                'params': [
-                    {
-                        'target': 'WarehouseUrl',
-                        'sourceType': 'dataMember',
-                        'source': 'some_member'
-                    }
-                ]
-            }
-        }
+        request_model = Request({
+            'operation': 'GetFrobs',
+            'params': [
+                {
+                    'target': 'WarehouseUrl',
+                    'sourceType': 'dataMember',
+                    'source': 'some_member'
+                }
+            ]
+        })
 
         parent = mock.Mock()
         parent.some_member = 'w-url'
 
-        params = create_request_parameters(parent, action_def['request'])
+        params = create_request_parameters(parent, request_model)
 
         self.assertEqual(params['WarehouseUrl'], 'w-url',
             'Parameter not set from resource property')
 
     def test_service_action_params_constants(self):
-        action_def = {
-            'request': {
-                'operation': 'GetFrobs',
-                'params': [
-                    {
-                        'target': 'Param1',
-                        'sourceType': 'string',
-                        'source': 'param1'
-                    },
-                    {
-                        'target': 'Param2',
-                        'sourceType': 'integer',
-                        'source': 123
-                    },
-                    {
-                        'target': 'Param3',
-                        'sourceType': 'boolean',
-                        'source': True
-                    }
-                ]
-            }
-        }
+        request_model = Request({
+            'operation': 'GetFrobs',
+            'params': [
+                {
+                    'target': 'Param1',
+                    'sourceType': 'string',
+                    'source': 'param1'
+                },
+                {
+                    'target': 'Param2',
+                    'sourceType': 'integer',
+                    'source': 123
+                },
+                {
+                    'target': 'Param3',
+                    'sourceType': 'boolean',
+                    'source': True
+                }
+            ]
+        })
 
-        params = create_request_parameters(None, action_def['request'])
+        params = create_request_parameters(None, request_model)
 
         self.assertEqual(params['Param1'], 'param1',
             'Parameter not set from string constant')
@@ -93,37 +88,33 @@ class TestServiceActionParams(BaseTestCase):
             'Parameter not set from boolean constant')
 
     def test_service_action_params_invalid(self):
-        action_def = {
-            'request': {
-                'operation': 'GetFrobs',
-                'params': [
-                    {
-                        'target': 'Param1',
-                        'sourceType': 'invalid',
-                        'source': 'param1'
-                    }
-                ]
-            }
-        }
+        request_model = Request({
+            'operation': 'GetFrobs',
+            'params': [
+                {
+                    'target': 'Param1',
+                    'sourceType': 'invalid',
+                    'source': 'param1'
+                }
+            ]
+        })
 
         with self.assertRaises(NotImplementedError):
-            create_request_parameters(None, action_def['request'])
+            create_request_parameters(None, request_model)
 
     def test_action_params_list(self):
-        action_def = {
-            'request': {
-                'operation': 'GetFrobs',
-                'params': [
-                    {
-                        'target': 'WarehouseUrls[0]',
-                        'sourceType': 'string',
-                        'source': 'w-url'
-                    }
-                ]
-            }
-        }
+        request_model = Request({
+            'operation': 'GetFrobs',
+            'params': [
+                {
+                    'target': 'WarehouseUrls[0]',
+                    'sourceType': 'string',
+                    'source': 'w-url'
+                }
+            ]
+        })
 
-        params = create_request_parameters(None, action_def['request'])
+        params = create_request_parameters(None, request_model)
 
         self.assertIsInstance(params['WarehouseUrls'], list,
             'Parameter did not create a list')

--- a/tests/unit/resources/test_response.py
+++ b/tests/unit/resources/test_response.py
@@ -13,6 +13,7 @@
 
 from tests import BaseTestCase, mock
 from boto3.resources.base import ServiceResource
+from boto3.resources.model import ResponseResource, Parameter
 from boto3.resources.factory import ResourceFactory
 from boto3.resources.response import build_identifiers, build_empty_response,\
                                      RawHandler, ResourceHandler
@@ -20,11 +21,8 @@ from boto3.resources.response import build_identifiers, build_empty_response,\
 
 class TestBuildIdentifiers(BaseTestCase):
     def test_build_identifier_from_res_path_scalar(self):
-        identifier_defs = [{
-            'target': 'Id',
-            'sourceType': 'responsePath',
-            'source': 'Container.Frob.Id'
-        }]
+        identifiers = [Parameter(target='Id', source_type='responsePath',
+                                 source='Container.Frob.Id')]
 
         parent = mock.Mock()
         params = {}
@@ -36,17 +34,14 @@ class TestBuildIdentifiers(BaseTestCase):
             }
         }
 
-        values = build_identifiers(identifier_defs, parent, params, response)
+        values = build_identifiers(identifiers, parent, params, response)
 
         self.assertEqual(values['id'], 'response-path',
             'Identifier loaded from responsePath scalar not set')
 
     def test_build_identifier_from_res_path_list(self):
-        identifier_defs = [{
-            'target': 'Id',
-            'sourceType': 'responsePath',
-            'source': 'Container.Frobs[].Id'
-        }]
+        identifiers = [Parameter(target='Id', source_type='responsePath',
+                       source='Container.Frobs[].Id')]
 
         parent = mock.Mock()
         params = {}
@@ -60,17 +55,14 @@ class TestBuildIdentifiers(BaseTestCase):
             }
         }
 
-        values = build_identifiers(identifier_defs, parent, params, response)
+        values = build_identifiers(identifiers, parent, params, response)
 
         self.assertEqual(values['id'], ['response-path'],
             'Identifier loaded from responsePath list not set')
 
     def test_build_identifier_from_parent_identifier(self):
-        identifier_defs = [{
-            'target': 'Id',
-            'sourceType': 'identifier',
-            'source': 'Id'
-        }]
+        identifiers = [Parameter(target='Id', source_type='identifier',
+                       source='Id')]
 
         parent = mock.Mock()
         parent.id = 'identifier'
@@ -81,17 +73,14 @@ class TestBuildIdentifiers(BaseTestCase):
             }
         }
 
-        values = build_identifiers(identifier_defs, parent, params, response)
+        values = build_identifiers(identifiers, parent, params, response)
 
         self.assertEqual(values['id'], 'identifier',
             'Identifier loaded from parent identifier not set')
 
     def test_build_identifier_from_parent_data_member(self):
-        identifier_defs = [{
-            'target': 'Id',
-            'sourceType': 'dataMember',
-            'source': 'Member'
-        }]
+        identifiers = [Parameter(target='Id', source_type='dataMember',
+                       source='Member')]
 
         parent = mock.Mock()
         parent.member = 'data-member'
@@ -102,17 +91,14 @@ class TestBuildIdentifiers(BaseTestCase):
             }
         }
 
-        values = build_identifiers(identifier_defs, parent, params, response)
+        values = build_identifiers(identifiers, parent, params, response)
 
         self.assertEqual(values['id'], 'data-member',
             'Identifier loaded from parent data member not set')
 
     def test_build_identifier_from_req_param(self):
-        identifier_defs = [{
-            'target': 'Id',
-            'sourceType': 'requestParameter',
-            'source': 'Param'
-        }]
+        identifiers = [Parameter(target='Id', source_type='requestParameter',
+                       source='Param')]
 
         parent = mock.Mock()
         params = {
@@ -124,17 +110,14 @@ class TestBuildIdentifiers(BaseTestCase):
             }
         }
 
-        values = build_identifiers(identifier_defs, parent, params, response)
+        values = build_identifiers(identifiers, parent, params, response)
 
         self.assertEqual(values['id'], 'request-param',
             'Identifier loaded from request parameter not set')
 
     def test_build_identifier_from_invalid_source_type(self):
-        identifier_defs = [{
-            'target': 'Id',
-            'sourceType': 'invalid',
-            'source': 'abc'
-        }]
+        identifiers = [Parameter(target='Id', source_type='invalid',
+                       source='abc')]
 
         parent = mock.Mock()
         params = {}
@@ -145,7 +128,7 @@ class TestBuildIdentifiers(BaseTestCase):
         }
 
         with self.assertRaises(NotImplementedError):
-            build_identifiers(identifier_defs, parent, params, response)
+            build_identifiers(identifiers, parent, params, response)
 
 
 class TestBuildEmptyResponse(BaseTestCase):
@@ -358,9 +341,11 @@ class TestResourceHandler(BaseTestCase):
                  'source': self.identifier_source},
             ]
         }
+        resource_model = ResponseResource(
+            request_resource_def, self.resource_defs)
 
         handler = ResourceHandler(search_path, self.factory,
-            self.resource_defs, self.service_model, request_resource_def,
+            self.resource_defs, self.service_model, resource_model,
             'GetFrobs')
         return handler(self.parent, self.params, response)
 


### PR DESCRIPTION
This change adds an abstraction over the raw JSON resource descriptions,
similar to how Botocore has a `ServiceModel` which abstracts its JSON
service descriptions. Advantages of this approach:
- Pythonic interface (e.g. `model.actions[0].request.operation`)
- Encapsulation of minor JSON changes (e.g. field name change)

All of the factory code is updated to use it and documentation code
will use it in the future. Tests have been updated accordingly
and the model has its own tests as well.

cc: @jamesls, @kyleknap
