### PR TITLE
Fix S3 resource identifier order bug

### DIFF
--- a/boto3/data/resources/s3-2006-03-01.resources.json
+++ b/boto3/data/resources/s3-2006-03-01.resources.json
@@ -698,8 +698,8 @@
             "type": "MultipartUploadPart",
             "identifiers": [
               { "target": "BucketName", "source": "identifier", "name": "BucketName" },
-              { "target": "MultipartUploadId", "source": "identifier", "name": "Id" },
               { "target": "ObjectKey", "source": "identifier", "name": "ObjectKey" },
+              { "target": "MultipartUploadId", "source": "identifier", "name": "Id" },
               { "target": "PartNumber", "source": "input" }
             ]
           }
@@ -770,8 +770,8 @@
             "type": "MultipartUpload",
             "identifiers": [
               { "target": "BucketName", "source": "identifier", "name": "BucketName" },
-              { "target": "Id", "source": "identifier", "name": "MultipartUploadId" },
-              { "target": "ObjectKey", "source": "identifier", "name": "ObjectKey" }
+              { "target": "ObjectKey", "source": "identifier", "name": "ObjectKey" },
+              { "target": "Id", "source": "identifier", "name": "MultipartUploadId" }
             ]
           }
         }

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -104,7 +104,7 @@ class TestS3Resource(unittest.TestCase):
 
         # Create and upload a part
         part = mpu.Part(1)
-        response = part.upload(b'hello, world!')
+        response = part.upload(Body='hello, world!')
 
         # Complete the upload, which requires info on all of the parts
         part_info = {
@@ -118,3 +118,6 @@ class TestS3Resource(unittest.TestCase):
 
         mpu.complete(MultipartUpload=part_info)
         self.addCleanup(bucket.Object('mp-test.txt').delete)
+
+        contents = bucket.Object('mp-test.txt').get()['Body'].read()
+        self.assertEqual(contents, b'hello, world!')


### PR DESCRIPTION
This change is for the issue described in #59 and updates the model based on
the output of the proposed change in awslabs/aws-model-validators#2. The
following now works properly:

```python
import boto3

obj = boto3.resource('s3').Bucket('foo').Object('bar')
mpu = obj.initiate_multipart_upload()
part = mpu.MultipartUploadPart(1)
print(part.object_key)
# => 'foo'
```

cc @jamesls @kyleknap 