### PR TITLE
(IAM) Make User properties available via `CurrentUser`

### DIFF
--- a/boto3/data/resources/iam-2010-05-08.resources.json
+++ b/boto3/data/resources/iam-2010-05-08.resources.json
@@ -420,6 +420,13 @@
       }
     },
     "CurrentUser": {
+      "shape": "User",
+      "load": {
+        "request": {
+          "operation": "GetUser"
+        },
+        "path": "User"
+      },
       "hasMany": {
         "AccessKeys": {
           "request": { "operation": "ListAccessKeys" },


### PR DESCRIPTION
This is a very simple change to make properties available when accessing a User via `resource.CurrentUser()`.

For example, it makes the following work:
```python
iam = boto3.resource('iam')
print iam.CurrentUser().arn
```

I am not sure of how to make the actions available without a large amount of duplication, as these are defined on the `User` resource. If there's a nice way to do this let me know and I'll update the PR.

As an aside, I also noticed that installing dependencies from `requirements.txt` installs the latest versions of a few packages from Github which are newer than `setup.py` expects, causing any setup tasks to fail. It would be good to fix this.