### PR TITLE
Load reference data if a resource path is defined

### DIFF
--- a/boto3/resources/factory.py
+++ b/boto3/resources/factory.py
@@ -253,9 +253,8 @@ class ResourceFactory(object):
         # Are there any identifiers that need access to data members?
         # This is important when building the resource below since
         # it requires the data to be loaded.
-        needs_data = False
-        if [i for i in reference.resource.identifiers if i.source == 'data']:
-            needs_data = True
+        needs_data = any(i.source == 'data' for i in \
+                         reference.resource.identifiers)
 
         def get_reference(self):
             # We need to lazy-evaluate the reference to handle circular

--- a/boto3/resources/factory.py
+++ b/boto3/resources/factory.py
@@ -253,7 +253,7 @@ class ResourceFactory(object):
         # Are there any identifiers that need access to data members?
         # This is important when building the resource below since
         # it requires the data to be loaded.
-        needs_data = any(i.source == 'data' for i in \
+        needs_data = any(i.source == 'data' for i in
                          reference.resource.identifiers)
 
         def get_reference(self):

--- a/tests/unit/resources/test_factory.py
+++ b/tests/unit/resources/test_factory.py
@@ -702,7 +702,8 @@ class TestResourceFactoryDanglingResource(BaseTestResourceFactory):
                         'resource': {
                             'type': 'NetworkInterface',
                             'identifiers': [
-                                {'target': 'Id', 'source': 'data', 'path': 'NetworkInterface.Id'}
+                                {'target': 'Id', 'source': 'data',
+                                 'path': 'NetworkInterface.Id'}
                             ],
                             'path': 'NetworkInterface'
                         }
@@ -725,7 +726,7 @@ class TestResourceFactoryDanglingResource(BaseTestResourceFactory):
                     'Id': 'network-interface-id',
                     'PublicIp': '127.0.0.1'
                 }
-        }
+            }
         instance.load = mock.Mock(side_effect=set_meta_data)
 
         # Now, get the reference and make sure it has its identifier

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -1,0 +1,86 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from botocore.model import DenormalizedStructureBuilder, ServiceModel
+
+from boto3.docs import py_type_name, document_structure
+from tests import mock, BaseTestCase
+
+
+class TestPythonTypeName(BaseTestCase):
+    def test_structure(self):
+        self.assertEqual('dict', py_type_name('structure'))
+
+    def test_list(self):
+        self.assertEqual('list', py_type_name('list'))
+
+    def test_map(self):
+        self.assertEqual('dict', py_type_name('map'))
+
+    def test_string(self):
+        self.assertEqual('string', py_type_name('string'))
+
+    def test_character(self):
+        self.assertEqual('string', py_type_name('character'))
+
+    def test_blob(self):
+        self.assertEqual('bytes', py_type_name('blob'))
+
+    def test_timestamp(self):
+        self.assertEqual('datetime', py_type_name('timestamp'))
+
+    def test_integer(self):
+        self.assertEqual('integer', py_type_name('integer'))
+
+    def test_long(self):
+        self.assertEqual('integer', py_type_name('long'))
+
+    def test_float(self):
+        self.assertEqual('float', py_type_name('float'))
+
+    def test_double(self):
+        self.assertEqual('float', py_type_name('double'))
+
+
+class TestDocumentStructure(BaseTestCase):
+    def test_nested_structure(self):
+        # Internally this doesn't use an OrderedDict so we can't
+        # test the full output, but we can test whether the
+        # parameters are all included as expected with the correct
+        # types.
+        shape = DenormalizedStructureBuilder().with_members({
+            'Param1': {
+                'type': 'list',
+                'member': {
+                    'type': 'structure',
+                    'members': {
+                        'Param2': {
+                            'type': 'string'
+                        },
+                        'Param3': {
+                            'type': 'float'
+                        }
+                    }
+                }
+            },
+            'Param4': {
+                'type': 'blob'
+            }
+        }).build_model()
+
+        doc = document_structure('Test', shape)
+
+        self.assertIn("'Param1': [", doc)
+        self.assertIn("'Param2': STRING", doc)
+        self.assertIn("'Param3': FLOAT", doc)
+        self.assertIn("'Param4': BYTES", doc)


### PR DESCRIPTION
This change allows references with a JMESPath query set on the reference
resource path attribute to be loaded with data at instantiation time if
that data is present in the parent (via `meta.data`). If the data has
not yet been loaded and the parent is loadable, then a `load` operation
is incurred.

Before:
```python
>>> ni = ec2.NetworkInterface('abc123')
>>> ni.association.public_ip
ResourceLoadException: ec2.NetworkInterfaceAssociation has no load method
```

After:
```python
>>> ni = ec2.NetworkInterface('abc123')
>>> ni.association.public_ip
'127.0.0.1'
```

Added a test to ensure this works as expected.

@kyleknap @jamesls please have a look.