### PR TITLE
Set custom HTTP user agent.

### DIFF
--- a/boto3/session.py
+++ b/boto3/session.py
@@ -15,6 +15,8 @@ import os
 
 import botocore.session
 
+import boto3
+
 from .exceptions import NoVersionFound
 from .resources.factory import ResourceFactory
 
@@ -47,7 +49,6 @@ class Session(object):
 
         # Setup custom user-agent string if it isn't already customized
         if self._session.user_agent_name == 'Botocore':
-            import boto3
             botocore_info = 'Botocore/{0}'.format(
                 self._session.user_agent_version)
             if self._session.user_agent_extra:

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -81,28 +81,43 @@ class TestSession(BaseTestCase):
         self.assertFalse(self.bc_session_cls.called)
 
     def test_user_agent(self):
-        bc_session = self.bc_session_cls()
+        # Here we get the underlying Botocore session, create a Boto 3
+        # session, and ensure that the user-agent is modified as expected
+        bc_session = self.bc_session_cls.return_value
         bc_session.user_agent_name = 'Botocore'
         bc_session.user_agent_version = '0.68.0'
         bc_session.user_agent_extra = ''
 
-        Session()
+        Session(botocore_session=bc_session)
 
         self.assertEqual(bc_session.user_agent_name, 'Boto3')
         self.assertEqual(bc_session.user_agent_version, __version__)
         self.assertEqual(bc_session.user_agent_extra, 'Botocore/0.68.0')
 
     def test_user_agent_extra(self):
-        bc_session = self.bc_session_cls()
+        # This test is the same as above, but includes custom extra content
+        # which must still be in the final modified user-agent.
+        bc_session = self.bc_session_cls.return_value
         bc_session.user_agent_name = 'Botocore'
         bc_session.user_agent_version = '0.68.0'
         bc_session.user_agent_extra = 'foo'
 
-        Session()
+        Session(botocore_session=bc_session)
 
-        self.assertEqual(bc_session.user_agent_name, 'Boto3')
-        self.assertEqual(bc_session.user_agent_version, __version__)
         self.assertEqual(bc_session.user_agent_extra, 'foo Botocore/0.68.0')
+
+    def test_custom_user_agent(self):
+        # This test ensures that a customized user-agent is left untouched.
+        bc_session = self.bc_session_cls.return_value
+        bc_session.user_agent_name = 'Custom'
+        bc_session.user_agent_version = '1.0'
+        bc_session.user_agent_extra = ''
+
+        Session(botocore_session=bc_session)
+
+        self.assertEqual(bc_session.user_agent_name, 'Custom')
+        self.assertEqual(bc_session.user_agent_version, '1.0')
+        self.assertEqual(bc_session.user_agent_extra, '')
 
     def test_get_available_services(self):
         bc_session = self.bc_session_cls.return_value


### PR DESCRIPTION
This sets a custom user agent string if the underlying Botocore session hasn't
had its user agent string customized.

cc @jamesls, @kyleknap 
