### PR TITLE
Expose all resources on a service resource.

### DIFF
--- a/boto3/resources/factory.py
+++ b/boto3/resources/factory.py
@@ -188,7 +188,7 @@ class ResourceFactory(object):
             # This is a sub-resource class you can create
             # by passing in an identifier, e.g. s3.Bucket(name).
             name = subresource.resource.type
-            attrs[name] = self._create_class_partial(
+            attrs[subresource.name] = self._create_class_partial(
                 name, subresource, service_name, resource_name, model,
                 resource_defs, service_model)
 

--- a/boto3/resources/model.py
+++ b/boto3/resources/model.py
@@ -312,6 +312,66 @@ class ResourceModel(object):
 
         return actions
 
+    def _get_has_definition(self):
+        """
+        Get a ``has`` relationship definition from a model, where the
+        service resource model is treated special in that it contains
+        a relationship to every resource defined for the service. This
+        allows things like ``s3.Object('bucket-name', 'key')`` to
+        work even though the JSON doesn't define it explicitly.
+
+        @rtype: dict
+        @return: Mapping of names to subresource and reference
+                 definitions.
+        """
+        if self.name not in self._resource_defs:
+            # This is the service resource, so let us expose all of
+            # the defined resources as subresources.
+            definition = {}
+
+            for name, resource_def in self._resource_defs.items():
+                # It's possible for the service to have renamed a
+                # resource, so we need to take that into account and
+                # search for the same resource type.
+                has_items = self._definition.get('has', {}).items()
+                for has_name, has_def in has_items:
+                    if has_def.get('resource', {}).get('type') == name:
+                        definition[has_name] = has_def
+                        break
+                else:
+                    # Create a relationship definition and attach it
+                    # to the model, such that all identifiers must be
+                    # supplied by the user. It will look something like:
+                    #
+                    # {
+                    #   'resource': {
+                    #     'type': 'ResourceName',
+                    #     'identifiers': [
+                    #       {'target': 'Name1', 'source': 'input'},
+                    #       {'target': 'Name2', 'source': 'input'},
+                    #       ...
+                    #     ]
+                    #   }
+                    # }
+                    #
+                    fake_has = {
+                        'resource': {
+                            'type': name,
+                            'identifiers': []
+                        }
+                    }
+
+                    for identifier in resource_def.get('identifiers', []):
+                        fake_has['resource']['identifiers'].append({
+                            'target': identifier['name'], 'source': 'input'
+                        })
+
+                    definition[name] = fake_has
+        else:
+            definition = self._definition.get('has', {})
+
+        return definition
+
     def _get_related_resources(self, subresources):
         """
         Get a list of sub-resources or references.
@@ -323,7 +383,7 @@ class ResourceModel(object):
         """
         resources = []
 
-        for name, definition in self._definition.get('has', {}).items():
+        for name, definition in self._get_has_definition().items():
             action = Action(name, definition, self._resource_defs)
 
             data_required = False

--- a/boto3/resources/model.py
+++ b/boto3/resources/model.py
@@ -331,14 +331,17 @@ class ResourceModel(object):
 
             for name, resource_def in self._resource_defs.items():
                 # It's possible for the service to have renamed a
-                # resource, so we need to take that into account and
-                # search for the same resource type.
+                # resource or to have defined multiple names that
+                # point to the same resource type, so we need to
+                # take that into account.
+                found = False
                 has_items = self._definition.get('has', {}).items()
                 for has_name, has_def in has_items:
                     if has_def.get('resource', {}).get('type') == name:
                         definition[has_name] = has_def
-                        break
-                else:
+                        found = True
+
+                if not found:
                     # Create a relationship definition and attach it
                     # to the model, such that all identifiers must be
                     # supplied by the user. It will look something like:

--- a/boto3/resources/model.py
+++ b/boto3/resources/model.py
@@ -320,8 +320,8 @@ class ResourceModel(object):
         allows things like ``s3.Object('bucket-name', 'key')`` to
         work even though the JSON doesn't define it explicitly.
 
-        @rtype: dict
-        @return: Mapping of names to subresource and reference
+        :rtype: dict
+        :return: Mapping of names to subresource and reference
                  definitions.
         """
         if self.name not in self._resource_defs:

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -82,4 +82,10 @@ class TestS3Resource(unittest.TestCase):
         obj.wait_until_exists()
 
         # List objects and make sure ours is present
-        self.assertIn('test.txt', [o.key for o in bucket.objects.all()])        
+        self.assertIn('test.txt', [o.key for o in bucket.objects.all()])
+
+    def test_can_create_object_directly(self):
+        obj = self.s3.Object(self.bucket_name, 'test.txt')
+
+        self.assertEqual(obj.bucket_name, self.bucket_name)
+        self.assertEqual(obj.key, 'test.txt')

--- a/tests/unit/resources/test_factory.py
+++ b/tests/unit/resources/test_factory.py
@@ -670,3 +670,54 @@ class TestResourceFactoryDanglingResource(TestResourceFactory):
 
         self.assertNotEqual(q1, q2)
         self.assertNotEqual(q1, m)
+
+
+class TestServiceResourceSubresources(TestResourceFactory):
+    def setUp(self):
+        super(TestServiceResourceSubresources, self).setUp()
+
+        self.model = {
+            'has': {
+                'QueueObject': {
+                    'resource': {
+                        'type': 'Queue',
+                        'identifiers': [
+                            {'target': 'Url', 'source': 'input'}
+                        ]
+                    }
+                }
+            }
+        }
+
+        self.defs = {
+            'Queue': {
+                'identifiers': [
+                    {'name': 'Url'}
+                ]
+            },
+            'Message': {
+                'identifiers': [
+                    {'name': 'QueueUrl'},
+                    {'name': 'ReceiptHandle'}
+                ]
+            }
+        }
+
+    def test_subresource_custom_name(self):
+        resource = self.load('test', 'test', self.model, self.defs, None)()
+
+        self.assertTrue(hasattr(resource, 'QueueObject'))
+
+    def test_contains_all_subresources(self):
+        resource = self.load('test', 'test', self.model, self.defs, None)()
+
+        self.assertIn('QueueObject', dir(resource))
+        self.assertIn('Message', dir(resource))
+
+    def test_subresource_missing_all_subresources(self):
+        resource = self.load('test', 'test', self.model, self.defs, None)()
+        message = resource.Message('url', 'handle')
+
+        self.assertNotIn('QueueObject', dir(message))
+        self.assertNotIn('Queue', dir(message))
+        self.assertNotIn('Message', dir(message))

--- a/tests/unit/resources/test_factory.py
+++ b/tests/unit/resources/test_factory.py
@@ -685,6 +685,14 @@ class TestServiceResourceSubresources(TestResourceFactory):
                             {'target': 'Url', 'source': 'input'}
                         ]
                     }
+                },
+                'PriorityQueue': {
+                    'resource': {
+                        'type': 'Queue',
+                        'identifiers': [
+                            {'target': 'Url', 'source': 'input'}
+                        ]
+                    }
                 }
             }
         }
@@ -712,6 +720,7 @@ class TestServiceResourceSubresources(TestResourceFactory):
         resource = self.load('test', 'test', self.model, self.defs, None)()
 
         self.assertIn('QueueObject', dir(resource))
+        self.assertIn('PriorityQueue', dir(resource))
         self.assertIn('Message', dir(resource))
 
     def test_subresource_missing_all_subresources(self):
@@ -719,5 +728,6 @@ class TestServiceResourceSubresources(TestResourceFactory):
         message = resource.Message('url', 'handle')
 
         self.assertNotIn('QueueObject', dir(message))
+        self.assertNotIn('PriorityQueue', dir(message))
         self.assertNotIn('Queue', dir(message))
         self.assertNotIn('Message', dir(message))

--- a/tests/unit/resources/test_model.py
+++ b/tests/unit/resources/test_model.py
@@ -154,7 +154,7 @@ class TestModels(BaseTestCase):
         action = model.subresources[0]
         resource = action.resource
 
-        self.assertEqual(action.name, 'RedFrob')
+        self.assertIn(action.name, ['RedFrob', 'GreenFrob'])
         self.assertEqual(resource.identifiers[0].target, 'Id')
         self.assertEqual(resource.identifiers[0].source, 'input')
         self.assertEqual(resource.type, 'Frob')

--- a/tests/unit/resources/test_model.py
+++ b/tests/unit/resources/test_model.py
@@ -127,7 +127,15 @@ class TestModels(BaseTestCase):
     def test_sub_resources(self):
         model = ResourceModel('test', {
             'has': {
-                'Frob': {
+                'RedFrob': {
+                    'resource': {
+                        'type': 'Frob',
+                        'identifiers': [
+                            {'target': 'Id', 'source': 'input'}
+                        ]
+                    }
+                },
+                'GreenFrob': {
                     'resource': {
                         'type': 'Frob',
                         'identifiers': [
@@ -141,11 +149,12 @@ class TestModels(BaseTestCase):
         })
 
         self.assertIsInstance(model.subresources, list)
+        self.assertEqual(len(model.subresources), 2)
 
         action = model.subresources[0]
         resource = action.resource
 
-        self.assertEqual(action.name, 'Frob')
+        self.assertEqual(action.name, 'RedFrob')
         self.assertEqual(resource.identifiers[0].target, 'Id')
         self.assertEqual(resource.identifiers[0].source, 'input')
         self.assertEqual(resource.type, 'Frob')


### PR DESCRIPTION
This change brings back behavior that was removed in Boto 3 - 0.0.7
and allows things like the following to work again:

```python
import boto3

s3 = boto3.resource('s3')
obj = s3.Object('bucket-name', 'key')
```

This is **required** to gain direct access to some resources that are not exposed as subresources nor references (think something like `sqs.Message`, which you can now only get from `sqs.Queue('url').receive_messages() => [Message(...)]` Without the change in this pull request there is **no way** to instantiate a message instance yourself).

cc @jamesls @kyleknap 