### PR TITLE
Fix several name collisions.

### DIFF
--- a/tests/unit/resources/test_factory.py
+++ b/tests/unit/resources/test_factory.py
@@ -121,21 +121,24 @@ class TestResourceFactory(BaseTestCase):
         self.assertTrue(hasattr(TestResource, 'last_modified'),
             'LastModified shape member not available on resource')
 
-    def test_factory_fails_on_clobber_identifier(self):
+    def test_factory_renames_on_clobber_identifier(self):
         model = {
             'identifiers': [
                 {'name': 'Meta'}
             ]
         }
 
-        # This fails because each resource has a `meta` defined.
-        with self.assertRaises(ValueError):
-            self.load('test', 'test', model, {}, None)
+        # Each resource has a ``meta`` defined, so this identifier
+        # must be renamed.
+        cls = self.load('test', 'test', model, {}, None)
+
+        self.assertTrue(hasattr(cls, 'meta_identifier'))
 
     def test_factory_fails_on_clobber_action(self):
         model = {
             'identifiers': [
-                {'name': 'Test'}
+                {'name': 'Test'},
+                {'name': 'TestAction'}
             ],
             'actions': {
                 'Test': {

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -16,6 +16,29 @@ from boto3.session import Session
 from tests import mock, BaseTestCase
 
 
+def test_create_all_resources():
+    """
+    This generator yields test functions for each available
+    resource via its service name. Individual tests can fail
+    indepdendently to let you know which services are not
+    working and why.
+    """
+    session = Session(aws_access_key_id='dummy',
+                      aws_secret_access_key='dummy',
+                      region_name='us-east-1')
+    for service_name in session.get_available_resources():
+        # TODO: Remove items once supported by Botocore!
+        if service_name in ['glacier']:
+            # Not supported by Botocore yet...
+            continue
+
+        yield _test_create_resource, session, service_name
+
+def _test_create_resource(session, service_name):
+    # Instantiate a resource and make sure no exceptions are thrown.
+    session.resource(service_name)
+
+
 class TestSession(BaseTestCase):
     def test_repr(self):
         bc_session = self.bc_session_cls.return_value


### PR DESCRIPTION
This is a workaround to fix a couple of existing issues and hopefully
mitigate future problems with the resource JSON descriptions. It is
only a partial fix and does not update docs, but currently only
two issues exist:
1. `ec2.RouteTable.associations` is defined both as an attribute via its
   shape and via a `hasMany` collection. The collection is renamed to
   `associations_collection`.
2. `ec2.VpcPeeringConnection.vpc` is defined both as an attribute via its
   shape and via a `hasOne` reference. The reference is renamed to
   `vpc_reference`.

Tests have been updated to take this renaming into account, and
a warning is logged each time we rename something, so we can use that
in the future for auditing the resource JSON files.

The issues above were found by a new test, which just instantiates each
resource to ensure it's possible. Apparently Botocore does not support
Glacier yet, so I skip that one.

cc @jamesls, @kyleknap 
