### PR TITLE
Add profile_name option to sessions

### DIFF
--- a/boto3/session.py
+++ b/boto3/session.py
@@ -37,10 +37,13 @@ class Session(object):
     :type botocore_session: botocore.session.Session
     :param botocore_session: Use this Botocore session instead of creating
                              a new default one.
+    :type profile_name: string
+    :param profile_name: The name of a profile to use. If not given, then
+                         the default profile is used.
     """
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
                  aws_session_token=None, region_name=None,
-                 botocore_session=None):
+                 botocore_session=None, profile_name=None):
         if botocore_session is not None:
             self._session = botocore_session
         else:
@@ -58,6 +61,9 @@ class Session(object):
             self._session.user_agent_name = 'Boto3'
             self._session.user_agent_version = boto3.__version__
 
+        if profile_name is not None:
+            self._session.profile = profile_name
+
         if aws_access_key_id or aws_secret_access_key or aws_session_token:
             self._session.set_credentials(aws_access_key_id,
                 aws_secret_access_key, aws_session_token)
@@ -71,6 +77,13 @@ class Session(object):
     def __repr__(self):
         return 'Session(region={0})'.format(
             repr(self._session.get_config_variable('region')))
+
+    @property
+    def profile_name(self):
+        """
+        The **read-only** profile name.
+        """
+        return self._session.profile or 'default'
 
     def _setup_loader(self):
         """

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -66,6 +66,23 @@ class TestSession(BaseTestCase):
         bc_session.set_credentials.assert_called_with(
             'key', 'secret', 'token')
 
+    def test_profile_can_be_set(self):
+        bc_session = self.bc_session_cls.return_value
+
+        session = Session(profile_name='foo')
+
+        self.assertEqual(bc_session.profile, 'foo')
+
+        # We should also be able to read the value
+        self.assertEqual(session.profile_name, 'foo')
+
+    def test_profile_default(self):
+        self.bc_session_cls.return_value.profile = None
+
+        session = Session()
+
+        self.assertEqual(session.profile_name, 'default')
+
     def test_custom_session(self):
         bc_session = self.bc_session_cls()
         self.bc_session_cls.reset_mock()


### PR DESCRIPTION
This change makes it possible to create a session using a profile name, which
was previously only possible via an environment variable. It allows you to
create clients and resources from any number of sessions using any number of
profiles.

Given that we have the following `~/.aws/credentials`:

```ini
[default]
aws_access_key_id = DEFAULT
aws_secret_access_key = SECRET1

[dev]
aws_access_key_id = DEV
aws_secret_access_key = SECRET2

[prod]
aws_access_key_id = PROD
aws_secret_access_key = SECRET3
```

You can do the following:

```python
import boto3.session

dev = boto3.session.Session(profile_name='dev')
prod = boto3.session.Session(profile_name='prod')

for session in [dev, prod]:
    print('Profile: ' + session.profile)
    s3 = session.resource('s3')
    for bucket in s3.buckets.all():
        print(bucket.name)
    print('')
```

It is also possible to setup the default session with a profile:

```python
import boto3

boto3.setup_default_session(profile_name='dev')

s3 = boto3.resource('s3')
```

And of course you can still use the environment variable:

```bash
$ BOTO_DEFAULT_PROFILE=dev ipython
>>> import boto3
>>> s3dev = boto3.resource('s3')
```

Once a session is created, the profile is immutable. The `profile_name`
property is provided for convenience and just surfaces the underlying
Botocore session's profile property.

Why not provide a profile name to the `client` and `resource` methods?
Currently there is no easy way to clone a session, and the behavior of
creating a new blank session (from one which may have customizations)
leads to possibly unintended side-effects like clients without the
proper event handlers registered. This would be an additive change
should we want to revisit in the future. At this point, the change
in this commit provides a way for Boto 3 users to use multiple profiles
without resorting to creating their own Botocore sessions.

I'm definitely open to suggestions and counter-arguments.

cc @jamesls @kyleknap 