### PR TITLE
Support plural references

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 Unreleased
 ----------
 
+* feature:Resources: Support plural references and nested JMESPath
+  queries for data members when building parameters and identifiers.
+  (`issue 52 <https://github.com/boto/boto3/pull/52>`__)
 * feature:Dependency: Update to JMESPath 0.6.1
 * feature:Resources: Update to the latest resource JSON format.
   (`issue 51 <https://github.com/boto/boto3/pull/51>`__)

--- a/boto3/resources/factory.py
+++ b/boto3/resources/factory.py
@@ -21,7 +21,7 @@ from .action import WaiterAction
 from .base import ResourceMeta, ServiceResource
 from .collection import CollectionFactory
 from .model import ResourceModel
-from .response import all_not_none, build_identifiers
+from .response import build_identifiers, ResourceHandler
 from ..exceptions import ResourceLoadException
 
 
@@ -299,24 +299,19 @@ class ResourceFactory(object):
         """
         Creates a new property on the resource to lazy-load a reference.
         """
+        # References are essentially an action with no request
+        # or response, so we can re-use the response handlers to
+        # build up resources from identifiers and data members.
+        handler = ResourceHandler('', factory_self, resource_defs,
+                                  service_model, reference.resource, None)
+
         def get_reference(self):
             # We need to lazy-evaluate the reference to handle circular
             # references between resources. We do this by loading the class
             # when first accessed.
             # First, though, we need to see if we have the required
             # identifiers to instantiate the resource reference.
-            identifiers = dict(build_identifiers(
-                reference.resource.identifiers, self))
-            resource = None
-            if all_not_none(identifiers.values()):
-                # Identifiers are present, so now we can create the resource
-                # instance using them.
-                resource_type = reference.resource.type
-                cls = factory_self.load_from_definition(
-                    service_name, name, resource_defs.get(resource_type),
-                    resource_defs, service_model)
-                resource = cls(**identifiers)
-            return resource
+            return handler(self, {}, {})
 
         get_reference.__name__ = str(snake_cased)
         get_reference.__doc__ = 'TODO'

--- a/boto3/resources/factory.py
+++ b/boto3/resources/factory.py
@@ -176,7 +176,7 @@ class ResourceFactory(object):
             # This is a dangling reference, i.e. we have all
             # the data we need to create the resource, so
             # this instance becomes an attribute on the class.
-            snake_cased = xform_name(reference.resource.type)
+            snake_cased = xform_name(reference.name)
             snake_cased = self._check_allowed_name(
                 attrs, snake_cased, 'reference', model.name)
             attrs[snake_cased] = self._create_reference(

--- a/boto3/resources/factory.py
+++ b/boto3/resources/factory.py
@@ -303,7 +303,7 @@ class ResourceFactory(object):
         # or response, so we can re-use the response handlers to
         # build up resources from identifiers and data members.
         handler = ResourceHandler('', factory_self, resource_defs,
-                                  service_model, reference.resource, None)
+                                  service_model, reference.resource)
 
         def get_reference(self):
             # We need to lazy-evaluate the reference to handle circular

--- a/boto3/resources/response.py
+++ b/boto3/resources/response.py
@@ -14,6 +14,9 @@
 import jmespath
 from botocore import xform_name
 
+from ..exceptions import ResourceLoadException
+from .params import get_data_member
+
 
 def all_not_none(iterable):
     """
@@ -59,8 +62,9 @@ def build_identifiers(identifiers, parent, params=None, raw_response=None):
         elif source == 'identifier':
             value = getattr(parent, xform_name(identifier.name))
         elif source == 'data':
-            # TODO: This should be a JMESPath query
-            value = getattr(parent, xform_name(identifier.path))
+            # If this is a data member then it may incur a load
+            # action before returning the value.
+            value = get_data_member(parent, identifier.path)
         elif source == 'input':
             # This value is set by the user, so ignore it here
             continue

--- a/boto3/resources/response.py
+++ b/boto3/resources/response.py
@@ -83,9 +83,7 @@ def build_empty_response(search_path, operation_name, service_model):
     :type search_path: string
     :param search_path: JMESPath expression to search in the response
     :type operation_name: string
-    :param operation_name: Name of the underlying service operation. If
-                           this is ``None`` then the empty response will
-                           always be ``None`` as well.
+    :param operation_name: Name of the underlying service operation.
     :type service_model: :ref:`botocore.model.ServiceModel`
     :param service_model: The Botocore service model
     :rtype: dict, list, or None

--- a/boto3/resources/response.py
+++ b/boto3/resources/response.py
@@ -83,13 +83,20 @@ def build_empty_response(search_path, operation_name, service_model):
     :type search_path: string
     :param search_path: JMESPath expression to search in the response
     :type operation_name: string
-    :param operation_name: Name of the underlying service operation
+    :param operation_name: Name of the underlying service operation. If
+                           this is ``None`` then the empty response will
+                           always be ``None`` as well.
     :type service_model: :ref:`botocore.model.ServiceModel`
     :param service_model: The Botocore service model
     :rtype: dict, list, or None
     :return: An appropriate empty value
     """
     response = None
+
+    # If this isn't a real service operation, then the response should
+    # just be ``None``.
+    if operation_name is None:
+        return response
 
     operation_model = service_model.operation_model(operation_name)
     shape = operation_model.output_shape

--- a/tests/unit/resources/test_action.py
+++ b/tests/unit/resources/test_action.py
@@ -191,13 +191,16 @@ class TestBatchActionCall(BaseTestCase):
         client = mock.Mock()
 
         item1 = mock.Mock()
-        item1.meta = ResourceMeta('test', client=client)
-        item1.bucket_name = 'bucket'
-        item1.key = 'item1'
+        item1.meta = ResourceMeta('test', client=client, data={
+            'BucketName': 'bucket',
+            'Key': 'item1'
+        })
 
         item2 = mock.Mock()
-        item2.bucket_name = 'bucket'
-        item2.key = 'item2'
+        item2.meta = ResourceMeta('test', client=client, data={
+            'BucketName': 'bucket',
+            'Key': 'item2'
+        })
 
         collection = mock.Mock()
         collection.pages.return_value = [[item1, item2]]

--- a/tests/unit/resources/test_factory.py
+++ b/tests/unit/resources/test_factory.py
@@ -432,11 +432,23 @@ class TestResourceFactory(BaseTestCase):
                              'path': 'SubnetId'}
                         ]
                     }
+                },
+                'Vpcs': {
+                    'resource': {
+                        'type': 'Vpc',
+                        'identifiers': [
+                            {'target': 'Id', 'source': 'data',
+                             'path': 'Vpcs[].Id'}
+                        ]
+                    }
                 }
             }
         }
         defs = {
             'Subnet': {
+                'identifiers': [{'name': 'Id'}]
+            },
+            'Vpc': {
                 'identifiers': [{'name': 'Id'}]
             }
         }
@@ -462,15 +474,31 @@ class TestResourceFactory(BaseTestCase):
         # Load the resource with no data
         resource.meta.data = {}
 
-        self.assertTrue(hasattr(resource, 'subnet'),
-                        'Resource should have a subnet reference')
-        self.assertIsNone(resource.subnet,
-                          'Missing identifier, should return None')
+        self.assertTrue(
+            hasattr(resource, 'subnet'),
+            'Resource should have a subnet reference')
+        self.assertIsNone(
+            resource.subnet,
+            'Missing identifier, should return None')
+        self.assertIsNone(resource.vpcs)
 
         # Load the resource with data to instantiate a reference
-        resource.meta.data = {'SubnetId': 'abc123'}
+        resource.meta.data = {
+            'SubnetId': 'abc123',
+            'Vpcs': [
+                {'Id': 'vpc1'},
+                {'Id': 'vpc2'}
+            ]
+        }
+
         self.assertIsInstance(resource.subnet, ServiceResource)
         self.assertEqual(resource.subnet.id, 'abc123')
+
+        vpcs = resource.vpcs
+        self.assertIsInstance(vpcs, list)
+        self.assertEqual(len(vpcs), 2)
+        self.assertEqual(vpcs[0].id, 'vpc1')
+        self.assertEqual(vpcs[1].id, 'vpc2')
 
     @mock.patch('boto3.resources.model.Collection')
     def test_resource_loads_collections(self, mock_model):

--- a/tests/unit/resources/test_response.py
+++ b/tests/unit/resources/test_response.py
@@ -83,7 +83,9 @@ class TestBuildIdentifiers(BaseTestCase):
                        path='Member')]
 
         parent = mock.Mock()
-        parent.member = 'data-member'
+        parent.meta = ResourceMeta('test', data={
+            'Member': 'data-member'
+        })
         params = {}
         response = {
             'Container': {


### PR DESCRIPTION
This change refactors the way that references are created to reuse the
existing response handling code for loading resources. As a side effect,
this supports plural references.

This is mainly future-proofing and removing some code duplication.

cc @jamesls @kyleknap 