### PR TITLE
Add migration guide for S3 and EC2

### DIFF
--- a/docs/source/guide/migration.rst
+++ b/docs/source/guide/migration.rst
@@ -1,31 +1,27 @@
 .. _guide_migration:
 
 Migrating from Boto 2.x
------------------------
+=======================
 Current Boto users can begin using Boto 3 right away. The two modules can
 live side-by-side in the same project, which means that a piecemeal
 approach can be used. New features can be written in Boto 3, or existing
 code can be migrated over as needed, piece by piece.
 
-.. warning::
-
-   Boto 3 is currently in **developer preview**.
-
 High Level Concepts
 -------------------
-Boto 2.x modules are typically split into two categories, those which include a high-level object-oriented interface and those which include only a low-level interface which matches the underlying Amazon Web Services API. Some modules are completely hand-written (like Amazon S3 or EC2), some include hand-written code on top of a code-generated connection (like Amazon DynamoDB), and others are 100% code-generated (like Amazon Elastic Transcoder).
+Boto 2.x modules are typically split into two categories, those which include a high-level object-oriented interface and those which include only a low-level interface which matches the underlying Amazon Web Services API. Some modules are completely high-level (like Amazon S3 or EC2), some include high-level code on top of a low-level connection (like Amazon DynamoDB), and others are 100% low-level (like Amazon Elastic Transcoder).
 
-In Boto 3 this general idea hasn't changed much, but there are two important points to understand.
+In Boto 3 this general low-level and high-level concept hasn't changed much, but there are two important points to understand.
 
 Data Driven
 ~~~~~~~~~~~
-First, code is no longer generated and instead classes are created at runtime from JSON data files that describe AWS APIs and organizational structures built atop of them. These data files are loaded at runtime and can be modified and updated without the need of installing an entirely new SDK release.
+First, in Boto 3 classes are created at runtime from JSON data files that describe AWS APIs and organizational structures built atop of them. These data files are loaded at runtime and can be modified and updated without the need of installing an entirely new SDK release.
 
-A side effect of having all the services generated from JSON files is that there is now consistency between all AWS service modules. One important change is that *all* API call parameters must now be passed as **keyword arguments**, and these keyword arguments take the form defined by the service. Though there are exceptions, this typically means ``UpperCamelCasing`` parameter names. You will see this in the service-specific migration guides linked to below.
+A side effect of having all the services generated from JSON files is that there is now consistency between all AWS service modules. One important change is that *all* API call parameters must now be passed as **keyword arguments**, and these keyword arguments take the form defined by the upstream service. Though there are exceptions, this typically means ``UpperCamelCasing`` parameter names. You will see this in the service-specific migration guides linked to below.
 
 Resource Objects
 ~~~~~~~~~~~~~~~~
-Second, while every service now uses the runtime-generated low-level client, some services additionally have high-level generated objects that we refer to as ``Resources``. The lower-level is comparable to Boto 2.x layer 1 connection objects. The higher level is comparable to the hand-written customizations from Boto 2.x: an S3 ``Key``, an EC2 ``Instance``, and a DynamoDB ``Table`` are all considered resources in Boto 3. Some services may also have hand-written customizations built on top of the runtime-generated high-level resources (such as utilities for working with S3 multipart uploads).
+Second, while every service now uses the runtime-generated low-level client, some services additionally have high-level generated objects that we refer to as ``Resources``. The lower-level is comparable to Boto 2.x layer 1 connection objects in that they provide a one to one mapping of API operations and return low-level responses. The higher level is comparable to the high-level customizations from Boto 2.x: an S3 ``Key``, an EC2 ``Instance``, and a DynamoDB ``Table`` are all considered resources in Boto 3. Just like a Boto 2.x ``S3Connection``'s ``list_buckets`` will return ``Bucket`` objects, the Boto 3 resource interface provides actions and collections that return resources. Some services may also have hand-written customizations built on top of the runtime-generated high-level resources (such as utilities for working with S3 multipart uploads).
 
 ::
 

--- a/docs/source/guide/migration.rst
+++ b/docs/source/guide/migration.rst
@@ -1,0 +1,68 @@
+.. _guide_migration:
+
+Migrating from Boto 2.x
+-----------------------
+Current Boto users can begin using Boto 3 right away. The two modules can
+live side-by-side in the same project, which means that a piecemeal
+approach can be used. New features can be written in Boto 3, or existing
+code can be migrated over as needed, piece by piece.
+
+.. warning::
+
+   Boto 3 is currently in **developer preview**.
+
+High Level Concepts
+-------------------
+Boto 2.x modules are typically split into two categories, those which include a high-level object-oriented interface and those which include only a low-level interface which matches the underlying Amazon Web Services API. Some modules are completely hand-written (like Amazon S3 or EC2), some include hand-written code on top of a code-generated connection (like Amazon DynamoDB), and others are 100% code-generated (like Amazon Elastic Transcoder).
+
+In Boto 3 this general idea hasn't changed much, but there are two important points to understand.
+
+Data Driven
+~~~~~~~~~~~
+First, code is no longer generated and instead classes are created at runtime from JSON data files that describe AWS APIs and organizational structures built atop of them. These data files are loaded at runtime and can be modified and updated without the need of installing an entirely new SDK release.
+
+A side effect of having all the services generated from JSON files is that there is now consistency between all AWS service modules. One important change is that *all* API call parameters must now be passed as **keyword arguments**, and these keyword arguments take the form defined by the service. Though there are exceptions, this typically means ``UpperCamelCasing`` parameter names. You will see this in the service-specific migration guides linked to below.
+
+Resource Objects
+~~~~~~~~~~~~~~~~
+Second, while every service now uses the runtime-generated low-level client, some services additionally have high-level generated objects that we refer to as ``Resources``. The lower-level is comparable to Boto 2.x layer 1 connection objects. The higher level is comparable to the hand-written customizations from Boto 2.x: an S3 ``Key``, an EC2 ``Instance``, and a DynamoDB ``Table`` are all considered resources in Boto 3. Some services may also have hand-written customizations built on top of the runtime-generated high-level resources (such as utilities for working with S3 multipart uploads).
+
+::
+
+    import boto, boto3
+
+    # Low-level connections
+    conn = boto.connect_elastictranscoder()
+    client = boto3.client('elastictranscoder')
+
+    # High-level connections & resource objects
+    from boto.s3.bucket import Bucket
+    s3_conn = boto.connect_s3()
+    boto2_bucket = Bucket('mybucket')
+
+    s3 = boto3.resource('s3')
+    boto3_bucket = s3.Bucket('mybucket')
+
+Installation & Configuration
+----------------------------
+The :ref:`guide_quickstart` guide provides instructions for installing Boto 3. You can also follow the instructions there to set up new credential files, or you can continue to use your existing Boto 2.x credentials. Please note that Boto 3, the AWS CLI, and several other SDKs all use the shared credentials file (usually at ``~/.aws/credentials``).
+
+Once configured, you may begin using Boto 3::
+
+    import boto3
+
+    for bucket in boto3.resource('s3').buckets.all():
+        print(bucket.name)
+
+See the :ref:`guide_tutorial` and `Boto 3 Documentation <http://boto3.readthedocs.org/>`__ for more information.
+
+The rest of this document will describe specific common usage scenarios of Boto 2 code and how to accomplish the same tasks with Boto 3.
+
+Services
+--------
+
+.. toctree::
+   :maxdepth: 2
+
+   migrations3
+   migrationec2

--- a/docs/source/guide/migrationec2.rst
+++ b/docs/source/guide/migrationec2.rst
@@ -2,7 +2,7 @@
 
 Amazon EC2
 ==========
-Boto 2.x contains a number of customizations to make working with Amazon EC2 instances, storage and networks easy.
+Boto 2.x contains a number of customizations to make working with Amazon EC2 instances, storage and networks easy. Boto 3 exposes these same objects through its resources interface in a unified and consistent way.
 
 Creating the Connection
 -----------------------
@@ -43,7 +43,7 @@ Stopping and terminating multiple instances given a list of instance IDs uses Bo
 
 Checking What Instances Are Running
 -----------------------------------
-Boto 3 collections come in handy when listing all your running instances as well::
+Boto 3 collections come in handy when listing all your running instances as well. Every collection exposes a ``filter`` method that allows you to pass additional parameters to the underlying service API operation. The EC2 instances collection takes a parameter called ``Filters`` which is a list of names and values, for example::
 
     # Boto 2.x
     reservations = ec2_connection.get_all_reservations(
@@ -53,6 +53,8 @@ Boto 3 collections come in handy when listing all your running instances as well
             print(instance.instance_id, instance.instance_type)
 
     # Boto 3
+    # Use the filter() method of the instances collection to retrieve
+    # all running EC2 instances.
     instances = ec2.instances.filter(
         Filters=[{'Name': 'instance-state-name', 'Values': ['running']}])
     for instance in instances:

--- a/docs/source/guide/migrationec2.rst
+++ b/docs/source/guide/migrationec2.rst
@@ -1,0 +1,123 @@
+.. _guide_migration_ec2:
+
+Amazon EC2
+==========
+Boto 2.x contains a number of customizations to make working with Amazon EC2 instances, storage and networks easy.
+
+Creating the Connection
+-----------------------
+Boto 3 has both low-level clients and higher-level resources. For Amazon EC2, the higher-level resources are the most similar to Boto 2.x's ``ec2`` and ``vpc`` modules::
+
+    # Boto 2.x
+    import boto
+    ec2_connection = boto.connect_ec2()
+    vpc_connection = boto.connect_vpc()
+
+    # Boto 3
+    import boto3
+    ec2 = boto3.resource('ec2')
+
+Launching New Instances
+-----------------------
+Launching new instances requires an image ID and the number of instances to launch. It can also take several optional parameters, such as the instance type and security group::
+
+    # Boto 2.x
+    ec2_connection.run_instances('<ami-image-id>')
+
+    # Boto 3
+    ec2.create_instances(ImageId='<ami-image-id>', MinCount=1, MaxCount=5)
+
+Stopping & Terminating Instances
+--------------------------------
+Stopping and terminating multiple instances given a list of instance IDs uses Boto 3 collection filtering::
+
+    ids = ['instance-id-1', 'instance-id-2', ...]
+
+    # Boto 2.x
+    ec2_connection.stop_instances(instance_ids=ids)
+    ec2_connection.terminate_instances(instance_ids=ids)
+
+    # Boto 3
+    ec2.instances.filter(InstanceIds=ids).stop()
+    ec2.instances.filter(InstanceIds=ids).terminate()
+
+Checking What Instances Are Running
+-----------------------------------
+Boto 3 collections come in handy when listing all your running instances as well::
+
+    # Boto 2.x
+    reservations = ec2_connection.get_all_reservations(
+        filters={'instance-state-name': 'running'})
+    for reservation in reservations:
+        for instance in reservation.instances:
+            print(instance.instance_id, instance.instance_type)
+
+    # Boto 3
+    instances = ec2.instances.filter(
+        Filters=[{'Name': 'instance-state-name', 'Values': ['running']}])
+    for instance in instances:
+        print(instance.id, instance.instance_type)
+
+Checking Health Status Of Instances
+-----------------------------------
+It is possible to get scheduled maintenance information for your running instances. At the time of this writing Boto 3 does not have a status resource, so you must drop down to the low-level client via ``ec2.meta.client``::
+
+    # Boto 2.x
+    for status in ec2_connection.get_all_instance_statuses():
+        print(status)
+
+    # Boto 3
+    for status in ec2.meta.client.describe_instance_status()['InstanceStatuses']:
+        print(status)
+
+Working with EBS Snapshots
+--------------------------
+Snapshots provide a way to create a copy of an EBS volume, as well as make new volumes from the snapshot which can be attached to an instance::
+
+    # Boto 2.x
+    snapshot = ec2_connection.create_snapshot('volume-id', 'Description')
+    volume = snapshot.create_volume('us-west-2')
+    ec2_connection.attach_volume(volume.id, 'instance-id', '/dev/sdy')
+    ec2_connection.delete_snapshot(snapshot.id)
+
+    # Boto 3
+    snapshot = ec2.create_snapshot(VolumeId='volume-id', Description='description')
+    volume = ec2.create_volume(SnapshotId=snapshot.id, AvailabilityZone='us-west-2a')
+    ec2.Instance('instance-id').attach_volume(VolumeId=volume.id, Device='/dev/sdy')
+    snapshot.delete()
+
+Creating a VPC, Subnet, and Gateway
+-----------------------------------
+Creating VPC resources in Boto 3 is very similar to Boto 2.x::
+
+    # Boto 2.x
+    vpc = vpc_connection.create_vpc('10.0.0.0/24')
+    subnet = vpc_connection.create_subnet(vpc.id, '10.0.0.0/25')
+    gateway = vpc_connection.create_internet_gateway()
+
+    # Boto 3
+    vpc = ec2.create_vpc(CidrBlock='10.0.0.0/24')
+    subnet = vpc.create_subnet(CidrBlock='10.0.0.0/25')
+    gateway = ec2.create_internet_gateway()
+
+Attaching and Detaching an Elastic IP and Gateway
+-------------------------------------------------
+Elastic IPs and gateways provide a way for instances inside of a VPC to communicate with the outside world::
+
+    # Boto 2.x
+    ec2_connection.attach_internet_gateway(gateway.id, vpc.id)
+    ec2_connection.detach_internet_gateway(gateway.id, vpc.id)
+
+    from boto.ec2.address import Address
+    address = Address()
+    address.allocation_id = 'eipalloc-35cf685d'
+    address.associate('i-71b2f60b')
+    address.disassociate()
+
+    # Boto 3
+    gateway.attach_to_vpc(VpcId=vpc.id)
+    gateway.detach_from_vpc(VpcId=vpc.id)
+
+    address = ec2.VpcAddress('eipalloc-35cf685d')
+    address.associate('i-71b2f60b')
+    address.association.delete()

--- a/docs/source/guide/migrations3.rst
+++ b/docs/source/guide/migrations3.rst
@@ -52,7 +52,6 @@ Getting a bucket is easy with Boto 3's resources, however these do not automatic
 
     # Boto 3
     bucket = s3.Bucket('mybucket')
-    bucket.wait_until_exists(max_attempts=2, service_args={'Foo': 1})
     exists = True
     try:
         s3.meta.client.head_bucket(Bucket='mybucket')

--- a/docs/source/guide/migrations3.rst
+++ b/docs/source/guide/migrations3.rst
@@ -1,0 +1,160 @@
+.. _guide_migration_s3:
+
+Amazon S3
+=========
+Boto 2.x contains a number of customizations to make working with Amazon S3 buckets and keys easy.
+
+Creating the Connection
+-----------------------
+Boto 3 has both low-level clients and higher-level resources. For Amazon S3, the higher-level resources are the most similar to Boto 2.x's ``s3`` module::
+
+    # Boto 2.x
+    import boto
+    s3_connection = boto.connect_s3()
+
+    # Boto 3
+    import boto3
+    s3 = boto3.resource('s3')
+
+Creating a Bucket
+-----------------
+Creating a bucket in Boto 2 and Boto 3 is very similar, except that in Boto 3 all action parameters must be passed via keyword arguments and a bucket configuration must be specified manually::
+
+    # Boto 2.x
+    s3_connection.create_bucket('mybucket')
+    s3_connection.create_bucket('mybucket', location=Location.USWest)
+
+    # Boto 3
+    s3.create_bucket(Bucket='mybucket')
+    s3.create_bucket(Bucket='mybucket', CreateBucketConfiguration={
+        'Location': 'us-west-1'})
+
+Storing Data
+------------
+Storing data from a file, stream, or string is easy::
+
+    # Boto 2.x
+    from boto.s3.key import Key
+    key = Key('hello.txt')
+    key.set_contents_from_file('/tmp/hello.txt')
+
+    # Boto 3
+    s3.Key('mybucket', 'hello.txt').put(Body=open('/tmp/hello.txt'))
+
+
+Accessing a Bucket
+------------------
+Getting a bucket is easy with Boto 3's resources, however these do not automatically validate whether a bucket exists::
+
+    # Boto 2.x
+    bucket = s3_connection.get_bucket('mybucket', validate=False)
+    exists = s3_connection.lookup('mybucket')
+
+    # Boto 3
+    bucket = s3.Bucket('mybucket')
+    bucket.wait_until_exists(max_attempts=2, service_args={'Foo': 1})
+    try:
+        s3.meta.client.head_bucket(Bucket='mybucket')
+        exists = True
+    except ClientError:
+        exists = False
+
+Deleting a Bucket
+-----------------
+All of the keys in a bucket must be deleted before the bucket itself can be deleted::
+
+    # Boto 2.x
+    for key in bucket:
+        key.delete()
+    bucket.delete()
+
+    # Boto 3
+    for key in bucket.objects.all():
+        key.delete()
+    bucket.delete()
+
+Iteration of Buckets and Keys
+-----------------------------
+Bucket and key objects are no longer iterable, but now provide collection attributes which can be iterated::
+
+    # Boto 2.x
+    for bucket in s3_connection:
+        for key in bucket:
+            print(key.name)
+
+    # Boto 3
+    for bucket in s3.buckets.all():
+        for key in bucket.objects.all():
+            print(key.name)
+
+Access Controls
+---------------
+Getting and setting canned access control values in Boto 3 operates on an ``ACL`` resource object::
+
+    # Boto 2.x
+    bucket.set_acl('public-read')
+    key.set_acl('public-read')
+
+    # Boto 3
+    bucket.Acl().put(ACL='public-read')
+    obj.put(ACL='public-read')
+
+It's also possible to retrieve the policy grant information::
+
+    # Boto 2.x
+    acp = bucket.get_acl()
+    for grant in acp.acl.grants:
+        print(grant.display_name, grant.permission)
+
+    # Boto 3
+    acl = bucket.Acl()
+    for grant in acl.grants:
+        print(grant['DisplayName'], grant['Permission'])
+
+Boto 3 lacks the grant shortcut methods present in Boto 2.x, but it is still fairly simple to add grantees::
+
+    # Boto 2.x
+    bucket.add_email_grant('READ', 'user@domain.tld')
+
+    # Boto 3
+    bucket.Acl.put(GrantRead='emailAddress=user@domain.tld')
+
+Key Metadata
+------------
+It's possible to set arbitrary metadata on keys::
+
+    # Boto 2.x
+    key.set_metadata('meta1', 'This is my metadata value')
+    print(key.get_metadata('meta1'))
+
+    # Boto 3
+    key.put(Metadata={'meta1': 'This is my metadata value'})
+    print(key.metadata['meta1'])
+
+Managing CORS Configuration
+---------------------------
+Allows you to manage the cross-origin resource sharing configuration for S3 buckets::
+
+    # Boto 2.x
+    cors = bucket.get_cors()
+
+    config = CORSConfiguration()
+    config.add_rule('GET', '*')
+    bucket.set_cors(config)
+
+    bucket.delete_cors()
+
+    # Boto 3
+    cors = bucket.Cors()
+
+    config = {
+        'CORSRules': [
+            {
+                'AllowedMethods': ['GET'],
+                'AllowedOrigins': ['*']
+            }
+        ]
+    }
+    cors.put(CORSConfiguration=config)
+
+    cors.delete()

--- a/docs/source/guide/migrations3.rst
+++ b/docs/source/guide/migrations3.rst
@@ -2,7 +2,7 @@
 
 Amazon S3
 =========
-Boto 2.x contains a number of customizations to make working with Amazon S3 buckets and keys easy.
+Boto 2.x contains a number of customizations to make working with Amazon S3 buckets and keys easy. Boto 3 exposes these same objects through its resources interface in a unified and consistent way.
 
 Creating the Connection
 -----------------------
@@ -27,7 +27,7 @@ Creating a bucket in Boto 2 and Boto 3 is very similar, except that in Boto 3 al
     # Boto 3
     s3.create_bucket(Bucket='mybucket')
     s3.create_bucket(Bucket='mybucket', CreateBucketConfiguration={
-        'Location': 'us-west-1'})
+        'LocationConstraint': 'us-west-1'})
 
 Storing Data
 ------------
@@ -53,11 +53,15 @@ Getting a bucket is easy with Boto 3's resources, however these do not automatic
     # Boto 3
     bucket = s3.Bucket('mybucket')
     bucket.wait_until_exists(max_attempts=2, service_args={'Foo': 1})
+    exists = True
     try:
         s3.meta.client.head_bucket(Bucket='mybucket')
-        exists = True
-    except ClientError:
-        exists = False
+    except ClientError as e:
+        # If a client error is thrown, then check that it was a 404 error.
+        # If it was a 404 error, then the bucket does not exist.
+        error_code = int(e.response['Error']['Code'])
+        if error_code == 404:
+            exists = False
 
 Deleting a Bucket
 -----------------

--- a/docs/source/guide/new.rst
+++ b/docs/source/guide/new.rst
@@ -37,13 +37,3 @@ Boto 3 is built atop of a library called
 `AWS CLI <http://aws.amazon.com/cli/>`_. Botocore provides the low level
 clients, session, and credential & configuration data. Boto 3 builds on top
 of Botocore by providing its own session, resources and collections.
-
-Migration
----------
-Current Boto users can begin using Boto 3 right away. The two modules can
-live side-by-side in the same project, which means that a piecemeal
-approach can be used. New features can be written in Boto 3, or existing
-code can be migrated over as needed, piece by piece.
-
-Boto 3 is currently in **developer preview**. A full migration guide is
-coming soon.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,6 +20,15 @@ direct service access.
 
    <div style="text-align:center;margin:1em"><iframe width="560" height="315" src="//www.youtube.com/embed/Cb2czfCV4Dg" frameborder="0" allowfullscreen></iframe></div>
 
+Quickstart
+----------
+
+.. toctree::
+   :maxdepth: 2
+
+   guide/quickstart
+   guide/tutorial
+
 User Guide
 ----------
 
@@ -27,10 +36,9 @@ User Guide
    :maxdepth: 2
 
    guide/new
-   guide/quickstart
+   guide/migration
    guide/resources
    guide/collections
-   guide/tutorial
    guide/clients
    guide/session
    guide/configuration


### PR DESCRIPTION
An initial attempt at starting a migration guide. This covers:

1. General changes between Boto 2 and 3
2. An S3 migration guide
3. An EC2 migration guide
4. Moving the quickstart/tutorial into its own section before the migration guides

The migration guides are based on the Boto tutorials available on Read The Docs. It's likely we will want to add to them in the future but this sets up the basic framework and gives people a place to get started.

cc @jamesls @kyleknap 