### PR TITLE
Document references.

### DIFF
--- a/boto3/docs.py
+++ b/boto3/docs.py
@@ -256,6 +256,18 @@ def document_resource(service_name, official_name, resource_model,
 
         docs += '\n\n'
 
+    refs = resource_model.references + resource_model.reverse_references
+    if sorted(refs, key=lambda i: i.name):
+        docs += ('   .. rst-class:: admonition-title\n\n   References\n\n'
+                 '   References are related resource instances that have'
+                 ' a belongs-to relationship.\n\n')
+        for ref in refs:
+            docs += ('   .. py:attribute:: {0}\n\n      '
+                     '(:py:class:`{1}.{2}`) The related {3} if set,'
+                     ' otherwise ``None``.\n\n').format(
+                        xform_name(ref.name), service_name,
+                        ref.resource.type, ref.resource.type)
+
     if resource_model.collections:
         docs += ('   .. rst-class:: admonition-title\n\n   Collections\n\n'
                  '   Collections provide an interface to iterate and'


### PR DESCRIPTION
This adds documentation for references, e.g. an EC2 instance has a `vpc`
and a `subnet` reference. This also documents reverse references discovered
through the `subResources` association, such as an S3 object having a `bucket`
reference. Previously these were not documented.

Note: this does **not** take in to account #17, but will be modified to do so
in the future. Right now only one reference is affected: `VpcPeeringConnection.vpc`
has been renamed to `VpcPeeringConnection.vpc_reference` but this is not
reflected in the docs yet. It's on my short-list to fix but requires larger changes
to the codebase.

cc @jamesls, @kyleknap
