### PR TITLE
Initial commit of S3 upload_file/download_file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
 sudo: false
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then travis_retry pip install -r requirements26.txt; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.* ]]; then travis_retry pip install -r requirements2.txt; fi
   - travis_retry pip install -r requirements.txt
   - travis_retry pip install coverage python-coveralls
 script: nosetests --with-coverage --cover-erase

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* bugfix:Documentation: Name collisions are now handled at the resource
+  model layer instead of the factory, meaning that the documentation
+  now uses the correct names.
+  (`issue 67 <https://github.com/boto/boto3/pull/67>`__)
+
 0.0.9 - 2015-02-19
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* feature:Resources: Add a ``load`` operation and ``user`` reference
+  to AWS IAM's ``CurrentUser`` resource.
+  (`issue 72 <https://github.com/boto/boto3/pull/72>`__,
+* feature:Resources: Add resources for AWS IAM managed policies.
+  (`issue 71 <https://github.com/boto/boto3/pull/71>`__)
+
 0.0.10 - 2015-03-05
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,18 @@ Unreleased
 * feature:Session: Add a ``region_name`` option when creating a session.
   (`issue 69 <https://github.com/boto/boto3/pull/69>`__,
   `issue 21 <https://github.com/boto/boto3/issues/21>`__)
+* feature:Botocore: Update to Botocore 0.94.0
+
+  * Update to the latest Amazon CloudeSearch API.
+  * Add support for near-realtime data updates and exporting historical
+    data from Amazon Cognito Sync.
+  * **Removed** the ability to clone a low-level client. Instead, create
+    a new client with the same parameters.
+  * Add support for URL paths in an endpoint URL.
+  * Multithreading signature fixes.
+  * Add support for listing hosted zones by name and getting hosted zone
+    counts from Amazon Route53.
+  * Add support for tagging to AWS Data Pipeline.
 
 0.0.9 - 2015-02-19
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* feature:Resources: Add the ability to load resource data from a
+  ``has`` relationship. This saves a call to ``load`` when available,
+  and otherwise fixes a problem where there was no way to get at
+  certain resource data.
+  (`issue 74 <https://github.com/boto/boto3/pull/72>`__,
+
 0.0.11 - 2015-03-24
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-Unreleased
-----------
+0.0.8 - 2015-02-10
+------------------
 
 * bugfix:Resources: Fix Amazon S3 resource identifier order.
   (`issue 62 <https://github.com/boto/boto3/pull/62>`__)
@@ -11,6 +11,12 @@ Unreleased
 * bugfix:Resources: Re-enable service-level access to all resources,
   allowing e.g. ``obj = s3.Object('bucket', 'key')``.
   (`issue 60 <https://github.com/boto/boto3/pull/60>`__)
+* feature:Botocore: Update to Botocore 0.87.0
+
+  * Add support for Amazon DynamoDB secondary index scanning.
+  * Upgrade to ``requests`` 2.5.1.
+  * Add support for anonymous (unsigned) clients.
+    (`botocore issue 448 <https://github.com/boto/botocore/pull/448>`__)
 
 0.0.7 - 2015-02-05
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,14 +1,19 @@
 Changelog
 =========
 
-Unreleased
-----------
+0.0.12 - 2015-03-26
+-------------------
 
 * feature:Resources: Add the ability to load resource data from a
   ``has`` relationship. This saves a call to ``load`` when available,
   and otherwise fixes a problem where there was no way to get at
   certain resource data.
   (`issue 74 <https://github.com/boto/boto3/pull/72>`__,
+* feature:Botocore: Update to Botocore 0.99.0
+
+  * Update service models for amazon Elastic Transcoder, AWS IAM
+    and AWS OpsWorks to the latest versions.
+  * Add deprecation warnings for old interface.
 
 0.0.11 - 2015-03-24
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-Unreleased
-----------
+0.0.10 - 2015-03-05
+-------------------
 
 * bugfix:Documentation: Name collisions are now handled at the resource
   model layer instead of the factory, meaning that the documentation

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,25 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* feature:Botocore: Update to Botocore 0.92.0
+
+  * Add support for the latest Amazon EC2 Container Service API.
+  * Allow calling AWS STS ``assume_role_with_saml`` without credentials.
+  * Update to latest Amazon CloudFront API
+  * Add support for AWS STS regionalized calls by passing both a region
+    name and an endpoint URL.
+    (`botocore issue 464 <https://github.com/boto/botocore/pull/464>`__)
+  * Add support for Amazon Simple Systems Management Service (SSM)
+  * Fix Amazon S3 auth errors when uploading large files
+    to the ``eu-central-1`` and ``cn-north-1`` regions.
+    (`botocore issue 462 <https://github.com/boto/botocore/pull/462>`__)
+  * Add support for AWS IAM managed policies
+  * Add support for Amazon ElastiCache tagging
+  * Add support for Amazon Route53 Domains tagging of domains
+
 0.0.8 - 2015-02-10
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* bugfix:Resources: Fix Amazon S3 resource identifier order.
+  (`issue 62 <https://github.com/boto/boto3/pull/62>`__)
+* bugfix:Resources: Fix collection resource hydration path.
+  (`issue 61 <https://github.com/boto/boto3/pull/61>`__)
+* bugfix:Resources: Re-enable service-level access to all resources,
+  allowing e.g. ``obj = s3.Object('bucket', 'key')``.
+  (`issue 60 <https://github.com/boto/boto3/pull/60>`__)
+
 0.0.7 - 2015-02-05
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,9 @@ Unreleased
   model layer instead of the factory, meaning that the documentation
   now uses the correct names.
   (`issue 67 <https://github.com/boto/boto3/pull/67>`__)
+* feature:Session: Add a ``region_name`` option when creating a session.
+  (`issue 69 <https://github.com/boto/boto3/pull/69>`__,
+  `issue 21 <https://github.com/boto/boto3/issues/21>`__)
 
 0.0.9 - 2015-02-19
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-Unreleased
-----------
+0.0.9 - 2015-02-19
+------------------
 
 * feature:Botocore: Update to Botocore 0.92.0
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,22 @@ Unreleased
   (`issue 72 <https://github.com/boto/boto3/pull/72>`__,
 * feature:Resources: Add resources for AWS IAM managed policies.
   (`issue 71 <https://github.com/boto/boto3/pull/71>`__)
+* feature:Botocore: Update to Botocore 0.97.0
+
+  * Add new Amazon EC2 waiters.
+  * Add support for Amazon S3 cross region replication.
+  * Fix an issue where empty config values could not be specified for
+    Amazon S3's bucket notifications.
+    (`botocore issue 495 <https://github.com/boto/botocore/pull/495>`__)
+  * Update Amazon CloudWatch Logs to the latest API.
+  * Update Amazon Elastic Transcoder to the latest API.
+  * Update AWS CloudTrail to the latest API.
+  * Fix bug where explicitly passed ``profile_name`` will now override
+    any access and secret keys set in environment variables.
+    (`botocore issue 486 <https://github.com/boto/botocore/pull/486>`__)
+  * Add ``endpoint_url`` to ``client.meta``.
+  * Better error messages for invalid regions.
+  * Fix creating clients with unicode service name.
 
 0.0.10 - 2015-03-05
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-Unreleased
-----------
+0.0.11 - 2015-03-24
+-------------------
 
 * feature:Resources: Add Amazon EC2 support for ClassicLink actions
   and add a delete action to EC2 ``Volume`` resources.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 Unreleased
 ----------
 
+* feature:Resources: Add Amazon EC2 support for ClassicLink actions
+  and add a delete action to EC2 ``Volume`` resources.
 * feature:Resources: Add a ``load`` operation and ``user`` reference
   to AWS IAM's ``CurrentUser`` resource.
   (`issue 72 <https://github.com/boto/boto3/pull/72>`__,

--- a/README.rst
+++ b/README.rst
@@ -10,9 +10,11 @@ of services like Amazon S3 and Amazon EC2. You can find the latest, most
 up to date, documentation at `Read the Docs`_, including a list of
 services that are supported.
 
-**WARNING**: Boto 3 is in *developer preview* and **should not** be used in
-production yet! Please try it out and give feedback by opening issues or
-pull requests on this repository. Thanks!
+Boto 3 is in **developer preview**.  This means that until a 1.0 release
+occurs, some of the interfaces may change based on your feedback.
+Once a 1.0 release happens, we guarantee backwards compatibility
+for all future 1.x.x releases.  Try out boto3 and give us
+`feedback <https://github.com/boto/boto3/issues>`__ today!
 
 .. _boto: https://docs.pythonboto.org/
 .. _`Read the Docs`: https://boto3.readthedocs.org/en/latest/

--- a/boto3/__init__.py
+++ b/boto3/__init__.py
@@ -17,7 +17,7 @@ from boto3.session import Session
 
 
 __author__ = 'Amazon Web Services'
-__version__ = '0.0.11'
+__version__ = '0.0.12'
 
 
 # The default Boto3 session; autoloaded when needed.

--- a/boto3/__init__.py
+++ b/boto3/__init__.py
@@ -17,7 +17,7 @@ from boto3.session import Session
 
 
 __author__ = 'Amazon Web Services'
-__version__ = '0.0.9'
+__version__ = '0.0.10'
 
 
 # The default Boto3 session; autoloaded when needed.

--- a/boto3/__init__.py
+++ b/boto3/__init__.py
@@ -17,7 +17,7 @@ from boto3.session import Session
 
 
 __author__ = 'Amazon Web Services'
-__version__ = '0.0.10'
+__version__ = '0.0.11'
 
 
 # The default Boto3 session; autoloaded when needed.

--- a/boto3/__init__.py
+++ b/boto3/__init__.py
@@ -17,7 +17,7 @@ from boto3.session import Session
 
 
 __author__ = 'Amazon Web Services'
-__version__ = '0.0.8'
+__version__ = '0.0.9'
 
 
 # The default Boto3 session; autoloaded when needed.

--- a/boto3/__init__.py
+++ b/boto3/__init__.py
@@ -17,7 +17,7 @@ from boto3.session import Session
 
 
 __author__ = 'Amazon Web Services'
-__version__ = '0.0.7'
+__version__ = '0.0.8'
 
 
 # The default Boto3 session; autoloaded when needed.

--- a/boto3/data/resources/ec2-2014-10-01.resources.json
+++ b/boto3/data/resources/ec2-2014-10-01.resources.json
@@ -601,6 +601,14 @@
             ]
           }
         },
+        "AttachClassicLinkVpc": {
+          "request": {
+            "operation": "AttachClassicLinkVpc",
+            "params": [
+              { "target": "InstanceId", "source": "identifier", "name": "Id" }
+            ]
+          }
+        },
         "ConsoleOutput": {
           "request": {
             "operation": "GetConsoleOutput",
@@ -642,6 +650,14 @@
         "DescribeAttribute": {
           "request": {
             "operation": "DescribeInstanceAttribute",
+            "params": [
+              { "target": "InstanceId", "source": "identifier", "name": "Id" }
+            ]
+          }
+        },
+        "DetachClassicLinkVpc": {
+          "request": {
+            "operation": "DetachClassicLinkVpc",
             "params": [
               { "target": "InstanceId", "source": "identifier", "name": "Id" }
             ]
@@ -1769,6 +1785,14 @@
             ]
           }
         },
+        "Delete": {
+          "request": {
+            "operation": "DeleteVolume",
+            "params": [
+              { "target": "VolumeId", "source": "identifier", "name": "Id" }
+            ]
+          }
+        },
         "DescribeAttribute": {
           "request": {
             "operation": "DescribeVolumeAttribute",
@@ -1850,6 +1874,14 @@
         "AssociateDhcpOptions": {
           "request": {
             "operation": "AssociateDhcpOptions",
+            "params": [
+              { "target": "VpcId", "source": "identifier", "name": "Id" }
+            ]
+          }
+        },
+        "AttachClassicLinkInstance": {
+          "request": {
+            "operation": "AttachClassicLinkVpc",
             "params": [
               { "target": "VpcId", "source": "identifier", "name": "Id" }
             ]
@@ -1954,9 +1986,33 @@
             ]
           }
         },
+        "DetachClassicLinkInstance": {
+          "request": {
+            "operation": "DetachClassicLinkVpc",
+            "params": [
+              { "target": "VpcId", "source": "identifier", "name": "Id" }
+            ]
+          }
+        },
         "DetachInternetGateway": {
           "request": {
             "operation": "DetachInternetGateway",
+            "params": [
+              { "target": "VpcId", "source": "identifier", "name": "Id" }
+            ]
+          }
+        },
+        "DisableClassicLink": {
+          "request": {
+            "operation": "DisableVpcClassicLink",
+            "params": [
+              { "target": "VpcId", "source": "identifier", "name": "Id" }
+            ]
+          }
+        },
+        "EnableClassicLink": {
+          "request": {
+            "operation": "EnableVpcClassicLink",
             "params": [
               { "target": "VpcId", "source": "identifier", "name": "Id" }
             ]

--- a/boto3/data/resources/iam-2010-05-08.resources.json
+++ b/boto3/data/resources/iam-2010-05-08.resources.json
@@ -420,6 +420,23 @@
       }
     },
     "CurrentUser": {
+      "shape": "User",
+      "load": {
+        "request": {
+          "operation": "GetUser"
+        },
+        "path": "User"
+      },
+      "has": {
+        "User": {
+          "resource": {
+            "type": "User",
+            "identifiers": [
+              { "target": "Name", "source": "data", "path": "UserName" }
+            ]
+          }
+        }
+      },
       "hasMany": {
         "AccessKeys": {
           "request": { "operation": "ListAccessKeys" },

--- a/boto3/data/resources/iam-2010-05-08.resources.json
+++ b/boto3/data/resources/iam-2010-05-08.resources.json
@@ -72,6 +72,15 @@
           "path": "Certificate"
         }
       },
+      "CreatePolicy": {
+        "request": { "operation": "CreatePolicy" },
+        "resource": {
+          "type": "Policy",
+          "identifiers": [
+            { "target": "Arn", "source": "response", "path": "Policy.Arn" }
+          ]
+        }
+      },
       "CreateUser": {
         "request": { "operation": "CreateUser" },
         "resource": {
@@ -128,6 +137,14 @@
           ]
         }
       },
+      "Policy": {
+        "resource": {
+          "type": "Policy",
+          "identifiers": [
+            { "target": "PolicyArn", "source": "input" }
+          ]
+        }
+      },
       "Role": {
         "resource": {
           "type": "Role",
@@ -178,6 +195,16 @@
             { "target": "Name", "source": "response", "path": "Groups[].GroupName" }
           ],
           "path": "Groups[]"
+        }
+      },
+      "Policies": {
+        "request": { "operation": "ListPolicies" },
+        "resource": {
+          "type": "Policy",
+          "identifiers": [
+            { "target": "Arn", "source": "response", "path": "Policies[].Arn" }
+          ],
+          "path": "Policies[]"
         }
       },
       "InstanceProfiles": {
@@ -455,6 +482,14 @@
             ]
           }
         },
+        "AttachPolicy": {
+          "request": {
+            "operation": "AttachGroupPolicy",
+            "params": [
+              { "target": "GroupName", "source": "identifier", "name": "Name" }
+            ]
+          }
+        },
         "Create": {
           "request": {
             "operation": "CreateGroup",
@@ -488,6 +523,14 @@
         "Delete": {
           "request": {
             "operation": "DeleteGroup",
+            "params": [
+              { "target": "GroupName", "source": "identifier", "name": "Name" }
+            ]
+          }
+        },
+        "DetachPolicy": {
+          "request": {
+            "operation": "DetachGroupPolicy",
             "params": [
               { "target": "GroupName", "source": "identifier", "name": "Name" }
             ]
@@ -528,6 +571,20 @@
         }
       },
       "hasMany": {
+        "AttachedPolicies": {
+          "request": {
+            "operation": "ListAttachedGroupPolicies",
+            "params": [
+              { "target": "GroupName", "source": "identifier", "name": "Name" }
+            ]
+          },
+          "resource": {
+            "type": "Policy",
+            "identifiers": [
+              { "target": "Arn", "source": "response", "path": "AttachedPolicies[].PolicyArn" }
+            ]
+          }
+        },
         "Policies": {
           "request": {
             "operation": "ListGroupPolicies",
@@ -781,6 +838,209 @@
         }
       }
     },
+    "Policy": {
+      "identifiers": [
+      { "name": "Arn",
+          "memberName": "PolicyArn" }
+      ],
+      "shape": "Policy",
+      "load": {
+         "request": {
+            "operation": "GetPolicy",
+            "params": [
+               { "target": "PolicyArn", "source": "identifier", "name": "Arn" }
+            ]
+         },
+         "path": "Policy"
+      },
+      "actions": {
+        "AttachGroup": {
+          "request": {
+            "operation": "AttachGroupPolicy",
+            "params": [
+              { "target": "PolicyArn", "source": "identifier", "name": "Arn" }
+            ]
+          }
+        },
+        "AttachRole": {
+          "request": {
+            "operation": "AttachRolePolicy",
+            "params": [
+              { "target": "PolicyArn", "source": "identifier", "name": "Arn" }
+            ]
+          }
+        },
+        "AttachUser": {
+          "request": {
+            "operation": "AttachUserPolicy",
+            "params": [
+              { "target": "PolicyArn", "source": "identifier", "name": "Arn" }
+            ]
+          }
+        },
+        "CreateVersion": {
+          "request": {
+            "operation": "CreatePolicyVersion",
+            "params": [
+              { "target": "PolicyArn", "source": "identifier", "name": "Arn" }
+            ]
+          },
+          "resource": {
+            "type": "PolicyVersion",
+            "identifiers": [
+              { "target": "Arn", "source": "identifier", "name": "Arn" },
+              { "target": "VersionId", "source": "response", "path": "PolicyVersion.VersionId" }
+            ]
+          }
+        },
+        "Delete": {
+          "request": {
+            "operation": "DeletePolicy",
+            "params": [
+              { "target": "PolicyArn", "source": "identifier", "name": "Arn" }
+            ]
+          }
+        },
+        "DetachGroup": {
+          "request": {
+            "operation": "DetachGroupPolicy",
+            "params": [
+              { "target": "PolicyArn", "source": "identifier", "name": "Arn" }
+            ]
+          }
+        },
+        "DetachRole": {
+          "request": {
+            "operation": "DetachRolePolicy",
+            "params": [
+              { "target": "PolicyArn", "source": "identifier", "name": "Arn" }
+            ]
+          }
+        },
+        "DetachUser": {
+          "request": {
+            "operation": "DetachUserPolicy",
+            "params": [
+              { "target": "PolicyArn", "source": "identifier", "name": "Arn" }
+            ]
+          }
+        }
+      },
+      "has": {
+        "DefaultVersion": {
+          "resource": {
+            "type": "PolicyVersion",
+            "identifiers": [
+              { "target": "Arn", "source": "identifier", "name": "Arn" },
+              { "target": "VersionId", "source": "data", "name": "DefaultVersionId", "path": "DefaultVersionId" }
+            ]
+          }
+        }
+      },
+      "hasMany": {
+        "Versions": {
+          "request": {
+            "operation": "ListPolicyVersions",
+            "params": [
+              { "target": "PolicyArn", "source": "identifier", "name": "Arn" }
+            ]
+          },
+          "resource": {
+            "type": "PolicyVersion",
+            "identifiers": [
+              { "target": "Arn", "source": "identifier", "name": "Arn" },
+              { "target": "VersionId", "source": "response", "path": "Versions[].VersionId" }
+            ],
+            "path": "Versions[]"
+          }
+        },
+        "AttachedGroups": {
+          "request": {
+            "operation": "ListEntitiesForPolicy",
+            "params": [
+              { "target": "PolicyArn", "source": "identifier", "name": "Arn" },
+              { "target": "EntityFilter", "source": "string", "value": "Group" }
+            ]
+          },
+          "resource": {
+            "type": "Group",
+            "identifiers": [
+              { "target": "Name", "source": "response", "path": "PolicyGroups[].GroupName" }
+            ]
+          },
+          "path": "PolicyGroups[]"
+        },
+        "AttachedRoles": {
+          "request": {
+            "operation": "ListEntitiesForPolicy",
+            "params": [
+              { "target": "PolicyArn", "source": "identifier", "name": "Arn" },
+              { "target": "EntityFilter", "source": "string", "value": "Role" }
+            ]
+          },
+          "resource": {
+            "type": "Role",
+            "identifiers": [
+              { "target": "Name", "source": "response", "path": "PolicyRoles[].RoleName" }
+            ]
+          },
+          "path": "PolicyRoles[]"
+        },
+        "AttachedUsers": {
+          "request": {
+            "operation": "ListEntitiesForPolicy",
+            "params": [
+              { "target": "PolicyArn", "source": "identifier", "name": "Arn" },
+              { "target": "EntityFilter", "source": "string", "value": "User" }
+            ]
+          },
+          "resource": {
+            "type": "User",
+            "identifiers": [
+              { "target": "Name", "source": "response", "path": "PolicyUsers[].UserName" }
+            ]
+          },
+          "path": "PolicyUsers[]"
+        }
+      }
+    },
+    "PolicyVersion": {
+      "identifiers": [
+        { "name": "Arn" },
+        { "name": "VersionId" }
+      ],
+      "shape": "PolicyVersion",
+      "load": {
+        "request": {
+          "operation": "GetPolicyVersion",
+          "params": [
+            { "target": "PolicyArn", "source": "identifier", "name": "Arn" },
+            { "target": "VersionId", "source": "identifier", "name": "VersionId" }
+          ]
+        },
+        "path": "PolicyVersion"
+      },
+      "actions": {
+        "Delete": {
+          "request": {
+            "operation": "DeletePolicyVersion",
+            "params": [
+              { "target": "PolicyArn", "source": "identifier", "name": "Arn" },
+              { "target": "VersionId", "source": "identifier", "name": "VersionId" }
+            ]
+          }
+        },
+        "SetAsDefault": {
+          "request": {
+            "operation": "SetDefaultPolicyVersion",
+            "params": [
+              { "target": "PolicyArn", "source": "identifier", "name": "Arn" },
+              { "target": "VersionId", "source": "identifier", "name": "VersionId" }
+            ]
+          }
+        }
+      }
+    },
     "Role": {
       "identifiers": [
         {
@@ -799,9 +1059,25 @@
         "path": "Role"
       },
       "actions": {
+        "AttachPolicy": {
+          "request": {
+            "operation": "AttachRolePolicy",
+            "params": [
+              { "target": "RoleName", "source": "identifier", "name": "Name" }
+            ]
+          }
+        },
         "Delete": {
           "request": {
             "operation": "DeleteRole",
+            "params": [
+              { "target": "RoleName", "source": "identifier", "name": "Name" }
+            ]
+          }
+        },
+        "DetachPolicy": {
+          "request": {
+            "operation": "DetachRolePolicy",
             "params": [
               { "target": "RoleName", "source": "identifier", "name": "Name" }
             ]
@@ -828,6 +1104,20 @@
         }
       },
       "hasMany": {
+        "AttachedPolicies": {
+          "request": {
+            "operation": "ListAttachedRolePolicies",
+            "params": [
+              { "target": "RoleName", "source": "identifier", "name": "Name" }
+            ]
+          },
+          "resource": {
+            "type": "Policy",
+            "identifiers": [
+              { "target": "Arn", "source": "response", "path": "AttachedPolicies[].PolicyArn" }
+            ]
+          }
+        },
         "InstanceProfiles": {
           "request": {
             "operation": "ListInstanceProfilesForRole",
@@ -1065,6 +1355,14 @@
             ]
           }
         },
+        "AttachPolicy": {
+          "request": {
+            "operation": "AttachUserPolicy",
+            "params": [
+              { "target": "UserName", "source": "identifier", "name": "Name" }
+            ]
+          }
+        },
         "Create": {
           "request": {
             "operation": "CreateUser",
@@ -1130,6 +1428,14 @@
         "Delete": {
           "request": {
             "operation": "DeleteUser",
+            "params": [
+              { "target": "UserName", "source": "identifier", "name": "Name" }
+            ]
+          }
+        },
+        "DetachPolicy": {
+          "request": {
+            "operation": "DetachUserPolicy",
             "params": [
               { "target": "UserName", "source": "identifier", "name": "Name" }
             ]
@@ -1220,6 +1526,20 @@
         }
       },
       "hasMany": {
+        "AttachedPolicies": {
+          "request": {
+            "operation": "ListAttachedUserPolicies",
+            "params": [
+              { "target": "UserName", "source": "identifier", "name": "Name" }
+            ]
+          },
+          "resource": {
+            "type": "Policy",
+            "identifiers": [
+              { "target": "Arn", "source": "response", "path": "AttachedPolicies[].PolicyArn" }
+            ]
+          }
+        },
         "AccessKeys": {
           "request": {
             "operation": "ListAccessKeys",

--- a/boto3/data/resources/iam-2010-05-08.resources.json
+++ b/boto3/data/resources/iam-2010-05-08.resources.json
@@ -949,7 +949,7 @@
             "type": "PolicyVersion",
             "identifiers": [
               { "target": "Arn", "source": "identifier", "name": "Arn" },
-              { "target": "VersionId", "source": "data", "name": "DefaultVersionId", "path": "DefaultVersionId" }
+              { "target": "VersionId", "source": "data", "path": "DefaultVersionId" }
             ]
           }
         }

--- a/boto3/exceptions.py
+++ b/boto3/exceptions.py
@@ -17,3 +17,9 @@ class ResourceLoadException(Exception):
 
 class NoVersionFound(Exception):
     pass
+
+
+class RetriesExceededError(Exception):
+    def __init__(self, last_exception, msg='Max Retries Exceeded'):
+        super(RetriesExceededError, self).__init__(msg)
+        self.last_exception = last_exception

--- a/boto3/resources/factory.py
+++ b/boto3/resources/factory.py
@@ -246,16 +246,27 @@ class ResourceFactory(object):
         # References are essentially an action with no request
         # or response, so we can re-use the response handlers to
         # build up resources from identifiers and data members.
-        handler = ResourceHandler('', factory_self, resource_defs,
-                                  service_model, reference.resource)
+        handler = ResourceHandler(reference.resource.path, factory_self,
+                                  resource_defs, service_model,
+                                  reference.resource)
+
+        # Are there any identifiers that need access to data members?
+        # This is important when building the resource below since
+        # it requires the data to be loaded.
+        needs_data = any(i.source == 'data' for i in
+                         reference.resource.identifiers)
 
         def get_reference(self):
             # We need to lazy-evaluate the reference to handle circular
             # references between resources. We do this by loading the class
             # when first accessed.
-            # First, though, we need to see if we have the required
-            # identifiers to instantiate the resource reference.
-            return handler(self, {}, {})
+            # This is using a *response handler* so we need to make sure
+            # our data is loaded (if possible) and pass that data into
+            # the handler as if it were a response. This allows references
+            # to have their data loaded properly.
+            if needs_data and self.meta.data is None and hasattr(self, 'load'):
+                self.load()
+            return handler(self, {}, self.meta.data)
 
         get_reference.__name__ = str(reference.name)
         get_reference.__doc__ = 'TODO'

--- a/boto3/resources/model.py
+++ b/boto3/resources/model.py
@@ -25,6 +25,8 @@ classes as well as by the documentation generator.
 
 import logging
 
+from botocore import xform_name
+
 
 logger = logging.getLogger(__name__)
 
@@ -152,14 +154,13 @@ class Waiter(DefinitionWithParams):
     :type definition: dict
     :param definition: The JSON definition
     """
+    PREFIX = 'WaitUntil'
+
     def __init__(self, name, definition):
         super(Waiter, self).__init__(definition)
 
         #: (``string``) The name of this waiter
         self.name = name
-
-        #: (``string``) The name of the waiter in the resource
-        self.resource_waiter_name = 'WaitUntil' + name
 
         #: (``string``) The name of the underlying event waiter
         self.waiter_name = definition.get('waiterName')
@@ -250,11 +251,171 @@ class ResourceModel(object):
     def __init__(self, name, definition, resource_defs):
         self._definition = definition
         self._resource_defs = resource_defs
+        self._renamed = {}
 
         #: (``string``) The name of this resource
         self.name = name
         #: (``string``) The service shape name for this resource or ``None``
         self.shape = definition.get('shape')
+
+    def load_rename_map(self, shape=None):
+        """
+        Load a name translation map given a shape. This will set
+        up renamed values for any collisions, e.g. if the shape,
+        an action, and a subresource all are all named ``foo``
+        then the resource will have an action ``foo``, a subresource
+        named ``Foo`` and a property named ``foo_attribute``.
+        This is the order of precedence, from most important to
+        least important:
+
+        * Load action (resource.load)
+        * Identifiers
+        * Actions
+        * Subresources
+        * References
+        * Collections
+        * Waiters
+        * Attributes (shape members)
+
+        Batch actions are only exposed on collections, so do not
+        get modified here. Subresources use upper camel casing, so
+        are unlikely to collide with anything but other subresources.
+
+        Creates a structure like this::
+
+            renames = {
+                ('action', 'id'): 'id_action',
+                ('collection', 'id'): 'id_collection',
+                ('attribute', 'id'): 'id_attribute'
+            }
+
+            # Get the final name for an action named 'id'
+            name = renames.get(('action', 'id'), 'id')
+
+        :type shape: botocore.model.Shape
+        :param shape: The underlying shape for this resource.
+        """
+        # Meta is a reserved name for resources
+        names = set(['meta'])
+        self._renamed = {}
+
+        if self._definition.get('load'):
+            names.add('load')
+
+        for item in self._definition.get('identifiers', []):
+            self._load_name_with_category(names, item['name'], 'identifier')
+
+        for name in self._definition.get('actions', {}):
+            self._load_name_with_category(names, name, 'action')
+
+        for name, ref in self._get_has_definition().items():
+            # Subresources require no data members, just typically
+            # identifiers and user input.
+            data_required = False
+            for identifier in ref['resource']['identifiers']:
+                if identifier['source'] == 'data':
+                    data_required = True
+                    break
+
+            if not data_required:
+                self._load_name_with_category(names, name, 'subresource',
+                                              snake_case=False)
+            else:
+                self._load_name_with_category(names, name, 'reference')
+
+        for name in self._definition.get('hasMany', {}):
+            self._load_name_with_category(names, name, 'collection')
+
+        for name in self._definition.get('waiters', {}):
+            self._load_name_with_category(names, Waiter.PREFIX + name,
+                                          'waiter')
+
+        if shape is not None:
+            for name in shape.members.keys():
+                self._load_name_with_category(names, name, 'attribute')
+
+    def _load_name_with_category(self, names, name, category,
+                                 snake_case=True):
+        """
+        Load a name with a given category, possibly renaming it
+        if that name is already in use. The name will be stored
+        in ``names`` and possibly be set up in ``self._renamed``.
+
+        :type names: set
+        :param names: Existing names (Python attributes, properties, or
+                      methods) on the resource.
+        :type name: string
+        :param name: The original name of the value.
+        :type category: string
+        :param category: The value type, such as 'identifier' or 'action'
+        :type snake_case: bool
+        :param snake_case: True (default) if the name should be snake cased.
+        """
+        if snake_case:
+            name = xform_name(name)
+
+        if name in names:
+            logger.debug('Renaming %s %s %s' % (self.name, category, name))
+            self._renamed[(category, name)] = name + '_' + category
+            name += '_' + category
+
+            if name in names:
+                # This isn't good, let's raise instead of trying to keep
+                # renaming this value.
+                raise ValueError('Problem renaming {0} {1} to {2}!'.format(
+                    self.name, category, name))
+
+        names.add(name)
+
+    def _get_name(self, category, name, snake_case=True):
+        """
+        Get a possibly renamed value given a category and name. This
+        uses the rename map set up in ``load_rename_map``, so that
+        method must be called once first.
+
+        :type category: string
+        :param category: The value type, such as 'identifier' or 'action'
+        :type name: string
+        :param name: The original name of the value
+        :type snake_case: bool
+        :param snake_case: True (default) if the name should be snake cased.
+        :rtype: string
+        :return: Either the renamed value if it is set, otherwise the
+                 original name.
+        """
+        if snake_case:
+            name = xform_name(name)
+
+        return self._renamed.get((category, name), name)
+
+    def get_attributes(self, shape):
+        """
+        Get a dictionary of attribute names to original name and shape
+        models that represent the attributes of this resource. Looks
+        like the following:
+
+            {
+                'some_name': ('SomeName', <Shape...>)
+            }
+
+        :type shape: botocore.model.Shape
+        :param shape: The underlying shape for this resource.
+        :rtype: dict
+        :return: Mapping of resource attributes.
+        """
+        attributes = {}
+        identifier_names = [i.name for i in self.identifiers]
+
+        for name, member in shape.members.items():
+            snake_cased = xform_name(name)
+            if snake_cased in identifier_names:
+                # Skip identifiers, these are set through other means
+                continue
+            snake_cased = self._get_name('attribute', snake_cased,
+                                         snake_case=False)
+            attributes[snake_cased] = (name, member)
+
+        return attributes
 
     @property
     def identifiers(self):
@@ -266,7 +427,8 @@ class ResourceModel(object):
         identifiers = []
 
         for item in self._definition.get('identifiers', []):
-            identifiers.append(Identifier(item['name']))
+            name = self._get_name('identifier', item['name'])
+            identifiers.append(Identifier(name))
 
         return identifiers
 
@@ -294,6 +456,7 @@ class ResourceModel(object):
         actions = []
 
         for name, item in self._definition.get('actions', {}).items():
+            name = self._get_name('action', name)
             actions.append(Action(name, item, self._resource_defs))
 
         return actions
@@ -308,6 +471,7 @@ class ResourceModel(object):
         actions = []
 
         for name, item in self._definition.get('batchActions', {}).items():
+            name = self._get_name('batch_action', name)
             actions.append(Action(name, item, self._resource_defs))
 
         return actions
@@ -387,6 +551,10 @@ class ResourceModel(object):
         resources = []
 
         for name, definition in self._get_has_definition().items():
+            if subresources:
+                name = self._get_name('subresource', name, snake_case=False)
+            else:
+                name = self._get_name('reference', name)
             action = Action(name, definition, self._resource_defs)
 
             data_required = False
@@ -430,6 +598,7 @@ class ResourceModel(object):
         collections = []
 
         for name, item in self._definition.get('hasMany', {}).items():
+            name = self._get_name('collection', name)
             collections.append(Collection(name, item, self._resource_defs))
 
         return collections
@@ -444,6 +613,7 @@ class ResourceModel(object):
         waiters = []
 
         for name, item in self._definition.get('waiters', {}).items():
+            name = self._get_name('waiter', Waiter.PREFIX + name)
             waiters.append(Waiter(name, item))
 
         return waiters

--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -1,0 +1,447 @@
+"""Abstractions over S3's upload/download operations.
+
+This module provides high level abstractions for efficient
+uploads/downloads.  It handles several things for the user:
+
+* Automatically switching to multipart transfers when
+  a file is over a specific size threshold
+* Uploading/downloading a file in parallel
+* Throttling based on max bandwidth
+* Progress callbacks to monitor transfers
+* Retries.  While botocore handles retries for streaming uploads,
+  it is not possible for it to handle retries for streaming
+  downloads.  This module handles retries for both cases so
+  you don't need to implement any retry logic yourself.
+
+This module has a reasonable set of defaults.  It also allows you
+to configure many aspects of the transfer process including:
+
+* Multipart threshold size
+* Max parallel downloads
+* Max bandwidth
+* Socket timeouts
+* Retry amounts
+
+There is no support for s3->s3 multipart copies at this
+time.
+
+
+Usage
+=====
+
+The simplest way to use this module is:
+
+.. code-block:: python
+
+    client = boto3.client('s3', 'us-west-2')
+    transfer = S3Transfer(client)
+    # Upload /tmp/myfile to s3://bucket/key
+    transfer.upload_file('/tmp/myfile', 'bucket', 'key')
+
+    # Download s3://bucket/key to /tmp/myfile
+    transfer.download_file('bucket', 'key', '/tmp/myfile')
+
+The ``upload_file`` and ``download_file`` methods also accept
+``**kwargs``, which will be forwarded through to the corresponding
+client operation.  Here are a few examples using ``upload_file``::
+
+    # Making the object public
+    transfer.upload_file('/tmp/myfile', 'bucket', 'key', ACL='public-read')
+
+    # Setting metadata
+    transfer.upload_file('/tmp/myfile', 'bucket', 'key',
+                         Metadata={'a': 'b', 'c': 'd'})
+
+    # Setting content type
+    transfer.upload_file('/tmp/myfile.json', 'bucket', 'key',
+                         ContentType="application/json")
+
+
+
+The ``S3Transfer`` clas also supports progress callbacks so you can
+provide transfer progress to users.  Both the ``upload_file`` and
+``download_file`` methods take an optional ``callback`` parameter.
+Here's an example of how to print a simple progress percentage
+to the user:
+
+.. code-block:: python
+
+    class ProgressPercentage(object):
+        def __init__(self, filename):
+            self._filename = filename
+            self._size = float(os.path.getsize(filename))
+            self._seen_so_far = 0
+            self._lock = threading.Lock()
+
+        def __call__(self, filename, bytes_amount):
+            # To simplify we'll assume this is hooked up
+            # to a single filename.
+            with self._lock:
+                self._seen_so_far += bytes_amount
+                percentage = (self._seen_so_far / self._size) * 100
+                sys.stdout.write(
+                    "\r%s  %s / %s  (%.2f%%)" % (filename, self._seen_so_far,
+                                                 self._size, percentage))
+                sys.stdout.flush()
+
+
+    transfer = S3Transfer(boto3.client('s3', 'us-west-2'))
+    # Upload /tmp/myfile to s3://bucket/key and print upload progress.
+    transfer.upload_file('/tmp/myfile', 'bucket', 'key',
+                         callback=ProgressPercentage('/tmp/myfile'))
+
+
+
+You can also provide an TransferConfig object to the S3Transfer
+object that gives you more fine grained control over the
+transfer.  For example:
+
+.. code-block:: python
+
+    client = boto3.client('s3', 'us-west-2')
+    config = TransferConfig(
+        multipart_threshold=8 * 1024 * 1024,
+        max_concurrency=10,
+        max_retries=10,
+        socket_timeout=120,
+    )
+    transfer = S3Transfer(client, config)
+    transfer.upload_file('/tmp/foo', 'bucket', 'key')
+
+
+"""
+import os
+import math
+import threading
+import functools
+import logging
+import socket
+from concurrent import futures
+
+from botocore.vendored.requests.packages.urllib3.exceptions import \
+    ReadTimeoutError
+from botocore.exceptions import IncompleteReadError
+
+from boto3.exceptions import RetriesExceededError
+
+
+logger = logging.getLogger(__name__)
+MB = 1024 * 1024
+
+
+class ReadFileChunk(object):
+    def __init__(self, fileobj, start_byte, chunk_size, full_file_size,
+                 callback=None):
+        """
+
+        Given a file object shown below:
+
+            |___________________________________________________|
+            0          |                 |                 full_file_size
+                       |----chunk_size---|
+                 start_byte
+
+        :type fileobj: file
+        :param fileobj: File like object
+
+        :type start_byte: int
+        :param start_byte: The first byte from which to start reading.
+
+        :type chunk_size: int
+        :param chunk_size: The max chunk size to read.  Trying to read
+            pass the end of the chunk size will behave like you've
+            reached the end of the file.
+
+        :type full_file_size: int
+        :param full_file_size: The entire content length associated
+            with ``fileobj``.
+
+        :type callback: function(amount_read)
+        :param callback: Called whenever data is read from this object.
+
+        """
+        self._fileobj = fileobj
+        self._start_byte = start_byte
+        self._size = self._calculate_file_size(
+            self._fileobj, requested_size=chunk_size,
+            start_byte=start_byte, actual_file_size=full_file_size)
+        self._fileobj.seek(self._start_byte)
+        self._amount_read = 0
+        self._callback = callback
+
+    @classmethod
+    def from_filename(cls, filename, start_byte, chunk_size, callback=None):
+        """Convenience factory function to create from a filename."""
+        f = open(filename, 'rb')
+        file_size = os.fstat(f.fileno()).st_size
+        return cls(f, start_byte, chunk_size, file_size, callback)
+
+    def _calculate_file_size(self, fileobj, requested_size, start_byte,
+                             actual_file_size):
+        max_chunk_size = actual_file_size - start_byte
+        return min(max_chunk_size, requested_size)
+
+    def read(self, amount=None):
+        if amount is None:
+            amount_to_read = self._size - self._amount_read
+        else:
+            amount_to_read = min(self._size - self._amount_read, amount)
+        data = self._fileobj.read(amount_to_read)
+        self._amount_read += len(data)
+        if self._callback is not None:
+            self._callback(len(data))
+        return data
+
+    def seek(self, where):
+        self._fileobj.seek(self._start_byte + where)
+        self._amount_read = where
+
+    def close(self):
+        self._fileobj.close()
+
+    def tell(self):
+        return self._amount_read
+
+    def __len__(self):
+        # __len__ is defined because requests will try to determine the length
+        # of the stream to set a content length.  In the normal case
+        # of the file it will just stat the file, but we need to change that
+        # behavior.  By providing a __len__, requests will use that instead
+        # of stat'ing the file.
+        return self._size
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.close()
+
+    def __iter__(self):
+        # This is a workaround for http://bugs.python.org/issue17575
+        # Basically httplib will try to iterate over the contents, even
+        # if its a file like object.  This wasn't noticed because we've
+        # already exhausted the stream so iterating over the file immediately
+        # steps, which is what we're simulating here.
+        return iter([])
+
+
+class StreamReaderProgress(object):
+    """Wrapper for a read only stream that adds progress callbacks."""
+    def __init__(self, stream, callback=None):
+        self._stream = stream
+        self._callback = callback
+
+    def read(self, *args, **kwargs):
+        value = self._stream.read(*args, **kwargs)
+        if self._callback is not None:
+            self._callback(len(value))
+        return value
+
+
+class ThreadSafeWriter(object):
+    def __init__(self, write_stream):
+        self._write_stream = write_stream
+        self._lock = threading.Lock()
+
+    def pwrite(self, data, offset):
+        with self._lock:
+            self._write_stream.seek(offset)
+            self._write_stream.write(data)
+
+    def close(self):
+        return self._write_stream.close()
+
+
+class OSUtils(object):
+    def get_file_size(self, filename):
+        return os.path.getsize(filename)
+
+    def open_file_chunk_reader(self, filename, start_byte, size, callback):
+        return ReadFileChunk.from_filename(filename, start_byte,
+                                           size, callback)
+
+    def open(self, filename, mode):
+        return open(filename, mode)
+
+    def wrap_stream_with_callback(self, stream, callback):
+        return StreamReaderProgress(stream, callback)
+
+    def wrap_thread_safe_writer(self, stream):
+        return ThreadSafeWriter(stream)
+
+
+class MultipartUploader(object):
+    def __init__(self, client, config, osutil,
+                 executor_cls=futures.ThreadPoolExecutor):
+        self._client = client
+        self._config = config
+        self._os = osutil
+        self._executor_cls = executor_cls
+
+    def upload_file(self, filename, bucket, key, callback, extra_args):
+        response = self._client.create_multipart_upload(Bucket=bucket,
+                                                        Key=key, **extra_args)
+        upload_id = response['UploadId']
+        parts = []
+        part_size = self._config.multipart_chunksize
+        num_parts = int(
+            math.ceil(self._os.get_file_size(filename) / float(part_size)))
+        max_workers = self._config.max_concurrency
+        with self._executor_cls(max_workers=max_workers) as executor:
+            upload_partial = functools.partial(
+                self._upload_one_part, filename, bucket, key, upload_id,
+                part_size, callback)
+            for part in executor.map(upload_partial, range(1, num_parts + 1)):
+                parts.append(part)
+        # Parts have to be ordered by part number.
+        parts.sort(key=lambda x: x['PartNumber'])
+        self._client.complete_multipart_upload(
+            Bucket=bucket, Key=key, UploadId=upload_id,
+            MultipartUpload={'Parts': parts})
+
+    def _upload_one_part(self, filename, bucket, key,
+                         upload_id, part_size, callback, part_number):
+        open_chunk_reader = self._os.open_file_chunk_reader
+        with open_chunk_reader(filename, part_size * (part_number - 1),
+                               part_size, callback) as body:
+            response = self._client.upload_part(
+                Bucket=bucket, Key=key,
+                UploadId=upload_id, PartNumber=part_number, Body=body)
+            etag = response['ETag']
+            return {'ETag': etag, 'PartNumber': part_number}
+
+
+class MultipartDownloader(object):
+    def __init__(self, client, config, osutil,
+                 executor_cls=futures.ThreadPoolExecutor):
+        self._client = client
+        self._config = config
+        self._os = osutil
+        self._executor_cls = executor_cls
+
+    def download_file(self, bucket, key, filename, object_size,
+                      callback=None):
+        part_size = self._config.multipart_chunksize
+        num_parts = int(math.ceil(object_size / float(part_size)))
+        max_workers = self._config.max_concurrency
+        with open(filename, 'wb') as f:
+            download_partial = functools.partial(
+                self._download_range, bucket, key, filename,
+                part_size, num_parts, callback, f)
+            with self._executor_cls(max_workers=max_workers) as executor:
+                list(executor.map(download_partial, range(num_parts)))
+
+    def _download_range(self, bucket, key, filename,
+                        part_size, num_parts, callback, fileobj, i):
+        start_range = i * part_size
+        if i == num_parts - 1:
+            end_range = ''
+        else:
+            end_range = start_range + part_size - 1
+        range_param = 'bytes=%s-%s' % (start_range, end_range)
+        response = self._client.get_object(
+            Bucket=bucket, Key=key, Range=range_param)
+        streaming_body = self._os.wrap_stream_with_callback(
+            response['Body'], callback)
+        buffer_size = 1024 * 16
+        current_index = start_range
+        safe_writer = self._os.wrap_thread_safe_writer(fileobj)
+        for chunk in iter(lambda: streaming_body.read(buffer_size), b''):
+            safe_writer.pwrite(chunk, current_index)
+            current_index += len(chunk)
+
+
+class TransferConfig(object):
+    def __init__(self,
+                 multipart_threshold=8 * MB,
+                 max_concurrency=1,
+                 multipart_chunksize=8 * MB,
+                 num_download_attempts=5):
+        self.multipart_threshold = multipart_threshold
+        self.max_concurrency = max_concurrency
+        self.multipart_chunksize = multipart_chunksize
+        self.num_download_attempts = num_download_attempts
+
+
+class S3Transfer(object):
+
+    def __init__(self, client, config=None, osutil=None):
+        self._client = client
+        if config is None:
+            config = TransferConfig()
+        self._config = config
+        if osutil is None:
+            osutil = OSUtils()
+        self._osutil = osutil
+
+    def upload_file(self, filename, bucket, key,
+                    callback=None, extra_args=None):
+        if extra_args is None:
+            extra_args = {}
+        if self._osutil.get_file_size(filename) >= \
+                self._config.multipart_threshold:
+            self._multipart_upload(filename, bucket, key, callback, extra_args)
+        else:
+            self._put_object(filename, bucket, key, callback, extra_args)
+
+    def _put_object(self, filename, bucket, key, callback, extra_args):
+        # We're using open_file_chunk_reader so we can take advantage of the
+        # progress callback functionality.
+        open_chunk_reader = self._osutil.open_file_chunk_reader
+        with open_chunk_reader(filename, 0,
+                               self._osutil.get_file_size(filename),
+                               callback=callback) as body:
+            self._client.put_object(Bucket=bucket, Key=key, Body=body,
+                                    **extra_args)
+
+    def download_file(self, bucket, key, filename, callback=None):
+        """Download an S3 object to a file.
+
+        This method will issue a ``head_object`` request to determine
+        the size of the S3 object.  This is used to determine if the
+        object is downloaded in parallel.
+
+        """
+        object_size = self._object_size(bucket, key)
+        if object_size >= self._config.multipart_threshold:
+            self._ranged_download(bucket, key, filename, object_size, callback)
+        else:
+            self._get_object(bucket, key, filename, callback)
+
+    def _ranged_download(self, bucket, key, filename, object_size, callback):
+        downloader = MultipartDownloader(self._client, self._config,
+                                         self._osutil)
+        downloader.download_file(bucket, key, filename, object_size,
+                                 callback)
+
+    def _get_object(self, bucket, key, filename, callback):
+        # precondition: num_download_attempts > 0
+        max_attempts = self._config.num_download_attempts
+        for i in range(max_attempts):
+            try:
+                return self._do_get_object(bucket, key, filename, callback)
+            except (socket.timeout, socket.error,
+                    ReadTimeoutError, IncompleteReadError) as e:
+                # TODO: we need a way to reset the callback if the
+                # download failed.
+                logger.debug("Retrying exception caught (%s), "
+                             "retrying request, (attempt %s / %s)", e, i,
+                             max_attempts, exc_info=True)
+                continue
+        raise RetriesExceededError(e)
+
+    def _do_get_object(self, bucket, key, filename, callback):
+        response = self._client.get_object(Bucket=bucket, Key=key)
+        streaming_body = self._osutil.wrap_stream_with_callback(
+            response['Body'], callback)
+        with self._osutil.open(filename, 'wb') as f:
+            for chunk in iter(lambda: streaming_body.read(8192), b''):
+                f.write(chunk)
+
+    def _object_size(self, bucket, key):
+        return self._client.head_object(
+            Bucket=bucket, Key=key)['ContentLength']
+
+    def _multipart_upload(self, filename, bucket, key, callback, extra_args):
+        uploader = MultipartUploader(self._client, self._config, self._osutil)
+        uploader.upload_file(filename, bucket, key, callback, extra_args)

--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -46,16 +46,16 @@ The ``upload_file`` and ``download_file`` methods also accept
 client operation.  Here are a few examples using ``upload_file``::
 
     # Making the object public
-    transfer.upload_file('/tmp/myfile', 'bucket', 'key', ACL='public-read')
+    transfer.upload_file('/tmp/myfile', 'bucket', 'key',
+                         extra_args={'ACL': 'public-read'})
 
     # Setting metadata
     transfer.upload_file('/tmp/myfile', 'bucket', 'key',
-                         Metadata={'a': 'b', 'c': 'd'})
+                         extra_args={'Metadata': {'a': 'b', 'c': 'd'}})
 
     # Setting content type
     transfer.upload_file('/tmp/myfile.json', 'bucket', 'key',
-                         ContentType="application/json")
-
+                         extra_args={'ContentType': "application/json"})
 
 
 The ``S3Transfer`` clas also supports progress callbacks so you can
@@ -102,8 +102,7 @@ transfer.  For example:
     config = TransferConfig(
         multipart_threshold=8 * 1024 * 1024,
         max_concurrency=10,
-        max_retries=10,
-        socket_timeout=120,
+        num_download_attempts=10,
     )
     transfer = S3Transfer(client, config)
     transfer.upload_file('/tmp/foo', 'bucket', 'key')

--- a/boto3/session.py
+++ b/boto3/session.py
@@ -37,10 +37,13 @@ class Session(object):
     :type botocore_session: botocore.session.Session
     :param botocore_session: Use this Botocore session instead of creating
                              a new default one.
+    :type profile_name: string
+    :param profile_name: The name of a profile to use. If not given, then
+                         the default profile is used.
     """
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
                  aws_session_token=None, region_name=None,
-                 botocore_session=None):
+                 botocore_session=None, profile_name=None):
         if botocore_session is not None:
             self._session = botocore_session
         else:
@@ -58,6 +61,9 @@ class Session(object):
             self._session.user_agent_name = 'Boto3'
             self._session.user_agent_version = boto3.__version__
 
+        if profile_name is not None:
+            self._session.profile = profile_name
+
         if aws_access_key_id or aws_secret_access_key or aws_session_token:
             self._session.set_credentials(aws_access_key_id,
                 aws_secret_access_key, aws_session_token)
@@ -71,6 +77,13 @@ class Session(object):
     def __repr__(self):
         return 'Session(region={0})'.format(
             repr(self._session.get_config_variable('region')))
+
+    @property
+    def profile_name(self):
+        """
+        The **read-only** profile name.
+        """
+        return self._session.profile or 'default'
 
     def _setup_loader(self):
         """

--- a/docs/source/guide/migration.rst
+++ b/docs/source/guide/migration.rst
@@ -1,0 +1,64 @@
+.. _guide_migration:
+
+Migrating from Boto 2.x
+=======================
+Current Boto users can begin using Boto 3 right away. The two modules can
+live side-by-side in the same project, which means that a piecemeal
+approach can be used. New features can be written in Boto 3, or existing
+code can be migrated over as needed, piece by piece.
+
+High Level Concepts
+-------------------
+Boto 2.x modules are typically split into two categories, those which include a high-level object-oriented interface and those which include only a low-level interface which matches the underlying Amazon Web Services API. Some modules are completely high-level (like Amazon S3 or EC2), some include high-level code on top of a low-level connection (like Amazon DynamoDB), and others are 100% low-level (like Amazon Elastic Transcoder).
+
+In Boto 3 this general low-level and high-level concept hasn't changed much, but there are two important points to understand.
+
+Data Driven
+~~~~~~~~~~~
+First, in Boto 3 classes are created at runtime from JSON data files that describe AWS APIs and organizational structures built atop of them. These data files are loaded at runtime and can be modified and updated without the need of installing an entirely new SDK release.
+
+A side effect of having all the services generated from JSON files is that there is now consistency between all AWS service modules. One important change is that *all* API call parameters must now be passed as **keyword arguments**, and these keyword arguments take the form defined by the upstream service. Though there are exceptions, this typically means ``UpperCamelCasing`` parameter names. You will see this in the service-specific migration guides linked to below.
+
+Resource Objects
+~~~~~~~~~~~~~~~~
+Second, while every service now uses the runtime-generated low-level client, some services additionally have high-level generated objects that we refer to as ``Resources``. The lower-level is comparable to Boto 2.x layer 1 connection objects in that they provide a one to one mapping of API operations and return low-level responses. The higher level is comparable to the high-level customizations from Boto 2.x: an S3 ``Key``, an EC2 ``Instance``, and a DynamoDB ``Table`` are all considered resources in Boto 3. Just like a Boto 2.x ``S3Connection``'s ``list_buckets`` will return ``Bucket`` objects, the Boto 3 resource interface provides actions and collections that return resources. Some services may also have hand-written customizations built on top of the runtime-generated high-level resources (such as utilities for working with S3 multipart uploads).
+
+::
+
+    import boto, boto3
+
+    # Low-level connections
+    conn = boto.connect_elastictranscoder()
+    client = boto3.client('elastictranscoder')
+
+    # High-level connections & resource objects
+    from boto.s3.bucket import Bucket
+    s3_conn = boto.connect_s3()
+    boto2_bucket = Bucket('mybucket')
+
+    s3 = boto3.resource('s3')
+    boto3_bucket = s3.Bucket('mybucket')
+
+Installation & Configuration
+----------------------------
+The :ref:`guide_quickstart` guide provides instructions for installing Boto 3. You can also follow the instructions there to set up new credential files, or you can continue to use your existing Boto 2.x credentials. Please note that Boto 3, the AWS CLI, and several other SDKs all use the shared credentials file (usually at ``~/.aws/credentials``).
+
+Once configured, you may begin using Boto 3::
+
+    import boto3
+
+    for bucket in boto3.resource('s3').buckets.all():
+        print(bucket.name)
+
+See the :ref:`guide_tutorial` and `Boto 3 Documentation <http://boto3.readthedocs.org/>`__ for more information.
+
+The rest of this document will describe specific common usage scenarios of Boto 2 code and how to accomplish the same tasks with Boto 3.
+
+Services
+--------
+
+.. toctree::
+   :maxdepth: 2
+
+   migrations3
+   migrationec2

--- a/docs/source/guide/migrationec2.rst
+++ b/docs/source/guide/migrationec2.rst
@@ -1,0 +1,125 @@
+.. _guide_migration_ec2:
+
+Amazon EC2
+==========
+Boto 2.x contains a number of customizations to make working with Amazon EC2 instances, storage and networks easy. Boto 3 exposes these same objects through its resources interface in a unified and consistent way.
+
+Creating the Connection
+-----------------------
+Boto 3 has both low-level clients and higher-level resources. For Amazon EC2, the higher-level resources are the most similar to Boto 2.x's ``ec2`` and ``vpc`` modules::
+
+    # Boto 2.x
+    import boto
+    ec2_connection = boto.connect_ec2()
+    vpc_connection = boto.connect_vpc()
+
+    # Boto 3
+    import boto3
+    ec2 = boto3.resource('ec2')
+
+Launching New Instances
+-----------------------
+Launching new instances requires an image ID and the number of instances to launch. It can also take several optional parameters, such as the instance type and security group::
+
+    # Boto 2.x
+    ec2_connection.run_instances('<ami-image-id>')
+
+    # Boto 3
+    ec2.create_instances(ImageId='<ami-image-id>', MinCount=1, MaxCount=5)
+
+Stopping & Terminating Instances
+--------------------------------
+Stopping and terminating multiple instances given a list of instance IDs uses Boto 3 collection filtering::
+
+    ids = ['instance-id-1', 'instance-id-2', ...]
+
+    # Boto 2.x
+    ec2_connection.stop_instances(instance_ids=ids)
+    ec2_connection.terminate_instances(instance_ids=ids)
+
+    # Boto 3
+    ec2.instances.filter(InstanceIds=ids).stop()
+    ec2.instances.filter(InstanceIds=ids).terminate()
+
+Checking What Instances Are Running
+-----------------------------------
+Boto 3 collections come in handy when listing all your running instances as well. Every collection exposes a ``filter`` method that allows you to pass additional parameters to the underlying service API operation. The EC2 instances collection takes a parameter called ``Filters`` which is a list of names and values, for example::
+
+    # Boto 2.x
+    reservations = ec2_connection.get_all_reservations(
+        filters={'instance-state-name': 'running'})
+    for reservation in reservations:
+        for instance in reservation.instances:
+            print(instance.instance_id, instance.instance_type)
+
+    # Boto 3
+    # Use the filter() method of the instances collection to retrieve
+    # all running EC2 instances.
+    instances = ec2.instances.filter(
+        Filters=[{'Name': 'instance-state-name', 'Values': ['running']}])
+    for instance in instances:
+        print(instance.id, instance.instance_type)
+
+Checking Health Status Of Instances
+-----------------------------------
+It is possible to get scheduled maintenance information for your running instances. At the time of this writing Boto 3 does not have a status resource, so you must drop down to the low-level client via ``ec2.meta.client``::
+
+    # Boto 2.x
+    for status in ec2_connection.get_all_instance_statuses():
+        print(status)
+
+    # Boto 3
+    for status in ec2.meta.client.describe_instance_status()['InstanceStatuses']:
+        print(status)
+
+Working with EBS Snapshots
+--------------------------
+Snapshots provide a way to create a copy of an EBS volume, as well as make new volumes from the snapshot which can be attached to an instance::
+
+    # Boto 2.x
+    snapshot = ec2_connection.create_snapshot('volume-id', 'Description')
+    volume = snapshot.create_volume('us-west-2')
+    ec2_connection.attach_volume(volume.id, 'instance-id', '/dev/sdy')
+    ec2_connection.delete_snapshot(snapshot.id)
+
+    # Boto 3
+    snapshot = ec2.create_snapshot(VolumeId='volume-id', Description='description')
+    volume = ec2.create_volume(SnapshotId=snapshot.id, AvailabilityZone='us-west-2a')
+    ec2.Instance('instance-id').attach_volume(VolumeId=volume.id, Device='/dev/sdy')
+    snapshot.delete()
+
+Creating a VPC, Subnet, and Gateway
+-----------------------------------
+Creating VPC resources in Boto 3 is very similar to Boto 2.x::
+
+    # Boto 2.x
+    vpc = vpc_connection.create_vpc('10.0.0.0/24')
+    subnet = vpc_connection.create_subnet(vpc.id, '10.0.0.0/25')
+    gateway = vpc_connection.create_internet_gateway()
+
+    # Boto 3
+    vpc = ec2.create_vpc(CidrBlock='10.0.0.0/24')
+    subnet = vpc.create_subnet(CidrBlock='10.0.0.0/25')
+    gateway = ec2.create_internet_gateway()
+
+Attaching and Detaching an Elastic IP and Gateway
+-------------------------------------------------
+Elastic IPs and gateways provide a way for instances inside of a VPC to communicate with the outside world::
+
+    # Boto 2.x
+    ec2_connection.attach_internet_gateway(gateway.id, vpc.id)
+    ec2_connection.detach_internet_gateway(gateway.id, vpc.id)
+
+    from boto.ec2.address import Address
+    address = Address()
+    address.allocation_id = 'eipalloc-35cf685d'
+    address.associate('i-71b2f60b')
+    address.disassociate()
+
+    # Boto 3
+    gateway.attach_to_vpc(VpcId=vpc.id)
+    gateway.detach_from_vpc(VpcId=vpc.id)
+
+    address = ec2.VpcAddress('eipalloc-35cf685d')
+    address.associate('i-71b2f60b')
+    address.association.delete()

--- a/docs/source/guide/migrations3.rst
+++ b/docs/source/guide/migrations3.rst
@@ -1,0 +1,163 @@
+.. _guide_migration_s3:
+
+Amazon S3
+=========
+Boto 2.x contains a number of customizations to make working with Amazon S3 buckets and keys easy. Boto 3 exposes these same objects through its resources interface in a unified and consistent way.
+
+Creating the Connection
+-----------------------
+Boto 3 has both low-level clients and higher-level resources. For Amazon S3, the higher-level resources are the most similar to Boto 2.x's ``s3`` module::
+
+    # Boto 2.x
+    import boto
+    s3_connection = boto.connect_s3()
+
+    # Boto 3
+    import boto3
+    s3 = boto3.resource('s3')
+
+Creating a Bucket
+-----------------
+Creating a bucket in Boto 2 and Boto 3 is very similar, except that in Boto 3 all action parameters must be passed via keyword arguments and a bucket configuration must be specified manually::
+
+    # Boto 2.x
+    s3_connection.create_bucket('mybucket')
+    s3_connection.create_bucket('mybucket', location=Location.USWest)
+
+    # Boto 3
+    s3.create_bucket(Bucket='mybucket')
+    s3.create_bucket(Bucket='mybucket', CreateBucketConfiguration={
+        'LocationConstraint': 'us-west-1'})
+
+Storing Data
+------------
+Storing data from a file, stream, or string is easy::
+
+    # Boto 2.x
+    from boto.s3.key import Key
+    key = Key('hello.txt')
+    key.set_contents_from_file('/tmp/hello.txt')
+
+    # Boto 3
+    s3.Key('mybucket', 'hello.txt').put(Body=open('/tmp/hello.txt'))
+
+
+Accessing a Bucket
+------------------
+Getting a bucket is easy with Boto 3's resources, however these do not automatically validate whether a bucket exists::
+
+    # Boto 2.x
+    bucket = s3_connection.get_bucket('mybucket', validate=False)
+    exists = s3_connection.lookup('mybucket')
+
+    # Boto 3
+    bucket = s3.Bucket('mybucket')
+    exists = True
+    try:
+        s3.meta.client.head_bucket(Bucket='mybucket')
+    except ClientError as e:
+        # If a client error is thrown, then check that it was a 404 error.
+        # If it was a 404 error, then the bucket does not exist.
+        error_code = int(e.response['Error']['Code'])
+        if error_code == 404:
+            exists = False
+
+Deleting a Bucket
+-----------------
+All of the keys in a bucket must be deleted before the bucket itself can be deleted::
+
+    # Boto 2.x
+    for key in bucket:
+        key.delete()
+    bucket.delete()
+
+    # Boto 3
+    for key in bucket.objects.all():
+        key.delete()
+    bucket.delete()
+
+Iteration of Buckets and Keys
+-----------------------------
+Bucket and key objects are no longer iterable, but now provide collection attributes which can be iterated::
+
+    # Boto 2.x
+    for bucket in s3_connection:
+        for key in bucket:
+            print(key.name)
+
+    # Boto 3
+    for bucket in s3.buckets.all():
+        for key in bucket.objects.all():
+            print(key.name)
+
+Access Controls
+---------------
+Getting and setting canned access control values in Boto 3 operates on an ``ACL`` resource object::
+
+    # Boto 2.x
+    bucket.set_acl('public-read')
+    key.set_acl('public-read')
+
+    # Boto 3
+    bucket.Acl().put(ACL='public-read')
+    obj.put(ACL='public-read')
+
+It's also possible to retrieve the policy grant information::
+
+    # Boto 2.x
+    acp = bucket.get_acl()
+    for grant in acp.acl.grants:
+        print(grant.display_name, grant.permission)
+
+    # Boto 3
+    acl = bucket.Acl()
+    for grant in acl.grants:
+        print(grant['DisplayName'], grant['Permission'])
+
+Boto 3 lacks the grant shortcut methods present in Boto 2.x, but it is still fairly simple to add grantees::
+
+    # Boto 2.x
+    bucket.add_email_grant('READ', 'user@domain.tld')
+
+    # Boto 3
+    bucket.Acl.put(GrantRead='emailAddress=user@domain.tld')
+
+Key Metadata
+------------
+It's possible to set arbitrary metadata on keys::
+
+    # Boto 2.x
+    key.set_metadata('meta1', 'This is my metadata value')
+    print(key.get_metadata('meta1'))
+
+    # Boto 3
+    key.put(Metadata={'meta1': 'This is my metadata value'})
+    print(key.metadata['meta1'])
+
+Managing CORS Configuration
+---------------------------
+Allows you to manage the cross-origin resource sharing configuration for S3 buckets::
+
+    # Boto 2.x
+    cors = bucket.get_cors()
+
+    config = CORSConfiguration()
+    config.add_rule('GET', '*')
+    bucket.set_cors(config)
+
+    bucket.delete_cors()
+
+    # Boto 3
+    cors = bucket.Cors()
+
+    config = {
+        'CORSRules': [
+            {
+                'AllowedMethods': ['GET'],
+                'AllowedOrigins': ['*']
+            }
+        ]
+    }
+    cors.put(CORSConfiguration=config)
+
+    cors.delete()

--- a/docs/source/guide/new.rst
+++ b/docs/source/guide/new.rst
@@ -37,13 +37,3 @@ Boto 3 is built atop of a library called
 `AWS CLI <http://aws.amazon.com/cli/>`_. Botocore provides the low level
 clients, session, and credential & configuration data. Boto 3 builds on top
 of Botocore by providing its own session, resources and collections.
-
-Migration
----------
-Current Boto users can begin using Boto 3 right away. The two modules can
-live side-by-side in the same project, which means that a piecemeal
-approach can be used. New features can be written in Boto 3, or existing
-code can be migrated over as needed, piece by piece.
-
-Boto 3 is currently in **developer preview**. A full migration guide is
-coming soon.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,6 +20,15 @@ direct service access.
 
    <div style="text-align:center;margin:1em"><iframe width="560" height="315" src="//www.youtube.com/embed/Cb2czfCV4Dg" frameborder="0" allowfullscreen></iframe></div>
 
+Quickstart
+----------
+
+.. toctree::
+   :maxdepth: 2
+
+   guide/quickstart
+   guide/tutorial
+
 User Guide
 ----------
 
@@ -27,10 +36,9 @@ User Guide
    :maxdepth: 2
 
    guide/new
-   guide/quickstart
+   guide/migration
    guide/resources
    guide/collections
-   guide/tutorial
    guide/clients
    guide/session
    guide/configuration

--- a/requirements2.txt
+++ b/requirements2.txt
@@ -1,0 +1,4 @@
+# Python2 needs the concurrent.futures backport.
+# We handle this logic in setup.py but we need
+# a separate file to track this in our requirements file.
+futures==2.2.0

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ packages = [
 ]
 
 requires = [
-    'botocore==0.86.0',
+    'botocore==0.87.0',
     'bcdoc==0.12.2',
     'jmespath==0.6.1',
 ]

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ packages = [
 ]
 
 requires = [
-    'botocore==0.87.0',
+    'botocore==0.92.0',
     'bcdoc==0.12.2',
     'jmespath==0.6.1',
 ]

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ distutils/setuptools install script.
 """
 import os
 import re
+import sys
 
 try:
     from setuptools import setup
@@ -30,6 +31,12 @@ requires = [
     'bcdoc==0.12.2',
     'jmespath==0.6.1',
 ]
+
+if sys.version_info[0] == 2:
+    # concurrent.futures is only in python3, so for
+    # python2 we need to install the backport.
+    requires.append('futures==2.2.0')
+
 
 setup(
     name='boto3',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ packages = [
 ]
 
 requires = [
-    'botocore==0.94.0',
+    'botocore==0.97.0',
     'bcdoc==0.12.2',
     'jmespath==0.6.1',
 ]

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ packages = [
 ]
 
 requires = [
-    'botocore==0.97.0',
+    'botocore==0.99.0',
     'bcdoc==0.12.2',
     'jmespath==0.6.1',
 ]
@@ -50,7 +50,7 @@ setup(
     install_requires=requires,
     license=open("LICENSE").read(),
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'Natural Language :: English',
         'License :: OSI Approved :: Apache Software License',

--- a/setup.py
+++ b/setup.py
@@ -20,13 +20,13 @@ def get_version():
     init = open(os.path.join(ROOT, 'boto3', '__init__.py')).read()
     return VERSION_RE.search(init).group(1)
 
-packages = [ 
+packages = [
     'boto3',
     'boto3.resources',
 ]
 
 requires = [
-    'botocore==0.92.0',
+    'botocore==0.94.0',
     'bcdoc==0.12.2',
     'jmespath==0.6.1',
 ]

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -10,10 +10,108 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-
-import boto3.session
+import os
+import threading
+import math
+import time
+import random
+import tempfile
+import shutil
+import hashlib
 
 from tests import unittest, unique_id
+from botocore.vendored import six
+
+import boto3.session
+import boto3.s3.transfer
+
+
+urlopen = six.moves.urllib.request.urlopen
+
+
+def assert_files_equal(first, second):
+    if os.path.getsize(first) != os.path.getsize(second):
+        raise AssertionError("Files are not equal: %s, %s" % (first, second))
+    first_md5 = md5_checksum(first)
+    second_md5 = md5_checksum(second)
+    if first_md5 != second_md5:
+        raise AssertionError(
+            "Files are not equal: %s(md5=%s) != %s(md5=%s)" % (
+                first, first_md5, second, second_md5))
+
+
+def md5_checksum(filename):
+    checksum = hashlib.md5()
+    with open(filename, 'rb') as f:
+        for chunk in iter(lambda: f.read(8192), b''):
+            checksum.update(chunk)
+    return checksum.hexdigest()
+
+
+class FileCreator(object):
+    def __init__(self):
+        self.rootdir = tempfile.mkdtemp()
+
+    def remove_all(self):
+        shutil.rmtree(self.rootdir)
+
+    def create_file(self, filename, contents, mtime=None, mode='w'):
+        """Creates a file in a tmpdir
+
+        ``filename`` should be a relative path, e.g. "foo/bar/baz.txt"
+        It will be translated into a full path in a tmp dir.
+
+        If the ``mtime`` argument is provided, then the file's
+        mtime will be set to the provided value (must be an epoch time).
+        Otherwise the mtime is left untouched.
+
+        ``mode`` is the mode the file should be opened either as ``w`` or
+        `wb``.
+
+        Returns the full path to the file.
+
+        """
+        full_path = os.path.join(self.rootdir, filename)
+        if not os.path.isdir(os.path.dirname(full_path)):
+            os.makedirs(os.path.dirname(full_path))
+        with open(full_path, mode) as f:
+            f.write(contents)
+        current_time = os.path.getmtime(full_path)
+        # Subtract a few years off the last modification date.
+        os.utime(full_path, (current_time, current_time - 100000000))
+        if mtime is not None:
+            os.utime(full_path, (mtime, mtime))
+        return full_path
+
+    def create_file_with_size(self, filename, filesize):
+        filename = self.create_file(filename, contents='')
+        chunksize = 8192
+        with open(filename, 'wb') as f:
+            for i in range(int(math.ceil(filesize / float(chunksize)))):
+                f.write(b'a' * chunksize)
+        return filename
+
+    def append_file(self, filename, contents):
+        """Append contents to a file
+
+        ``filename`` should be a relative path, e.g. "foo/bar/baz.txt"
+        It will be translated into a full path in a tmp dir.
+
+        Returns the full path to the file.
+        """
+        full_path = os.path.join(self.rootdir, filename)
+        if not os.path.isdir(os.path.dirname(full_path)):
+            os.makedirs(os.path.dirname(full_path))
+        with open(full_path, 'a') as f:
+            f.write(contents)
+        return full_path
+
+    def full_path(self, filename):
+        """Translate relative path to full path in temp dir.
+
+        f.full_path('foo/bar.txt') -> /tmp/asdfasd/foo/bar.txt
+        """
+        return os.path.join(self.rootdir, filename)
 
 
 class TestS3Resource(unittest.TestCase):
@@ -74,7 +172,6 @@ class TestS3Resource(unittest.TestCase):
         self.assertIn(self.bucket_name,
                       [b.name for b in self.s3.buckets.all()])
 
-
         # Create an object
         obj = bucket.Object('test.txt')
         obj.put(
@@ -121,3 +218,146 @@ class TestS3Resource(unittest.TestCase):
 
         contents = bucket.Object('mp-test.txt').get()['Body'].read()
         self.assertEqual(contents, b'hello, world!')
+
+
+class TestS3Transfers(unittest.TestCase):
+    """Tests for the high level boto3.s3.transfer module."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.region = 'us-west-2'
+        cls.session = boto3.session.Session(region_name=cls.region)
+        cls.client = cls.session.client('s3', cls.region)
+        cls.bucket_name = 'boto3-integ-transfer-%s-%s' % (
+            int(time.time()), random.randint(1, 100))
+        cls.client.create_bucket(
+            Bucket=cls.bucket_name,
+            CreateBucketConfiguration={'LocationConstraint': cls.region})
+
+    def setUp(self):
+        self.files = FileCreator()
+
+    def tearDown(self):
+        self.files.remove_all()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.client.delete_bucket(Bucket=cls.bucket_name)
+
+    def delete_object(self, key):
+        self.client.delete_object(
+            Bucket=self.bucket_name,
+            Key=key)
+
+    def object_exists(self, key):
+        self.client.head_object(Bucket=self.bucket_name,
+                                Key=key)
+        return True
+
+    def create_s3_transfer(self):
+        return boto3.s3.transfer.S3Transfer(self.client)
+
+    def test_upload_below_threshold(self):
+        transfer = self.create_s3_transfer()
+        filename = self.files.create_file_with_size(
+            'foo.txt', filesize=1024 * 1024)
+        transfer.upload_file(filename, self.bucket_name,
+                             'foo.txt')
+        self.addCleanup(self.delete_object, 'foo.txt')
+
+        self.assertTrue(self.object_exists('foo.txt'))
+
+    def test_upload_above_threshold(self):
+        transfer = self.create_s3_transfer()
+        filename = self.files.create_file_with_size(
+            '20mb.txt', filesize=20 * 1024 * 1024)
+        transfer.upload_file(filename, self.bucket_name,
+                             '20mb.txt')
+        self.addCleanup(self.delete_object, '20mb.txt')
+        self.assertTrue(self.object_exists('20mb.txt'))
+
+    def test_progress_callback_on_upload(self):
+        self.amount_seen = 0
+        lock = threading.Lock()
+
+        def progress_callback(amount):
+            with lock:
+                self.amount_seen += amount
+
+        transfer = self.create_s3_transfer()
+        filename = self.files.create_file_with_size(
+            '20mb.txt', filesize=20 * 1024 * 1024)
+        transfer.upload_file(filename, self.bucket_name,
+                             '20mb.txt', callback=progress_callback)
+        self.addCleanup(self.delete_object, '20mb.txt')
+
+        # The callback should have been called enough times such that
+        # the total amount of bytes we've seen (via the "amount"
+        # arg to the callback function) should be the size
+        # of the file we uploaded.
+        self.assertEqual(self.amount_seen, 20 * 1024 * 1024)
+
+    def test_can_send_extra_params_on_upload(self):
+        pass
+
+    def test_can_configure_threshold(self):
+        config = boto3.s3.transfer.TransferConfig(
+            multipart_threshold=6 * 1024 * 1024
+        )
+        transfer = boto3.s3.transfer.S3Transfer(self.client, config)
+        filename = self.files.create_file_with_size(
+            'foo.txt', filesize=8 * 1024 * 1024)
+        transfer.upload_file(filename, self.bucket_name,
+                             'foo.txt')
+        self.addCleanup(self.delete_object, 'foo.txt')
+
+        self.assertTrue(self.object_exists('foo.txt'))
+
+    def test_can_send_extra_params_on_download(self):
+        transfer = self.create_s3_transfer()
+        extra_args = {'ACL': 'public-read'}
+        filename = self.files.create_file_with_size(
+            'foo.txt', filesize=1024 * 1024)
+        transfer.upload_file(filename, self.bucket_name,
+                             'foo.txt', extra_args=extra_args)
+        self.addCleanup(self.delete_object, 'foo.txt')
+
+        self.assertTrue(self.object_exists('foo.txt'))
+        # TODO: Verify we can download the object
+        # I'd like to create an anonymous client in boto3, but that doesn't
+        # appear possible.
+
+    def test_progress_callback_on_download(self):
+        pass
+
+    def test_download_below_threshold(self):
+        transfer = self.create_s3_transfer()
+
+        filename = self.files.create_file_with_size(
+            'foo.txt', filesize=1024 * 1024)
+        with open(filename, 'rb') as f:
+            self.client.put_object(Bucket=self.bucket_name,
+                                   Key='foo.txt',
+                                   Body=f)
+            self.addCleanup(self.delete_object, 'foo.txt')
+
+        download_path = os.path.join(self.files.rootdir, 'downloaded.txt')
+        transfer.download_file(self.bucket_name, 'foo.txt',
+                               download_path)
+        assert_files_equal(filename, download_path)
+
+    def test_download_above_threshold(self):
+        transfer = self.create_s3_transfer()
+
+        filename = self.files.create_file_with_size(
+            'foo.txt', filesize=20 * 1024 * 1024)
+        with open(filename, 'rb') as f:
+            self.client.put_object(Bucket=self.bucket_name,
+                                   Key='foo.txt',
+                                   Body=f)
+            self.addCleanup(self.delete_object, 'foo.txt')
+
+        download_path = os.path.join(self.files.rootdir, 'downloaded.txt')
+        transfer.download_file(self.bucket_name, 'foo.txt',
+                               download_path)
+        assert_files_equal(filename, download_path)

--- a/tests/unit/resources/test_factory.py
+++ b/tests/unit/resources/test_factory.py
@@ -20,15 +20,14 @@ from boto3.resources.action import WaiterAction
 from tests import BaseTestCase, mock
 
 
-class TestResourceFactory(BaseTestCase):
+class BaseTestResourceFactory(BaseTestCase):
     def setUp(self):
-        super(TestResourceFactory, self).setUp()
+        super(BaseTestResourceFactory, self).setUp()
         self.factory = ResourceFactory()
         self.load = self.factory.load_from_definition
 
-    def tearDown(self):
-        super(TestResourceFactory, self).tearDown()
 
+class TestResourceFactory(BaseTestResourceFactory):
     def test_get_service_returns_resource_class(self):
         TestResource = self.load('test', 'test', {}, {}, None)
 
@@ -574,7 +573,7 @@ class TestResourceFactory(BaseTestCase):
         waiter_action.assert_called_with(resource, 'arg1', arg2=2)
 
 
-class TestResourceFactoryDanglingResource(TestResourceFactory):
+class TestResourceFactoryDanglingResource(BaseTestResourceFactory):
     def setUp(self):
         super(TestResourceFactoryDanglingResource, self).setUp()
 
@@ -672,7 +671,7 @@ class TestResourceFactoryDanglingResource(TestResourceFactory):
         self.assertNotEqual(q1, m)
 
 
-class TestServiceResourceSubresources(TestResourceFactory):
+class TestServiceResourceSubresources(BaseTestResourceFactory):
     def setUp(self):
         super(TestServiceResourceSubresources, self).setUp()
 

--- a/tests/unit/resources/test_factory.py
+++ b/tests/unit/resources/test_factory.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from botocore.model import ServiceModel, StructureShape
+from botocore.model import DenormalizedStructureBuilder, ServiceModel
 from boto3.exceptions import ResourceLoadException
 from boto3.resources.base import ServiceResource
 from boto3.resources.collection import CollectionManager
@@ -126,11 +126,14 @@ class TestResourceFactory(BaseTestResourceFactory):
                 }
             }
         }
-        shape = mock.Mock()
-        shape.members = {
-            'ETag': None,
-            'LastModified': None,
-        }
+        shape = DenormalizedStructureBuilder().with_members({
+            'ETag': {
+                'type': 'string',
+            },
+            'LastModified': {
+                'type': 'string'
+            }
+        }).build_model()
         service_model = mock.Mock()
         service_model.shape_for.return_value = shape
 
@@ -357,12 +360,20 @@ class TestResourceFactory(BaseTestResourceFactory):
                 }
             }
         }
-        shape = mock.Mock()
-        shape.members = {
-            'Url': None,
-            'ETag': None,
-            'LastModified': None,
-        }
+        shape = DenormalizedStructureBuilder().with_members({
+            'ETag': {
+                'type': 'string',
+                'shape_name': 'ETag'
+            },
+            'LastModified': {
+                'type': 'string',
+                'shape_name': 'LastModified'
+            },
+            'Url': {
+                'type': 'string',
+                'shape_name': 'Url'
+            }
+        }).build_model()
         service_model = mock.Mock()
         service_model.shape_for.return_value = shape
 
@@ -401,12 +412,17 @@ class TestResourceFactory(BaseTestResourceFactory):
             # Note the lack of a `load` method. These resources
             # are usually loaded via a call on a parent resource.
         }
-        shape = mock.Mock()
-        shape.members = {
-            'Url': None,
-            'ETag': None,
-            'LastModified': None,
-        }
+        shape = DenormalizedStructureBuilder().with_members({
+            'ETag': {
+                'type': 'string',
+            },
+            'LastModified': {
+                'type': 'string'
+            },
+            'Url': {
+                'type': 'string'
+            }
+        }).build_model()
         service_model = mock.Mock()
         service_model.shape_for.return_value = shape
 
@@ -517,7 +533,7 @@ class TestResourceFactory(BaseTestResourceFactory):
             'Queue': {}
         }
         service_model = ServiceModel({})
-        mock_model.return_value.name = 'Queues'
+        mock_model.return_value.name = 'queues'
 
         resource = self.load('test', 'test', model, defs, service_model)()
 

--- a/tests/unit/s3/test_transfer.py
+++ b/tests/unit/s3/test_transfer.py
@@ -1,0 +1,446 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the 'license' file accompanying this file. This file is
+# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import os
+import tempfile
+import shutil
+import socket
+from tests import unittest
+from contextlib import closing
+
+import mock
+from botocore.vendored import six
+from botocore.client import BaseClient
+
+from boto3.exceptions import RetriesExceededError
+from boto3.s3.transfer import ReadFileChunk, StreamReaderProgress
+from boto3.s3.transfer import S3Transfer
+from boto3.s3.transfer import OSUtils, TransferConfig
+from boto3.s3.transfer import ThreadSafeWriter
+from boto3.s3.transfer import MultipartDownloader, MultipartUploader
+
+
+class InMemoryOSLayer(OSUtils):
+    def __init__(self, filemap):
+        self._filemap = filemap
+
+    def get_file_size(self, filename):
+        return len(self._filemap[filename])
+
+    def open_file_chunk_reader(self, filename, start_byte, size, callback):
+        # TODO: handle the case for partial reads.
+        return closing(six.BytesIO(self._filemap[filename]))
+
+    def open(self, filename, mode):
+        if 'wb' in mode:
+            fileobj = six.BytesIO()
+            self._filemap = fileobj
+            return closing(fileobj)
+        else:
+            return closing(self._filemap[filename])
+
+
+class SequentialExecutor(object):
+    def __init__(self, max_workers):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        pass
+
+    # The real map() interface actually takes *args, but we specifically do
+    # _not_ use this interface.
+    def map(self, function, args):
+        results = []
+        for arg in args:
+            results.append(function(arg))
+        return results
+
+
+class TestThreadSafeWriter(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+        self.filename = os.path.join(self.tempdir, 'foo')
+        self.fileobj = open(self.filename, 'w')
+
+    def tearDown(self):
+        self.fileobj.close()
+        shutil.rmtree(self.tempdir)
+
+    def test_pwrite_to_beginning_of_file(self):
+        # We're not actually interested in unit testing the threading logic
+        # via a unit test.  Any concurrency issues will crop up in integration
+        # tests.
+        writer = ThreadSafeWriter(self.fileobj)
+        writer.pwrite('foobar', 0)
+        self.fileobj.flush()
+        with open(self.filename, 'r') as f:
+            self.assertEqual(f.read(), 'foobar')
+        writer.close()
+
+    def test_pwrite_to_offset_not_at_start(self):
+        writer = ThreadSafeWriter(self.fileobj)
+        writer.pwrite('foobar', 5)
+        self.fileobj.flush()
+        with open(self.filename, 'r') as f:
+            # Because we used an offset of 5 above, we should have
+            # the first 5 bytes filled with 0.
+            self.assertEqual(
+                f.read(), '\x00\x00\x00\x00\x00foobar')
+
+    def test_multiple_pwrite_calls(self):
+        writer = ThreadSafeWriter(self.fileobj)
+        writer.pwrite('first', 8)
+        writer.pwrite('second', 1)
+        self.fileobj.flush()
+        with open(self.filename, 'r') as f:
+            self.assertEqual(f.read(), '\x00second\x00first')
+
+
+class TestOSUtils(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    def test_get_file_size(self):
+        with mock.patch('os.path.getsize') as m:
+            OSUtils().get_file_size('myfile')
+            m.assert_called_with('myfile')
+
+    def test_open_file_chunk_reader(self):
+        with mock.patch('boto3.s3.transfer.ReadFileChunk') as m:
+            OSUtils().open_file_chunk_reader('myfile', 0, 100, None)
+            m.from_filename.assert_called_with('myfile', 0, 100, None)
+
+    def test_open_file(self):
+        fileobj = OSUtils().open(os.path.join(self.tempdir, 'foo'), 'w')
+        self.assertTrue(hasattr(fileobj, 'write'))
+
+    def test_wrap_thread_safe_writer(self):
+        wrapped = OSUtils().wrap_thread_safe_writer(None)
+        self.assertIsInstance(wrapped, ThreadSafeWriter)
+
+    def test_wrap_stream_with_callback(self):
+        wrapped = OSUtils().wrap_stream_with_callback(None, None)
+        self.assertIsInstance(wrapped, StreamReaderProgress)
+
+
+class TestReadFileChunk(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    def test_read_entire_chunk(self):
+        filename = os.path.join(self.tempdir, 'foo')
+        f = open(filename, 'wb')
+        f.write(b'onetwothreefourfivesixseveneightnineten')
+        f.flush()
+        chunk = ReadFileChunk.from_filename(
+            filename, start_byte=0, chunk_size=3)
+        self.assertEqual(chunk.read(), b'one')
+        self.assertEqual(chunk.read(), b'')
+
+    def test_read_with_amount_size(self):
+        filename = os.path.join(self.tempdir, 'foo')
+        f = open(filename, 'wb')
+        f.write(b'onetwothreefourfivesixseveneightnineten')
+        f.flush()
+        chunk = ReadFileChunk.from_filename(
+            filename, start_byte=11, chunk_size=4)
+        self.assertEqual(chunk.read(1), b'f')
+        self.assertEqual(chunk.read(1), b'o')
+        self.assertEqual(chunk.read(1), b'u')
+        self.assertEqual(chunk.read(1), b'r')
+        self.assertEqual(chunk.read(1), b'')
+
+    def test_reset_stream_emulation(self):
+        filename = os.path.join(self.tempdir, 'foo')
+        f = open(filename, 'wb')
+        f.write(b'onetwothreefourfivesixseveneightnineten')
+        f.flush()
+        chunk = ReadFileChunk.from_filename(
+            filename, start_byte=11, chunk_size=4)
+        self.assertEqual(chunk.read(), b'four')
+        chunk.seek(0)
+        self.assertEqual(chunk.read(), b'four')
+
+    def test_read_past_end_of_file(self):
+        filename = os.path.join(self.tempdir, 'foo')
+        f = open(filename, 'wb')
+        f.write(b'onetwothreefourfivesixseveneightnineten')
+        f.flush()
+        chunk = ReadFileChunk.from_filename(
+            filename, start_byte=36, chunk_size=100000)
+        self.assertEqual(chunk.read(), b'ten')
+        self.assertEqual(chunk.read(), b'')
+        self.assertEqual(len(chunk), 3)
+
+    def test_tell_and_seek(self):
+        filename = os.path.join(self.tempdir, 'foo')
+        f = open(filename, 'wb')
+        f.write(b'onetwothreefourfivesixseveneightnineten')
+        f.flush()
+        chunk = ReadFileChunk.from_filename(
+            filename, start_byte=36, chunk_size=100000)
+        self.assertEqual(chunk.tell(), 0)
+        self.assertEqual(chunk.read(), b'ten')
+        self.assertEqual(chunk.tell(), 3)
+        chunk.seek(0)
+        self.assertEqual(chunk.tell(), 0)
+
+    def test_callback_is_invoked_on_read(self):
+        filename = os.path.join(self.tempdir, 'foo')
+        f = open(filename, 'wb')
+        f.write(b'abc')
+        f.flush()
+        amounts_seen = []
+        def callback(amount):
+            amounts_seen.append(amount)
+        chunk = ReadFileChunk.from_filename(
+            filename, start_byte=0, chunk_size=3, callback=callback)
+        chunk.read(1)
+        chunk.read(1)
+        chunk.read(1)
+
+        self.assertEqual(amounts_seen, [1, 1, 1])
+
+    def test_file_chunk_supports_context_manager(self):
+        filename = os.path.join(self.tempdir, 'foo')
+        f = open(filename, 'wb')
+        f.write(b'abc')
+        f.flush()
+        with ReadFileChunk.from_filename(filename,
+                                         start_byte=0,
+                                         chunk_size=2) as chunk:
+            val = chunk.read()
+            self.assertEqual(val, b'ab')
+
+    def test_iter_is_always_empty(self):
+        # This tests the workaround for the httplib bug (see
+        # the source for more info).
+        filename = os.path.join(self.tempdir, 'foo')
+        f = open(filename, 'wb').close()
+        chunk = ReadFileChunk.from_filename(
+            filename, start_byte=0, chunk_size=10)
+        self.assertEqual(list(chunk), [])
+
+
+class TestStreamReaderProgress(unittest.TestCase):
+
+    def test_proxies_to_wrapped_stream(self):
+        original_stream = six.StringIO('foobarbaz')
+        wrapped = StreamReaderProgress(original_stream)
+        self.assertEqual(wrapped.read(), 'foobarbaz')
+
+    def test_callback_invoked(self):
+        amounts_seen = []
+        def callback(amount):
+            amounts_seen.append(amount)
+        original_stream = six.StringIO('foobarbaz')
+        wrapped = StreamReaderProgress(original_stream, callback)
+        self.assertEqual(wrapped.read(), 'foobarbaz')
+        self.assertEqual(amounts_seen, [9])
+
+
+class TestMultipartUploader(unittest.TestCase):
+    def test_multipart_upload_uses_correct_client_calls(self):
+        client = mock.Mock()
+        uploader = MultipartUploader(client, TransferConfig(),
+                                     InMemoryOSLayer({'filename': b'foobar'}), SequentialExecutor)
+        client.create_multipart_upload.return_value = {'UploadId': 'upload_id'}
+        client.upload_part.return_value = {'ETag': 'first'}
+
+        uploader.upload_file('filename', 'bucket', 'key', None, {})
+
+
+        # We need to check both the sequence of calls (create/upload/complete)
+        # as well as the params passed between the calls, including
+        # 1. The upload_id was plumbed through
+        # 2. The collected etags were added to the complete call.
+        client.create_multipart_upload.assert_called_with(
+            Bucket='bucket', Key='key')
+        # Should be two parts.
+        client.upload_part.assert_called_with(
+            Body=mock.ANY, Bucket='bucket',
+            UploadId='upload_id', Key='key', PartNumber=1)
+        client.complete_multipart_upload.assert_called_with(
+            MultipartUpload={'Parts': [{'PartNumber': 1, 'ETag': 'first'}]},
+            Bucket='bucket',
+            UploadId='upload_id',
+            Key='key')
+
+
+class TestMultipartDownloader(unittest.TestCase):
+    def test_multipart_download_uses_correct_client_calls(self):
+        client = mock.Mock()
+        response_body = b'foobarbaz'
+        client.get_object.return_value = {'Body': six.BytesIO(response_body)}
+
+
+        downloader = MultipartDownloader(client, TransferConfig(),
+                                         InMemoryOSLayer({}),
+                                         SequentialExecutor)
+        downloader.download_file('bucket', 'key', 'filename', len(response_body))
+
+        client.get_object.assert_called_with(
+            Range='bytes=0-',
+            Bucket='bucket',
+            Key='key'
+        )
+
+    def test_multipart_download_with_multiple_parts(self):
+        client = mock.Mock()
+        response_body = b'foobarbaz'
+        client.get_object.return_value = {'Body': six.BytesIO(response_body)}
+        # For testing purposes, we're testing with a multipart threshold
+        # of 4 bytes and a chunksize of 4 bytes.  Given b'foobarbaz',
+        # this should result in 3 calls.  In python slices this would be:
+        # r[0:4], r[4:8], r[8:9].  But the Range param will be slightly
+        # different because they use inclusive ranges.
+        config = TransferConfig(multipart_threshold=4,
+                                multipart_chunksize=4)
+
+        downloader = MultipartDownloader(client, config,
+                                         InMemoryOSLayer({}),
+                                         SequentialExecutor)
+        downloader.download_file('bucket', 'key', 'filename', len(response_body))
+
+        # We're storing these in **extra because the assertEqual
+        # below is really about verifying we have the correct value
+        # for the Range param.
+        extra = {'Bucket': 'bucket', 'Key': 'key'}
+        self.assertEqual(client.get_object.call_args_list,
+                         # Note these are inclusive ranges.
+                         [mock.call(Range='bytes=0-3', **extra),
+                          mock.call(Range='bytes=4-7', **extra),
+                          mock.call(Range='bytes=8-', **extra)])
+
+    def test_retry_on_failures_from_stream_reads(self):
+        # If we get an exception during a call to the response body's .read()
+        # method, we should retry the request.
+        pass
+
+
+class TestS3Transfer(unittest.TestCase):
+    def setUp(self):
+        self.client = mock.Mock()
+
+    def test_upload_below_multipart_threshold_uses_put_object(self):
+        below_multipart_threshold = 10
+        fake_files = {
+            'smallfile': b'foobar',
+        }
+        osutil = InMemoryOSLayer(fake_files)
+        transfer = S3Transfer(self.client, osutil=osutil)
+        transfer.upload_file('smallfile', 'bucket', 'key')
+        self.client.put_object.assert_called_with(
+            Bucket='bucket', Key='key', Body=mock.ANY
+        )
+
+    def test_extra_args_on_uploaded_passed_to_api_call(self):
+        below_multipart_threshold = 10
+        extra_args = {'ACL': 'public-read'}
+        fake_files = {
+            'smallfile': b'hello world'
+        }
+        osutil = InMemoryOSLayer(fake_files)
+        transfer = S3Transfer(self.client, osutil=osutil)
+        transfer.upload_file('smallfile', 'bucket', 'key',
+                             extra_args=extra_args)
+        self.client.put_object.assert_called_with(
+            Bucket='bucket', Key='key', Body=mock.ANY,
+            ACL='public-read'
+        )
+
+    def test_uses_multipart_upload_when_over_threshold(self):
+        with mock.patch('boto3.s3.transfer.MultipartUploader') as uploader:
+            fake_files = {
+                'smallfile': b'foobar',
+            }
+            osutil = InMemoryOSLayer(fake_files)
+            config = TransferConfig(multipart_threshold=2,
+                                    multipart_chunksize=2)
+            transfer = S3Transfer(self.client, osutil=osutil, config=config)
+            transfer.upload_file('smallfile', 'bucket', 'key')
+
+            uploader.return_value.upload_file.assert_called_with(
+                'smallfile', 'bucket', 'key', None, {})
+
+    def test_uses_multipart_download_when_over_threshold(self):
+        with mock.patch('boto3.s3.transfer.MultipartDownloader') as downloader:
+            osutil = InMemoryOSLayer({})
+            over_multipart_threshold = 100 * 1024 * 1024
+            transfer = S3Transfer(self.client, osutil=osutil)
+            callback = mock.sentinel.CALLBACK
+            self.client.head_object.return_value = {
+                'ContentLength': over_multipart_threshold,
+            }
+            transfer.download_file('bucket', 'key', 'filename',
+                                   callback=callback)
+
+            downloader.return_value.download_file.assert_called_with(
+                'bucket', 'key', 'filename', over_multipart_threshold,
+                callback)
+
+    def test_get_object_stream_is_retried_and_succeeds(self):
+        below_threshold = 20
+        osutil = InMemoryOSLayer({'smallfile': b'hello world'})
+        transfer = S3Transfer(self.client, osutil=osutil)
+        self.client.head_object.return_value = {
+            'ContentLength': below_threshold}
+        self.client.get_object.side_effect = [
+            # First request fails.
+            socket.error("fake error"),
+            # Second succeeds.
+            {'Body': six.BytesIO(b'foobar')}
+        ]
+        transfer.download_file('bucket', 'key', '/tmp/smallfile')
+
+        self.assertEqual(self.client.get_object.call_count, 2)
+
+    def test_get_object_stream_uses_all_retries_and_errors_out(self):
+        below_threshold = 20
+        osutil = InMemoryOSLayer({'smallfile': b'hello world'})
+        transfer = S3Transfer(self.client, osutil=osutil)
+        self.client.head_object.return_value = {
+            'ContentLength': below_threshold}
+        # Here we're raising an exception every single time, which
+        # will exhaust our retry count and propogate a
+        # RetriesExceededError.
+        self.client.get_object.side_effect = socket.error("fake error")
+        with self.assertRaises(RetriesExceededError):
+            transfer.download_file('bucket', 'key', '/tmp/smallfile')
+
+        self.assertEqual(self.client.get_object.call_count, 5)
+
+    def test_download_below_multipart_threshold(self):
+        below_threshold = 20
+        osutil = InMemoryOSLayer({'smallfile': b'hello world'})
+        transfer = S3Transfer(self.client, osutil=osutil)
+        self.client.head_object.return_value = {
+            'ContentLength': below_threshold}
+        self.client.get_object.return_value = {
+            'Body': six.BytesIO(b'foobar')
+        }
+        transfer.download_file('bucket', 'key', '/tmp/smallfile')
+
+        self.client.get_object.assert_called_with(Bucket='bucket', Key='key')
+
+    def test_can_create_with_just_client(self):
+        transfer = S3Transfer(client=mock.Mock())
+        self.assertIsInstance(transfer, S3Transfer)

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -1,0 +1,86 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from botocore.model import DenormalizedStructureBuilder, ServiceModel
+
+from boto3.docs import py_type_name, document_structure
+from tests import mock, BaseTestCase
+
+
+class TestPythonTypeName(BaseTestCase):
+    def test_structure(self):
+        self.assertEqual('dict', py_type_name('structure'))
+
+    def test_list(self):
+        self.assertEqual('list', py_type_name('list'))
+
+    def test_map(self):
+        self.assertEqual('dict', py_type_name('map'))
+
+    def test_string(self):
+        self.assertEqual('string', py_type_name('string'))
+
+    def test_character(self):
+        self.assertEqual('string', py_type_name('character'))
+
+    def test_blob(self):
+        self.assertEqual('bytes', py_type_name('blob'))
+
+    def test_timestamp(self):
+        self.assertEqual('datetime', py_type_name('timestamp'))
+
+    def test_integer(self):
+        self.assertEqual('integer', py_type_name('integer'))
+
+    def test_long(self):
+        self.assertEqual('integer', py_type_name('long'))
+
+    def test_float(self):
+        self.assertEqual('float', py_type_name('float'))
+
+    def test_double(self):
+        self.assertEqual('float', py_type_name('double'))
+
+
+class TestDocumentStructure(BaseTestCase):
+    def test_nested_structure(self):
+        # Internally this doesn't use an OrderedDict so we can't
+        # test the full output, but we can test whether the
+        # parameters are all included as expected with the correct
+        # types.
+        shape = DenormalizedStructureBuilder().with_members({
+            'Param1': {
+                'type': 'list',
+                'member': {
+                    'type': 'structure',
+                    'members': {
+                        'Param2': {
+                            'type': 'string'
+                        },
+                        'Param3': {
+                            'type': 'float'
+                        }
+                    }
+                }
+            },
+            'Param4': {
+                'type': 'blob'
+            }
+        }).build_model()
+
+        doc = document_structure('Test', shape)
+
+        self.assertIn("'Param1': [", doc)
+        self.assertIn("'Param2': STRING", doc)
+        self.assertIn("'Param3': FLOAT", doc)
+        self.assertIn("'Param4': BYTES", doc)

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -66,6 +66,23 @@ class TestSession(BaseTestCase):
         bc_session.set_credentials.assert_called_with(
             'key', 'secret', 'token')
 
+    def test_profile_can_be_set(self):
+        bc_session = self.bc_session_cls.return_value
+
+        session = Session(profile_name='foo')
+
+        self.assertEqual(bc_session.profile, 'foo')
+
+        # We should also be able to read the value
+        self.assertEqual(session.profile_name, 'foo')
+
+    def test_profile_default(self):
+        self.bc_session_cls.return_value.profile = None
+
+        session = Session()
+
+        self.assertEqual(session.profile_name, 'default')
+
     def test_custom_session(self):
         bc_session = self.bc_session_cls()
         self.bc_session_cls.reset_mock()


### PR DESCRIPTION
This PR adds support for an intelligent upload_file/download_file method for boto3.

The module docstring provides some general information and an overview of how to use the module.

I'd like to get some initial feedback on this.  There's unit/integ tests added (there's a few integration tests I've haven't fleshed out yet), and the code is fully functional, but I will be pushing some changes in a bit.

There are two changes I plan on making:

* I'm going to be changing the logic for the _download_range function.  The single lock writer on the file unnecessarily slows down the parallel downloads.  I'm likely going to port some version of the what the AWS CLI does to improve this.
* The callback interface may need to change.  It requires a lot of information that's not technically necessary and could be provided.  It also doesn't handle retries.  In order to do this, I might need to change the interface from a simple callback to an actual class that has a few required methods.


Also, the socket timeouts and bandwidth throttling are not implemented.  Those are stretch features I might end up deferring for now.

There will also be another pull request that integrates this with the s3 client and s3 resource objects.

cc @kyleknap @danielgtaylor