### PR TITLE
Add basic integration tests.

### DIFF
--- a/boto3/session.py
+++ b/boto3/session.py
@@ -143,6 +143,10 @@ class Session(object):
         service_names = set()
 
         for path in self._get_resource_files():
+            # TODO: Glacier is not yet supported by Botocore.
+            if 'glacier' in path:
+                continue
+
             # 'foo-bar-2006-03-01' => 'foo-bar'
             service_names.add('-'.join(path.split('-')[:-3]))
 

--- a/tests/integration/test_collections.py
+++ b/tests/integration/test_collections.py
@@ -1,0 +1,55 @@
+# Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import boto3.session
+
+from boto3.resources.collection import CollectionManager
+
+
+# A map of services to regions that cannot use us-west-2
+# for the integration tests.
+REGION_MAP = {
+    'opsworks': 'us-east-1'
+}
+
+# A list of collections to ignore. They require parameters
+# or are very slow to run.
+BLACKLIST = {
+    'ec2': ['images'],
+    'sqs': ['dead_letter_source_queues']
+}
+
+
+def test_all_collections():
+    # This generator yields test functions for every collection
+    # on every available resource, except those which have
+    # been blacklisted.
+    session = boto3.session.Session()
+    for service_name in session.get_available_resources():
+        resource = session.resource(
+            service_name,
+            region_name=REGION_MAP.get(service_name, 'us-west-2'))
+
+        for key in dir(resource):
+            if key in BLACKLIST.get(service_name, []):
+                continue
+
+            value = getattr(resource, key)
+            if isinstance(value, CollectionManager):
+                yield _test_collection, service_name, key, value
+
+def _test_collection(service_name, collection_name, collection):
+    # Create a list of the first page of items. This tests that
+    # a remote request can be made, the response parsed, and that
+    # resources are successfully created.
+    list(collection.limit(1))

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -28,11 +28,6 @@ def test_create_all_resources():
                       aws_secret_access_key='dummy',
                       region_name='us-east-1')
     for service_name in session.get_available_resources():
-        # TODO: Remove items once supported by Botocore!
-        if service_name in ['glacier']:
-            # Not supported by Botocore yet...
-            continue
-
         yield _test_create_resource, session, service_name
 
 def _test_create_resource(session, service_name):


### PR DESCRIPTION
This attempts to get the first page of results from every collection
exposed through a service (e.g. S3 buckets, EC2 instances, etc).
SQS dead letter queues are skipped because they require a parameter,
and we skip an EC2 collection that takes ~30 seconds because it's
a huge response.

cc @jamesls, @kyleknap 
