### PR TITLE
Implement reverse JMESPath support to build params

### DIFF
--- a/boto3/resources/params.py
+++ b/boto3/resources/params.py
@@ -83,13 +83,24 @@ def build_param_structure(params, target, value):
         # Is it indexing an array?
         result = INDEX_RE.search(part)
         if result:
-            index = int(result.group(1))
+            if result.group(1):
+                # We have an explicit index
+                index = int(result.group(1))
 
-            # Strip index off part name
-            part = part[:-len(str(index) + '[]')]
+                # Strip index off part name
+                part = part[:-len(str(index) + '[]')]
+            else:
+                # Index will be set after we know the proper part
+                # name and that it's a list instance.
+                index = None
+                part = part[:-2]
 
             if part not in pos or not isinstance(pos[part], list):
                 pos[part] = []
+
+            # This means we should append, e.g. 'foo[]'
+            if index is None:
+                index = len(pos[part])
 
             while len(pos[part]) <= index:
                 # Assume it's a dict until we set the final value below

--- a/tests/unit/resources/test_params.py
+++ b/tests/unit/resources/test_params.py
@@ -160,3 +160,11 @@ class TestStructBuilder(BaseTestCase):
         build_param_structure(params, 'foo[0].secret', 123)
         self.assertEqual(params['foo'][0]['key'], 'abc')
         self.assertEqual(params['foo'][0]['secret'], 123)
+
+    def test_append_no_index(self):
+        params = {}
+        build_param_structure(params, 'foo[]', 123)
+        self.assertEqual(params['foo'], [123])
+
+        build_param_structure(params, 'foo[]', 456)
+        self.assertEqual(params['foo'], [123, 456])


### PR DESCRIPTION
This adds proper reverse JMESPath support so that we can now build all
parameters properly. The following did not work before, but does now
because we can build up the filters array structure:

``` python
ec2 = boto3.resource('ec2')

instances = ec2.instances.filter(
    Filters=[{'Name': 'instance-type', 'Values': ['m1.small']}])

for instance in instances:
    print(instance.id)
```

Tests are added to cover the various cases of `dict` and `list`
combinations.

cc @jamesls, @kyleknap 
