### PR TITLE
Add nested structure descriptions to params & return value.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,5 +2,3 @@
 branch = True
 include =
     boto3/*
-omit =
-    boto3/docs.py

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ services that are supported.
 Boto 3 is in **developer preview**.  This means that until a 1.0 release
 occurs, some of the interfaces may change based on your feedback.
 Once a 1.0 release happens, we guarantee backwards compatibility
-for all future 1.x.x releases.  Try out boto3 and give us
+for all future 1.x.x releases.  Try out Boto 3 and give us
 `feedback <https://github.com/boto/boto3/issues>`__ today!
 
 .. _boto: https://docs.pythonboto.org/

--- a/boto3/docs.py
+++ b/boto3/docs.py
@@ -129,6 +129,10 @@ def docs_for(service_name, session=None, resource_filename=None):
     :param service_name: The service short-name, like 'ec2'
     :type session: botocore.session.Session
     :param session: Existing pre-setup session or ``None``.
+    :type resource_filename: string
+    :param resource_filename: Full path to the service's resource JSON
+                              description file. If unset, then this is
+                              loaded from the default location.
     :rtype: string
     """
     if session is None:
@@ -752,7 +756,7 @@ def render_map(shape, spaces, indent, eol):
     member in the shape::
 
         {
-            'MemberName': 'Value'
+            'Key': 'Value'
         }
 
     """

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,11 +10,13 @@ developers to write software that makes use of Amazon services like S3 and
 EC2. Boto provides an easy to use, object-oriented API as well as low-level
 direct service access.
 
-.. danger::
+.. note::
 
-   Boto 3 is in *developer preview* and **should not** be used in production
-   yet. However, we would greatly appreciate it if you try out Boto 3 and
-   give us some `feedback <https://github.com/boto/boto3>`_!
+   Boto 3 is in **developer preview**.  This means that until a 1.0 release
+   occurs, some of the interfaces may change based on your feedback. Once a
+   1.0 release happens, we guarantee backwards compatibility for all future
+   1.x.x releases.  Try out Boto 3 and give us
+   `feedback <https://github.com/boto/boto3/issues>`__ today!
 
 .. raw:: html
 

--- a/tests/unit/data/aws/todo/2015-04-01.normal.json
+++ b/tests/unit/data/aws/todo/2015-04-01.normal.json
@@ -1,0 +1,185 @@
+{
+  "metadata":{
+    "apiVersion":"2015-04-01",
+    "endpointPrefix":"todo",
+    "jsonVersion":"1.1",
+    "serviceFullName":"AWS ToDo Sample API for Tasks",
+    "serviceAbbreviation":"AWS ToDo Tasks",
+    "signatureVersion":"v4",
+    "protocol":"json"
+  },
+  "documentation":"<p>AWS sample API that tracks to-do items.</p><ul></ul>",
+  "operations":{
+    "CreateToDo":{
+      "name":"CreateToDo",
+      "http":{
+        "method":"POST",
+        "requestUri":"/todos"
+      },
+      "input":{
+        "shape":"CreateToDoInput",
+        "documentation":"<p>Container of the newly created to-do's values.</p>"
+      },
+      "output":{
+        "shape":"ToDoItem",
+        "documentation":"<p>A single ToDo item.</p>"
+      },
+      "errors":[
+        {
+          "shape":"ToDoServerException",
+          "exception":true,
+          "documentation":"<p>A server-side error occurred during the API call. The error message will contain additional details about the cause.</p>"
+        },
+        {
+          "shape":"ToDoClientException",
+          "exception":true,
+          "documentation":"<p>The API was called with invalid parameters. The error message will contain additional details about the cause.</p>"
+        }
+      ],
+      "documentation":"<p>Create a new to-do item.</p>"
+    },
+    "DescribeToDos": {
+      "name":"DescribeToDos",
+      "http":{
+        "method":"GET",
+        "requestUri":"/todos"
+      },
+      "output":{
+        "shape":"ToDoList",
+        "documentation":"<p>List of to-do items.</p>"
+      },
+      "errors":[
+        {
+          "shape":"ToDoServerException",
+          "exception":true,
+          "documentation":"<p>A server-side error occurred during the API call. The error message will contain additional details about the cause.</p>"
+        }
+      ],
+      "documentation":"<p>Create a new to-do item.</p>"
+    },
+    "GetToDo":{
+      "name":"GetToDo",
+      "http":{
+        "method":"GET",
+        "requestUri":"/todos/{Id+}"
+      },
+      "input":{
+        "shape":"ToDoInput"
+      },
+      "output":{
+        "shape":"ToDoItem"
+      },
+      "errors":[
+        {
+          "shape":"ToDoServerException",
+          "exception":true,
+          "documentation":"<p>A server-side error occurred during the API call. The error message will contain additional details about the cause.</p>"
+        },
+        {
+          "shape":"ToDoClientException",
+          "exception":true,
+          "documentation":"<p>The API was called with invalid parameters. The error message will contain additional details about the cause.</p>"
+        }
+      ],
+      "documentation":"<p>Get an existing to-do item.</p>"
+    },
+    "DeleteToDo":{
+      "name":"DeleteToDo",
+      "http":{
+        "method":"DELETE",
+        "requestUri":"/todos/{Id+}"
+      },
+      "input":{
+        "shape":"ToDoInput"
+      },
+      "errors":[
+        {
+          "shape":"ToDoServerException",
+          "exception":true,
+          "documentation":"<p>A server-side error occurred during the API call. The error message will contain additional details about the cause.</p>"
+        },
+        {
+          "shape":"ToDoClientException",
+          "exception":true,
+          "documentation":"<p>The API was called with invalid parameters. The error message will contain additional details about the cause.</p>"
+        }
+      ],
+      "documentation":"<p>Delete an existing to-do item.</p>"
+    }
+  },
+  "shapes":{
+    "CreateToDoInput":{
+      "type":"structure",
+      "required":[
+        "Title"
+      ],
+      "members":{
+        "Title":{
+          "shape":"String",
+          "documentation":"The title of the to-do item."
+        }
+      },
+      "documentation":"<p>Container for to-do values.</p>"
+    },
+    "String":{
+      "type":"string"
+    },
+    "ToDoClientException":{
+      "type":"structure",
+      "members":{
+        "message":{"shape":"ErrorMessage"}
+      },
+      "exception":true,
+      "documentation":"<p>The API was called with invalid parameters. The error message will contain additional details about the cause.</p>"
+    },
+    "ToDoInput":{
+      "type":"structure",
+      "required":[
+        "Id"
+      ],
+      "members":{
+        "Id":{
+          "shape":"String",
+          "location":"uri",
+          "locationName":"Id"
+        }
+      }
+    },
+    "ToDoItem":{
+      "type":"structure",
+      "members":{
+        "Id":{
+          "shape":"String",
+          "documentation":"Unique identifier"
+        },
+        "Title":{
+          "shape":"String",
+          "documentation":"The title of the to-do item."
+        },
+        "Status":{
+          "shape":"String",
+          "documentation":"The status of the to-do item. Either <i>CREATING</i>, <i>READY</i>, or <i>DONE</i>."
+        }
+      },
+      "documentation":"A single to-do item."
+    },
+    "ToDoList":{
+      "type":"list",
+      "member":{
+        "shape":"ToDoItem",
+        "documentation":"List of to-do items."
+      }
+    },
+    "ToDoServerException":{
+      "type":"structure",
+      "members":{
+        "message":{"shape":"ErrorMessage"}
+      },
+      "exception":true,
+      "documentation":"<p>A server-side error occurred during the API call. The error message will contain additional details about the cause.</p>"
+    },
+    "ErrorMessage":{
+      "type":"string"
+    }
+  }
+}

--- a/tests/unit/data/aws/todo/2015-04-01.waiters.json
+++ b/tests/unit/data/aws/todo/2015-04-01.waiters.json
@@ -1,0 +1,24 @@
+{
+  "version": 2,
+  "waiters": {
+    "ToDoReady": {
+      "delay": 20,
+      "operation": "GetToDo",
+      "maxAttempts": 25,
+      "acceptors": [
+        {
+          "expected": "READY",
+          "matcher": "path",
+          "state": "success",
+          "argument": "ToDo.Status"
+        },
+        {
+          "expected": "DONE",
+          "matcher": "path",
+          "state": "success",
+          "argument": "ToDo.Status"
+        }
+      ]
+    }
+  }
+}

--- a/tests/unit/data/resources/todo-2015-04-01.resources.json
+++ b/tests/unit/data/resources/todo-2015-04-01.resources.json
@@ -1,0 +1,72 @@
+{
+  "service": {
+    "actions": {
+      "CreateToDo": {
+        "request": { "operation": "CreateToDo" },
+        "resource": {
+          "type": "ToDo",
+          "identifiers": [
+            { "target": "Id", "source": "response", "path": "Id" }
+          ]
+        }
+      }
+    },
+    "has": {
+      "ToDo": {
+        "resource": {
+          "type": "ToDo",
+          "identifiers": [
+            { "target": "Id", "source": "input" }
+          ]
+        }
+      }
+    },
+    "hasMany": {
+      "ToDos": {
+        "request": { "operation": "DescribeToDos" },
+        "resource": {
+          "type": "ToDo",
+          "identifiers": [
+            { "target": "Id", "source": "response", "path": "ToDoList[].Id" }
+          ]
+        }
+      }
+    }
+  },
+  "resources": {
+    "ToDo": {
+      "identifiers": [
+        { "name": "Id" }
+      ],
+      "shape": "ToDoItem",
+      "actions": {
+        "Delete": {
+          "request": {
+            "operation": "DeleteToDo",
+            "params": [
+              { "target": "Id", "source": "identifier", "name": "Id" }
+            ]
+          }
+        }
+      },
+      "waiters": {
+        "Ready": {
+          "waiterName": "ToDoReady",
+          "params": [
+            { "target": "Id", "source": "identifier", "name": "Id" }
+          ]
+        }
+      },
+      "has": {
+        "MySelf": {
+          "resource": {
+            "type": "ToDo",
+            "identifiers": [
+              { "target": "Id", "source": "data", "path": "Id" }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -84,8 +84,7 @@ class TestPythonTypeName(BaseTestCase):
 
 class TestDocumentStructure(BaseTestCase):
     def test_nested_structure(self):
-        shape = DenormalizedStructureBuilder(
-            dict_type=OrderedDict).with_members(
+        shape = DenormalizedStructureBuilder().with_members(
                 load_json('''{
                     "Param1": {
                         "type": "list",

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -11,10 +11,40 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+from botocore.compat import json, OrderedDict
 from botocore.model import DenormalizedStructureBuilder, ServiceModel
 
 from boto3.docs import py_type_name, document_structure
 from tests import mock, BaseTestCase
+
+
+def load_json(data):
+    """
+    Load a string of JSON data using OrderedDict for object
+    pairs.
+    """
+    return json.loads(data, object_pairs_hook=OrderedDict)
+
+
+def fix_whitespace(data):
+    """
+    Return a string without extra leading whitespace. For example:
+
+                    {
+                        "foo": 1
+                    }
+
+    Becomes:
+
+        {
+            "foo": 1
+        }
+
+    """
+    if data and data[0] == '\n':
+        data = data[1:]
+    spaces = len(data) - len(data.lstrip())
+    return '\n'.join([line[spaces:] for line in data.split('\n')])
 
 
 class TestPythonTypeName(BaseTestCase):
@@ -54,33 +84,51 @@ class TestPythonTypeName(BaseTestCase):
 
 class TestDocumentStructure(BaseTestCase):
     def test_nested_structure(self):
-        # Internally this doesn't use an OrderedDict so we can't
-        # test the full output, but we can test whether the
-        # parameters are all included as expected with the correct
-        # types.
-        shape = DenormalizedStructureBuilder().with_members({
-            'Param1': {
-                'type': 'list',
-                'member': {
-                    'type': 'structure',
-                    'members': {
-                        'Param2': {
-                            'type': 'string'
-                        },
-                        'Param3': {
-                            'type': 'float'
+        shape = DenormalizedStructureBuilder(
+            dict_type=OrderedDict).with_members(
+                load_json('''{
+                    "Param1": {
+                        "type": "list",
+                        "member": {
+                            "type": "structure",
+                            "members": {
+                                "Param2": {
+                                    "type": "string"
+                                },
+                                "Param3": {
+                                    "type": "float"
+                                }
+                            }
+                        }
+                    },
+                    "Param4": {
+                        "type": "blob"
+                    },
+                    "Param5": {
+                        "type": "list",
+                        "member": {
+                            "type": "string"
                         }
                     }
-                }
-            },
-            'Param4': {
-                'type': 'blob'
-            }
-        }).build_model()
+                }''')).build_model()
+
+        expected = fix_whitespace('''
+        {
+            'Param1': [
+                {
+                    'Param2': STRING,
+                    'Param3': FLOAT
+                },
+                ...
+            ],
+            'Param4': BYTES,
+            'Param5': [
+                STRING,
+                ...
+            ]
+        }
+        ''')
 
         doc = document_structure('Test', shape)
 
-        self.assertIn("'Param1': [", doc)
-        self.assertIn("'Param2': STRING", doc)
-        self.assertIn("'Param3': FLOAT", doc)
-        self.assertIn("'Param4': BYTES", doc)
+        self.assertEqual(doc, expected)

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -11,11 +11,17 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+import os
+
 from botocore.compat import json, OrderedDict
 from botocore.model import DenormalizedStructureBuilder, ServiceModel
+from botocore.session import get_session
 
-from boto3.docs import py_type_name, document_structure
-from tests import mock, BaseTestCase
+from boto3.docs import py_type_name, document_param_response, docs_for
+from tests import mock, unittest, BaseTestCase
+
+
+ROOT = os.path.dirname(__file__)
 
 
 def load_json(data):
@@ -82,6 +88,141 @@ class TestPythonTypeName(BaseTestCase):
         self.assertEqual('float', py_type_name('double'))
 
 
+class TestDocumentService(unittest.TestCase):
+    """
+    End-to-end tests of the documentation functionality that uses a dummy
+    service and resource JSON description. The tests check for specific
+    values in the output.
+    """
+    def setUp(self):
+        self.session = get_session()
+
+        loader = self.session.get_component('data_loader')
+        loader.data_path = os.path.join(ROOT, 'data')
+
+        self.docs = docs_for(
+            'todo', session=self.session,
+            resource_filename=os.path.join(ROOT, 'data', 'resources',
+                                           'todo-2015-04-01.resources.json'))
+
+        self.resource_docs = ''
+        if 'Service Resource' in self.docs:
+            self.resource_docs = self.docs.split('Service Resource')[-1]
+
+    def assert_after(self, marker, expected, actual):
+        """
+        Assert that the expected value occurs after a text marker in
+        the actual value.
+        """
+        pos = actual.find(marker)
+        self.assertIn(expected, actual[pos:])
+
+    def test_removed_html(self):
+        self.assertNotIn('<p>', self.docs)
+        self.assertNotIn('<ul>', self.docs)
+        self.assertNotIn('<i>', self.docs)
+
+    def test_page_title(self):
+        # The service full name and abbreviated name are both
+        # important!
+        self.assertIn('AWS ToDo Sample API for Tasks (ToDo Tasks)',
+                      self.docs)
+
+    def test_client_description(self):
+        self.assertIn('A low-level client representing AWS ToDo Sample API',
+                      self.docs)
+
+    def test_client_example(self):
+        self.assertIn('todo = boto3.client(\'todo\')', self.docs)
+
+    def test_client_method(self):
+        self.assertIn('.. py:method:: create_to_do(Title=None)', self.docs)
+
+    def test_client_method_description(self):
+        self.assertIn('Create a new to-do item.', self.docs)
+
+    def test_client_method_example(self):
+        self.assertIn('response = client.create_to_do(Title=\'string\')',
+                      self.docs)
+
+    def test_client_method_parameters(self):
+        self.assertIn(':param string Title: *Required*', self.docs)
+        self.assertIn('The title of the to-do item.', self.docs)
+
+    def test_client_method_return(self):
+        self.assertIn(':rtype: dict', self.docs)
+        self.assertIn(':return:', self.docs)
+        self.assertIn('\'Id\': STRING', self.docs)
+        self.assertIn('\'Title\': STRING', self.docs)
+
+    def test_waiter_description(self):
+        self.assertIn('to_do_ready', self.docs)
+        self.assertIn('.. py:method:: wait(Id=None)', self.docs)
+        self.assertIn('This polls :py:meth:`todo.Client.get_to_do` every 20 '
+                      'seconds until a successful state is reached. An error '
+                      'is returned after 25 failed checks.', self.docs)
+
+    def test_waiter_example(self):
+        self.assertIn('client.get_waiter(\'to_do_ready\').wait('
+                      'Id=\'string\')', self.docs)
+
+    def test_resource_description(self):
+        self.assertIn('py:class:: todo.Service()', self.resource_docs)
+        self.assertIn('A resource representing AWS ToDo Sample API',
+                      self.resource_docs)
+
+    def test_resource_example(self):
+        self.assertIn('todo = boto3.resource(\'todo\')', self.resource_docs)
+
+    def test_resource_action_description(self):
+        self.assertIn('.. py:method:: create_to_do(Title=None)',
+                      self.resource_docs)
+        self.assertIn('This method calls :py:meth:`todo.Client.create_to_do`.',
+                      self.resource_docs)
+
+    def test_resource_action_return(self):
+        self.assertIn(':rtype: :py:class:`todo.ToDo`', self.resource_docs)
+
+    def test_resource_collection_description(self):
+        self.assertIn('.. py:attribute:: to_dos', self.resource_docs)
+        self.assertIn('A collection of :py:class:`todo.ToDo` instances. This '
+                      'collection uses the :py:meth:`todo.Client.describe_to_'
+                      'dos` operation to get items.', self.resource_docs)
+
+    def test_resource_has_description(self):
+        self.assertIn('py:class:: todo.ToDo(id)', self.resource_docs)
+        self.assertIn('A resource representing an AWS ToDo Sample API for '
+                      'Tasks (ToDo Tasks) ToDo', self.resource_docs)
+
+    def test_resource_has_example(self):
+        self.assertIn('to_do = todo.ToDo(\'id\')', self.resource_docs)
+
+    def test_resource_identifier(self):
+        self.assertIn('.. py:attribute:: id', self.resource_docs)
+        self.assertIn('(``string``, **identifier**) The ToDo\'s id identifier.'
+                      ' This attribute **must** be set for the actions below '
+                      'to work.', self.resource_docs)
+
+    def test_resource_attribute(self):
+        self.assertIn('.. py:attribute:: title', self.resource_docs)
+        self.assertIn('(``string``) The title of the to-do item.',
+                      self.resource_docs)
+
+    def test_resource_waiter_description(self):
+        self.assertIn('.. py:method:: wait_until_ready()', self.resource_docs)
+        self.assertIn('Waits until this ToDo is ready.', self.resource_docs)
+        self.assertIn('This method calls ``wait()`` on :py:meth:`todo.'
+                      'Client.get_waiter` using `to_do_ready`_ .',
+                      self.resource_docs)
+
+    def test_resource_waiter_example(self):
+        self.assertIn('to_do.wait_until_ready()', self.resource_docs)
+
+    def test_resource_reference(self):
+        self.assertIn('.. py:attribute:: my_self', self.resource_docs)
+        self.assertIn('(:py:class:`todo.ToDo`) The related ToDo if set, '
+                      'otherwise ``None``.', self.resource_docs)
+
 class TestDocumentStructure(BaseTestCase):
     def test_nested_structure(self):
         shape = DenormalizedStructureBuilder().with_members(
@@ -108,6 +249,15 @@ class TestDocumentStructure(BaseTestCase):
                         "member": {
                             "type": "string"
                         }
+                    },
+                    "Param6": {
+                        "type": "map",
+                        "key": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "integer"
+                        }
                     }
                 }''')).build_model()
 
@@ -124,10 +274,13 @@ class TestDocumentStructure(BaseTestCase):
             'Param5': [
                 STRING,
                 ...
-            ]
+            ],
+            'Param6': {
+                STRING: INTEGER
+            }
         }
         ''')
 
-        doc = document_structure('Test', shape)
+        doc = document_param_response('Test', shape)
 
         self.assertEqual(doc, expected)


### PR DESCRIPTION
This change modifies the documentation to include structure examples for
both nested input parameters and nested service response values. Responses
are included for both clients and any resource action which returns a low-
level response. This is part of the work for #54.

This does **not** yet include documentation for each of the nested values
except for a basic Python type. I'm hoping to get some feedback on
this before including the full member documentation.

Additionally, this includes some basic tests for the new functionality
in the `docs.py` module. It also includes a minor naming change for
PEP8 (more of these are coming soon).

Example output:

![screen shot 2015-03-26 at 10 57 55 am](https://cloud.githubusercontent.com/assets/106826/6853526/ef09f87e-d3a8-11e4-9410-77a184feb5ab.png)

cc @jamesls @kyleknap 