### PR TITLE
Move name collision logic to the model

### DIFF
--- a/boto3/docs.py
+++ b/boto3/docs.py
@@ -339,7 +339,8 @@ def document_resource(service_name, official_name, resource_model,
             docs += '   Attributes:\n\n'
             shape = service_model.shape_for(resource_model.shape)
 
-            for name, member in sorted(resource_model.get_attributes(shape).items()):
+            attributes = resource_model.get_attributes(shape)
+            for name, (orig_name, member) in sorted(attributes.items()):
                 docs += ('   .. py:attribute:: {0}\n\n      (``{1}``)'
                          ' {2}\n\n').format(
                     xform_name(name), py_type_name(member.type_name),

--- a/boto3/docs.py
+++ b/boto3/docs.py
@@ -177,6 +177,12 @@ def docs_for(service_name):
         for name, model in sorted(data['resources'].items(),
                                   key=lambda i:i[0]):
             resource_model = ResourceModel(name, model, data['resources'])
+
+            shape = None
+            if resource_model.shape:
+                shape = service_model.shape_for(resource_model.shape)
+            resource_model.load_rename_map(shape)
+
             if name not in models:
                 models[name] = {'type': 'resource', 'model': resource_model}
 
@@ -333,7 +339,7 @@ def document_resource(service_name, official_name, resource_model,
             docs += '   Attributes:\n\n'
             shape = service_model.shape_for(resource_model.shape)
 
-            for name, member in sorted(shape.members.items()):
+            for name, member in sorted(resource_model.get_attributes(shape).items()):
                 docs += ('   .. py:attribute:: {0}\n\n      (``{1}``)'
                          ' {2}\n\n').format(
                     xform_name(name), py_type_name(member.type_name),

--- a/boto3/docs.py
+++ b/boto3/docs.py
@@ -410,7 +410,7 @@ def document_resource(service_name, official_name, resource_model,
                  ' to reach a specific state.\n\n')
         service_waiter_model = session.get_waiter_model(service_name)
         for waiter in sorted(resource_model.waiters,
-                             key=lambda i: i.resource_waiter_name):
+                             key=lambda i: i.name):
             docs += document_waiter(waiter, service_name, resource_model,
                                     service_model, service_waiter_model)
 
@@ -474,7 +474,7 @@ def document_waiter(waiter, service_name, resource_model, service_model,
                    '      This method calls ``wait()`` on'
                    ' :py:meth:`{2}.Client.get_waiter` using `{3}`_ .').format(
                         resource_model.name,
-                        xform_name(waiter.name).replace('_', ' '),
+                        ' '.join(waiter.name.split('_')[2:]),
                         service_name,
                         xform_name(waiter.waiter_name))
 
@@ -483,7 +483,7 @@ def document_waiter(waiter, service_name, resource_model, service_model,
 
     return document_operation(
         operation_model=operation_model, service_name=service_name,
-        operation_name=xform_name(waiter.resource_waiter_name),
+        operation_name=xform_name(waiter.name),
         description=description,
         example_instance = xform_name(resource_model.name),
         ignore_params=ignore_params, rtype=None)

--- a/boto3/resources/factory.py
+++ b/boto3/resources/factory.py
@@ -134,8 +134,9 @@ class ResourceFactory(object):
         if model.shape:
             shape = service_model.shape_for(model.shape)
 
-            for name, member in model.get_attributes(shape).items():
-                attrs[name] = self._create_autoload_property(member.name, name)
+            attributes = model.get_attributes(shape)
+            for name, (orig_name, member) in attributes.items():
+                attrs[name] = self._create_autoload_property(orig_name, name)
 
     def _load_collections(self, attrs, model, resource_defs, service_model):
         """

--- a/boto3/resources/factory.py
+++ b/boto3/resources/factory.py
@@ -190,8 +190,7 @@ class ResourceFactory(object):
         of the resource.
         """
         for waiter in model.waiters:
-            snake_cased = xform_name(waiter.resource_waiter_name)
-            attrs[snake_cased] = self._create_waiter(waiter, snake_cased)
+            attrs[waiter.name] = self._create_waiter(waiter)
 
     def _create_autoload_property(factory_self, name, snake_cased):
         """
@@ -216,16 +215,17 @@ class ResourceFactory(object):
         property_loader.__doc__ = 'TODO'
         return property(property_loader)
 
-    def _create_waiter(factory_self, waiter_model, snake_cased):
+    def _create_waiter(factory_self, waiter_model):
         """
         Creates a new wait method for each resource where both a waiter and
         resource model is defined.
         """
-        waiter = WaiterAction(waiter_model, waiter_resource_name=snake_cased)
+        waiter = WaiterAction(waiter_model,
+                              waiter_resource_name=waiter_model.name)
         def do_waiter(self, *args, **kwargs):
             waiter(self, *args, **kwargs)
 
-        do_waiter.__name__ = str(snake_cased)
+        do_waiter.__name__ = str(waiter_model.name)
         do_waiter.__doc__ = 'TODO'
         return do_waiter
 

--- a/boto3/resources/model.py
+++ b/boto3/resources/model.py
@@ -386,8 +386,13 @@ class ResourceModel(object):
 
     def get_attributes(self, shape):
         """
-        Get a dictionary of attribute names to shape models that
-        represent the attributes of this resource.
+        Get a dictionary of attribute names to original name and shape
+        models that represent the attributes of this resource. Looks
+        like the following:
+
+            {
+                'some_name': ('SomeName', <Shape...>)
+            }
 
         :type shape: botocore.model.Shape
         :param shape: The underlying shape for this resource.
@@ -404,7 +409,7 @@ class ResourceModel(object):
                 continue
             snake_cased = self._get_name('attribute', snake_cased,
                                          snake_case=False)
-            attributes[snake_cased] = member
+            attributes[snake_cased] = (name, member)
 
         return attributes
 

--- a/tests/unit/resources/test_factory.py
+++ b/tests/unit/resources/test_factory.py
@@ -534,7 +534,7 @@ class TestResourceFactory(BaseTestCase):
             'Queue': {}
         }
         service_model = ServiceModel({})
-        mock_model.return_value.name = 'Queues'
+        mock_model.return_value.name = 'queues'
 
         resource = self.load('test', 'test', model, defs, service_model)()
 

--- a/tests/unit/resources/test_factory.py
+++ b/tests/unit/resources/test_factory.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from botocore.model import ServiceModel, StructureShape, Shape
+from botocore.model import DenormalizedStructureBuilder, ServiceModel
 from boto3.exceptions import ResourceLoadException
 from boto3.resources.base import ServiceResource
 from boto3.resources.collection import CollectionManager
@@ -127,13 +127,14 @@ class TestResourceFactory(BaseTestCase):
                 }
             }
         }
-        shape = StructureShape('TestShape', {
-            'type': 'structure',
-            'members': {}
-        })
-        shape.members['ETag'] = Shape('ETag', {'type': 'string'})
-        shape.members['LastModified'] = Shape(
-            'LastModified', {'type': 'date'})
+        shape = DenormalizedStructureBuilder().with_members({
+            'ETag': {
+                'type': 'string',
+            },
+            'LastModified': {
+                'type': 'string'
+            }
+        }).build_model()
         service_model = mock.Mock()
         service_model.shape_for.return_value = shape
 
@@ -360,14 +361,20 @@ class TestResourceFactory(BaseTestCase):
                 }
             }
         }
-        shape = StructureShape('TestShape', {
-            'type': 'structure',
-            'members': {}
-        })
-        shape.members['ETag'] = Shape('ETag', {'type': 'string'})
-        shape.members['LastModified'] = Shape(
-            'LastModified', {'type': 'date'})
-        shape.members['Url'] = Shape('Url', {'type': 'string'})
+        shape = DenormalizedStructureBuilder().with_members({
+            'ETag': {
+                'type': 'string',
+                'shape_name': 'ETag'
+            },
+            'LastModified': {
+                'type': 'string',
+                'shape_name': 'LastModified'
+            },
+            'Url': {
+                'type': 'string',
+                'shape_name': 'Url'
+            }
+        }).build_model()
         service_model = mock.Mock()
         service_model.shape_for.return_value = shape
 
@@ -406,14 +413,17 @@ class TestResourceFactory(BaseTestCase):
             # Note the lack of a `load` method. These resources
             # are usually loaded via a call on a parent resource.
         }
-        shape = StructureShape('TestShape', {
-            'type': 'structure',
-            'members': {}
-        })
-        shape.members['ETag'] = Shape('ETag', {'type': 'string'})
-        shape.members['LastModified'] = Shape(
-            'LastModified', {'type': 'date'})
-        shape.members['Url'] = Shape('Url', {'type': 'string'})
+        shape = DenormalizedStructureBuilder().with_members({
+            'ETag': {
+                'type': 'string',
+            },
+            'LastModified': {
+                'type': 'string'
+            },
+            'Url': {
+                'type': 'string'
+            }
+        }).build_model()
         service_model = mock.Mock()
         service_model.shape_for.return_value = shape
 

--- a/tests/unit/resources/test_factory.py
+++ b/tests/unit/resources/test_factory.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from botocore.model import ServiceModel, StructureShape
+from botocore.model import ServiceModel, StructureShape, Shape
 from boto3.exceptions import ResourceLoadException
 from boto3.resources.base import ServiceResource
 from boto3.resources.collection import CollectionManager
@@ -127,11 +127,13 @@ class TestResourceFactory(BaseTestCase):
                 }
             }
         }
-        shape = mock.Mock()
-        shape.members = {
-            'ETag': None,
-            'LastModified': None,
-        }
+        shape = StructureShape('TestShape', {
+            'type': 'structure',
+            'members': {}
+        })
+        shape.members['ETag'] = Shape('ETag', {'type': 'string'})
+        shape.members['LastModified'] = Shape(
+            'LastModified', {'type': 'date'})
         service_model = mock.Mock()
         service_model.shape_for.return_value = shape
 
@@ -358,12 +360,14 @@ class TestResourceFactory(BaseTestCase):
                 }
             }
         }
-        shape = mock.Mock()
-        shape.members = {
-            'Url': None,
-            'ETag': None,
-            'LastModified': None,
-        }
+        shape = StructureShape('TestShape', {
+            'type': 'structure',
+            'members': {}
+        })
+        shape.members['ETag'] = Shape('ETag', {'type': 'string'})
+        shape.members['LastModified'] = Shape(
+            'LastModified', {'type': 'date'})
+        shape.members['Url'] = Shape('Url', {'type': 'string'})
         service_model = mock.Mock()
         service_model.shape_for.return_value = shape
 
@@ -402,12 +406,14 @@ class TestResourceFactory(BaseTestCase):
             # Note the lack of a `load` method. These resources
             # are usually loaded via a call on a parent resource.
         }
-        shape = mock.Mock()
-        shape.members = {
-            'Url': None,
-            'ETag': None,
-            'LastModified': None,
-        }
+        shape = StructureShape('TestShape', {
+            'type': 'structure',
+            'members': {}
+        })
+        shape.members['ETag'] = Shape('ETag', {'type': 'string'})
+        shape.members['LastModified'] = Shape(
+            'LastModified', {'type': 'date'})
+        shape.members['Url'] = Shape('Url', {'type': 'string'})
         service_model = mock.Mock()
         service_model.shape_for.return_value = shape
 

--- a/tests/unit/resources/test_model.py
+++ b/tests/unit/resources/test_model.py
@@ -182,7 +182,7 @@ class TestModels(BaseTestCase):
         self.assertEqual(len(model.references), 1)
 
         ref = model.references[0]
-        self.assertEqual(ref.name, 'Frob')
+        self.assertEqual(ref.name, 'frob')
         self.assertEqual(ref.resource.type, 'Frob')
         self.assertEqual(ref.resource.identifiers[0].target, 'Id')
         self.assertEqual(ref.resource.identifiers[0].source, 'data')


### PR DESCRIPTION
This change moves and formalizes the name collision logic from the factory
to the resource model. The following has changed:

* Documentation now better matches the factory output.
* Collision renaming order is formalized in one place
  * Order: reserved names (meta), load action, identifiers, actions,
    subresources, references, collections, and then attributes.
* Renaming resource model attributes/methods now happens at model loading
  time rather than class creation time.

The way this works is by creating a mapping of (type, name) tuples to
the renamed value, if it exists. Typically this mapping will be very
sparse and it's fast to create / access. In practice we currently only
have one or two names that collide across all the resource models.

Tests have been updated, some of which needed to define proper Botocore
shapes as the code now looks more closely at those at model load time.

cc @kyleknap @jamesls 