### PR TITLE
Implement batch actions.

### DIFF
--- a/boto3/resources/model.py
+++ b/boto3/resources/model.py
@@ -210,7 +210,16 @@ class Collection(Action):
     :type resource_defs: dict
     :param resource_defs: All resources defined in the service
     """
-    pass
+    @property
+    def batch_actions(self):
+        """
+        Get a list of batch actions supported by the resource type
+        contained in this action. This is a shortcut for accessing
+        the same information through the resource model.
+
+        :rtype: list(:py:class:`Action`)
+        """
+        return self.resource.model.batch_actions
 
 
 class SubResourceList(object):

--- a/boto3/resources/params.py
+++ b/boto3/resources/params.py
@@ -19,19 +19,27 @@ from botocore import xform_name
 INDEX_RE = re.compile('\[(.*)\]$')
 
 
-def create_request_parameters(parent, request_model):
+def create_request_parameters(parent, request_model, params=None):
     """
     Handle request parameters that can be filled in from identifiers,
     resource data members or constants.
+
+    By passing ``params``, you can invoke this method multiple times and
+    build up a parameter dict over time, which is particularly useful
+    for reverse JMESPath expressions that append to lists.
 
     :type parent: ServiceResource
     :param parent: The resource instance to which this action is attached.
     :type request_model: :py:class:`~boto3.resources.model.Request`
     :param request_model: The action request model.
+    :type params: dict
+    :param params: If set, then add to this existing dict. It is both
+                   edited in-place and returned.
     :rtype: dict
     :return: Pre-filled parameters to be sent to the request operation.
     """
-    params = {}
+    if params is None:
+        params = {}
 
     for param in request_model.params:
         source = param.source

--- a/docs/source/guide/collections.rst
+++ b/docs/source/guide/collections.rst
@@ -32,6 +32,10 @@ the following conditions:
 
       buckets = list(s3.buckets.all())
 
+* **Batch actions (see below)**::
+
+      s3.Bucket('my-bucket').objects.delete()
+
 Filtering
 ---------
 Some collections support extra arguments to filter the returned data set,

--- a/tests/unit/resources/test_action.py
+++ b/tests/unit/resources/test_action.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from boto3.resources.action import ServiceAction
+from boto3.resources.action import BatchAction, ServiceAction
 from boto3.resources.model import Action
 from tests import BaseTestCase, mock
 
@@ -121,3 +121,117 @@ class TestServiceActionCall(BaseTestCase):
             service_model, action_model.resource,
             self.action_def['request']['operation'])
         handler_mock.return_value.assert_called_with(resource, {}, 'response')
+
+
+class TestBatchActionCall(BaseTestCase):
+    def setUp(self):
+        super(TestBatchActionCall, self).setUp()
+
+        self.action_def = {
+            'request': {
+                'operation': 'GetFrobs',
+                'params': []
+            }
+        }
+
+    @property
+    def model(self):
+        return Action('test', self.action_def, {})
+
+    def test_batch_action_gets_pages_from_collection(self):
+        collection = mock.Mock()
+        collection.pages.return_value = []
+        action = BatchAction(self.model)
+
+        action(collection)
+
+        collection.pages.assert_called_with()
+
+    def test_batch_action_creates_parameters_from_items(self):
+        self.action_def['request']['params'] = [
+            {'target': 'Bucket', 'sourceType': 'dataMember',
+             'source': 'BucketName'},
+            {'target': 'Delete.Objects[].Key', 'sourceType': 'dataMember',
+             'source': 'Key'}
+        ]
+
+        client = mock.Mock()
+
+        item1 = mock.Mock()
+        item1.meta = {
+            'service_name': 'test',
+            'client': client
+        }
+        item1.bucket_name = 'bucket'
+        item1.key = 'item1'
+
+        item2 = mock.Mock()
+        item2.bucket_name = 'bucket'
+        item2.key = 'item2'
+
+        collection = mock.Mock()
+        collection.pages.return_value = [[item1, item2]]
+
+        action = BatchAction(self.model)
+        action(collection)
+
+        client.get_frobs.assert_called_with(Bucket='bucket', Delete={
+            'Objects': [
+                {'Key': 'item1'},
+                {'Key': 'item2'}
+            ]
+        })
+
+    @mock.patch('boto3.resources.action.create_request_parameters',
+                return_value={})
+    def test_batch_action_skips_operation(self, crp_mock):
+        # In this test we have an item from the collection, but no
+        # parameters are set up. Because of this, we do NOT call
+        # the batch operation.
+        client = mock.Mock()
+
+        item = mock.Mock()
+        item.meta = {
+            'service_name': 'test',
+            'client': client
+        }
+
+        collection = mock.Mock()
+        collection.pages.return_value = [[item]]
+
+        model = self.model
+        action = BatchAction(model)
+        action(collection)
+
+        crp_mock.assert_called_with(item, model.request, params={})
+        client.get_frobs.assert_not_called()
+
+    @mock.patch('boto3.resources.action.create_request_parameters')
+    def test_batch_action_calls_operation(self, crp_mock):
+        # In this test we have an item and parameters, so the call
+        # to the batch operation should be made.
+        def side_effect(resource, model, params=None):
+            params['foo'] = 'bar'
+
+        crp_mock.side_effect = side_effect
+
+        client = mock.Mock()
+
+        item = mock.Mock()
+        item.meta = {
+            'service_name': 'test',
+            'client': client
+        }
+
+        collection = mock.Mock()
+        collection.pages.return_value = [[item]]
+
+        model = self.model
+        action = BatchAction(model)
+        action(collection)
+
+        # Here the call is made with params={}, but they are edited
+        # in-place so we need to compare to the final edited value.
+        crp_mock.assert_called_with(item, model.request,
+                                    params={'foo': 'bar'})
+        client.get_frobs.assert_called_with(foo='bar')

--- a/tests/unit/resources/test_factory.py
+++ b/tests/unit/resources/test_factory.py
@@ -14,6 +14,7 @@
 from botocore.model import ServiceModel, StructureShape
 from boto3.exceptions import ResourceLoadException
 from boto3.resources.base import ServiceResource
+from boto3.resources.collection import CollectionManager
 from boto3.resources.factory import ResourceFactory
 from tests import BaseTestCase, mock
 
@@ -554,9 +555,8 @@ class TestResourceFactory(BaseTestCase):
         self.assertIsInstance(resource.subnet, ServiceResource)
         self.assertEqual(resource.subnet.id, 'abc123')
 
-    @mock.patch('boto3.resources.factory.CollectionManager')
     @mock.patch('boto3.resources.model.Collection')
-    def test_resource_loads_collections(self, mock_model, collection_cls):
+    def test_resource_loads_collections(self, mock_model):
         model = {
             'hasMany': {
                 u'Queues': {
@@ -579,8 +579,5 @@ class TestResourceFactory(BaseTestCase):
 
         self.assertTrue(hasattr(resource, 'queues'),
             'Resource should expose queues collection')
-        self.assertEqual(resource.queues, collection_cls.return_value,
+        self.assertIsInstance(resource.queues, CollectionManager,
             'Queues collection should be a collection manager')
-
-        collection_cls.assert_called_with(mock_model.return_value,
-            resource, self.factory, defs, service_model)

--- a/tests/unit/resources/test_params.py
+++ b/tests/unit/resources/test_params.py
@@ -103,7 +103,7 @@ class TestServiceActionParams(BaseTestCase):
         with self.assertRaises(NotImplementedError):
             create_request_parameters(None, request_model)
 
-    def test_action_params_list(self):
+    def test_service_action_params_list(self):
         request_model = Request({
             'operation': 'GetFrobs',
             'params': [
@@ -123,6 +123,38 @@ class TestServiceActionParams(BaseTestCase):
             'Parameter list should only have a single item')
         self.assertIn('w-url', params['WarehouseUrls'],
             'Parameter not in expected list')
+
+    def test_service_action_params_reuse(self):
+        request_model = Request({
+            'operation': 'GetFrobs',
+            'params': [
+                {
+                    'target': 'Delete.Objects[].Key',
+                    'sourceType': 'dataMember',
+                    'source': 'Key'
+                }
+            ]
+        })
+
+        item1 = mock.Mock()
+        item1.key = 'item1'
+
+        item2 = mock.Mock()
+        item2.key = 'item2'
+
+        # Here we create params and then re-use it to build up a more
+        # complex structure over multiple calls.
+        params = create_request_parameters(item1, request_model)
+        create_request_parameters(item2, request_model, params=params)
+
+        self.assertEqual(params, {
+            'Delete': {
+                'Objects': [
+                    {'Key': 'item1'},
+                    {'Key': 'item2'}
+                ]
+            }
+        })
 
 
 class TestStructBuilder(BaseTestCase):


### PR DESCRIPTION
This change implements batch actions on collections:

``` python
s3.Bucket('boto3').objects.delete()
```

It does the following:
- Create a `CollectionFactory` class to generate subclasses of
  `CollectionManager` and `ResourceCollection`.
- Update the `ResourceFactory` to use the new `CollectionFactory`.
- Add a public `pages()` method to collections. This returns entire
  pages of resource instances and it used by `__iter__` as well.
- Add batch actions as methods via the new `CollectionFactory`.
- Add a `BatchAction` subclass of `Action` which does the following:
  1. Get a page of results from the collection's operation
  2. Build parameters for the batch action operation
  3. Call the batch action operation
  4. Repeat until no more pages
- Makes some previously public members private on `Action` as these
  should never have been public.
- Update documentation to include collection classes.
- Fix a couple minor documentation issues.
- Add tests to cover the new functionality.

cc @jamesls, @kyleknap 
