### PR TITLE
Fix collection resource hydration path

### DIFF
--- a/boto3/resources/collection.py
+++ b/boto3/resources/collection.py
@@ -312,7 +312,7 @@ class CollectionManager(object):
         operation_name = self._model.request.operation
         self._parent = parent
 
-        search_path = model.path
+        search_path = model.resource.path
         self._handler = ResourceHandler(search_path, factory, resource_defs,
             service_model, model.resource, operation_name)
 

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -57,6 +57,9 @@ class TestS3Resource(unittest.TestCase):
         # Lazy-loaded attribute
         self.assertEqual(12, obj.content_length)
 
+        # Load a similar attribute from the collection response
+        self.assertEqual(12, list(bucket.objects.all())[0].size)
+
         # Perform a resource action with a low-level response
         self.assertEqual(b'hello, world',
                          obj.get()['Body'].read())

--- a/tests/unit/resources/test_model.py
+++ b/tests/unit/resources/test_model.py
@@ -187,9 +187,9 @@ class TestModels(BaseTestCase):
                         'operation': 'GetFrobList'
                     },
                     'resource': {
-                        'type': 'Frob'
-                    },
-                    'path': 'FrobList[]'
+                        'type': 'Frob',
+                        'path': 'FrobList[]'
+                    }
                 }
             }
         }, {
@@ -202,7 +202,7 @@ class TestModels(BaseTestCase):
         self.assertEqual(model.collections[0].request.operation, 'GetFrobList')
         self.assertEqual(model.collections[0].resource.type, 'Frob')
         self.assertEqual(model.collections[0].resource.model.name, 'Frob')
-        self.assertEqual(model.collections[0].path, 'FrobList[]')
+        self.assertEqual(model.collections[0].resource.path, 'FrobList[]')
 
     def test_waiter(self):
         model = ResourceModel('test', {


### PR DESCRIPTION
This fixes #57 by hydrating resources from a collection with a JMESPath
query that is at `collection.resource.path` instead of `collection.path`
in the resource model.

```python
import boto3

for o in boto3.resource('s3').Bucket('boto3').objects.all():
    # `o.meta.data` is set now, so the following succeeds.
    print(o.size)
```

cc @jamesls @kyleknap 