### PR TITLE
Add S3 and SQS integration tests.

### DIFF
--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -19,9 +19,7 @@ from tests import unittest
 
 class TestS3Resource(unittest.TestCase):
     def setUp(self):
-        # We use the us-east-1 region here to prevent needing
-        # to set up special bucket configuration.
-        self.session = boto3.session.Session(region_name='us-east-1')
+        self.session = boto3.session.Session(region_name='us-west-2')
         self.s3 = self.session.resource('s3')
         self.bucket_name = 'boto3-test-{0}'.format(int(time.time()))
 
@@ -29,7 +27,11 @@ class TestS3Resource(unittest.TestCase):
         client = self.s3.meta['client']
 
         # Create a bucket (resource action with a resource response)
-        bucket = self.s3.create_bucket(Bucket=self.bucket_name)
+        bucket = self.s3.create_bucket(
+            Bucket=self.bucket_name,
+            CreateBucketConfiguration={
+                'LocationConstraint': 'us-west-2'
+            })
         waiter = client.get_waiter('bucket_exists')
         waiter.wait(Bucket=self.bucket_name)
         self.addCleanup(bucket.delete)

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -19,7 +19,7 @@ from tests import unittest
 
 class TestSQSResource(unittest.TestCase):
     def setUp(self):
-        self.session = boto3.session.Session()
+        self.session = boto3.session.Session(region_name='us-west-2')
         self.sqs = self.session.resource('sqs')
         self.queue_name = 'boto3-test-{0}'.format(int(time.time()))
 


### PR DESCRIPTION
This adds integration tests that exercise previously untested functionality,
specifically this adds the following to the existing describe calls:
- Create and delete remote resources
- Call actions to put and get data from remote resources
- Handle low-level responses from a service
- Exercise low-level waiters (to be replaced with high-level waiters)
- Access data attributes of pre-loaded resources with no `load` method

The last item would have prevented #33. This PR is related to #34,
which fixed the underlying issue that this test would have caught.

The full integration test suite now takes around 20-30 seconds on
my machine.

cc @jamesls, @kyleknap 
