### PR TITLE
Initial commit of S3 upload_file/download_file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
 sudo: false
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then travis_retry pip install -r requirements26.txt; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.* ]]; then travis_retry pip install -r requirements2.txt; fi
   - travis_retry pip install -r requirements.txt
   - travis_retry pip install coverage python-coveralls
 script: nosetests --with-coverage --cover-erase

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
-  - "pypy"
 sudo: false
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then travis_retry pip install -r requirements26.txt; fi

--- a/boto3/compat.py
+++ b/boto3/compat.py
@@ -1,0 +1,25 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import sys
+import os
+
+
+if sys.platform.startswith('win'):
+    def rename_file(current_filename, new_filename):
+        try:
+            os.remove(new_filename)
+        except OSError:
+            pass
+        os.rename(current_filename, new_filename)
+else:
+    rename_file = os.rename

--- a/boto3/exceptions.py
+++ b/boto3/exceptions.py
@@ -17,3 +17,9 @@ class ResourceLoadException(Exception):
 
 class NoVersionFound(Exception):
     pass
+
+
+class RetriesExceededError(Exception):
+    def __init__(self, last_exception, msg='Max Retries Exceeded'):
+        super(RetriesExceededError, self).__init__(msg)
+        self.last_exception = last_exception

--- a/boto3/exceptions.py
+++ b/boto3/exceptions.py
@@ -23,3 +23,11 @@ class RetriesExceededError(Exception):
     def __init__(self, last_exception, msg='Max Retries Exceeded'):
         super(RetriesExceededError, self).__init__(msg)
         self.last_exception = last_exception
+
+
+class S3TransferFailedError(Exception):
+    pass
+
+
+class S3UploadFailedError(Exception):
+    pass

--- a/boto3/s3/__init__.py
+++ b/boto3/s3/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -1,3 +1,15 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
 """Abstractions over S3's upload/download operations.
 
 This module provides high level abstractions for efficient

--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -488,7 +488,6 @@ class S3Transfer(object):
         else:
             self._put_object(filename, bucket, key, callback, extra_args)
 
-
     def _put_object(self, filename, bucket, key, callback, extra_args):
         # We're using open_file_chunk_reader so we can take advantage of the
         # progress callback functionality.

--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -384,7 +384,6 @@ class MultipartUploader(object):
             return {'ETag': etag, 'PartNumber': part_number}
 
 
-
 class ShutdownQueue(queue.Queue):
     """A queue implementation that can be shutdown.
 
@@ -617,7 +616,7 @@ class S3Transfer(object):
         try:
             self._download_file(bucket, key, temp_filename, object_size,
                                 extra_args, callback)
-        except Exception as e:
+        except Exception:
             logger.debug("Exception caught in download_file, removing partial "
                          "file: %s", temp_filename, exc_info=True)
             self._osutil.remove_file(temp_filename)

--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -416,6 +416,7 @@ class S3Transfer(object):
     def _get_object(self, bucket, key, filename, callback):
         # precondition: num_download_attempts > 0
         max_attempts = self._config.num_download_attempts
+        last_exception = None
         for i in range(max_attempts):
             try:
                 return self._do_get_object(bucket, key, filename, callback)
@@ -426,8 +427,9 @@ class S3Transfer(object):
                 logger.debug("Retrying exception caught (%s), "
                              "retrying request, (attempt %s / %s)", e, i,
                              max_attempts, exc_info=True)
+                last_exception = None
                 continue
-        raise RetriesExceededError(e)
+        raise RetriesExceededError(last_exception)
 
     def _do_get_object(self, bucket, key, filename, callback):
         response = self._client.get_object(Bucket=bucket, Key=key)

--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -123,7 +123,6 @@ transfer.  For example:
 """
 import os
 import math
-import threading
 import functools
 import logging
 import socket

--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -116,7 +116,9 @@ import functools
 import logging
 import socket
 from concurrent import futures
+import contextlib
 
+import six
 from botocore.vendored.requests.packages.urllib3.exceptions import \
     ReadTimeoutError
 from botocore.exceptions import IncompleteReadError
@@ -125,7 +127,10 @@ from boto3.exceptions import RetriesExceededError
 
 
 logger = logging.getLogger(__name__)
+queue = six.moves.queue
+
 MB = 1024 * 1024
+SHUTDOWN_SENTINEL = object()
 
 
 class ReadFileChunk(object):
@@ -317,22 +322,48 @@ class MultipartDownloader(object):
         self._config = config
         self._os = osutil
         self._executor_cls = executor_cls
+        self._ioqueue = queue.Queue(self._config.max_io_queue)
 
     def download_file(self, bucket, key, filename, object_size,
                       callback=None):
+        with self._executor_cls(max_workers=2) as controller:
+            # 1 thread for the future that manages the uploading of files
+            # 1 thread for the future that manages IO writes.
+            download_parts_handler = functools.partial(
+                self._download_file_as_future,
+                bucket, key, filename, object_size, callback)
+            parts_future = controller.submit(download_parts_handler)
+
+            io_writes_handler = functools.partial(
+                self._perform_io_writes, filename)
+            io_future = controller.submit(io_writes_handler)
+            results = futures.wait([parts_future, io_future],
+                                   return_when=futures.FIRST_EXCEPTION)
+            assert not results[1], "wait() returned incomplete futures"
+            self._process_future_results(results[0])
+
+    def _process_future_results(self, futures):
+        for future in futures:
+            future.result()
+
+    def _download_file_as_future(self, bucket, key, filename, object_size,
+                                 callback):
         part_size = self._config.multipart_chunksize
         num_parts = int(math.ceil(object_size / float(part_size)))
         max_workers = self._config.max_concurrency
-        with self._os.open(filename, 'wb') as f:
-            thread_safe_fileobj = self._os.wrap_thread_safe_writer(f)
-            download_partial = functools.partial(
-                self._download_range, bucket, key, filename,
-                part_size, num_parts, callback, thread_safe_fileobj)
-            with self._executor_cls(max_workers=max_workers) as executor:
-                list(executor.map(download_partial, range(num_parts)))
+        download_partial = functools.partial(
+            self._download_range, bucket, key, filename,
+            part_size, num_parts, callback)
+        logger.debug("Starting download partials.")
+        with self._executor_cls(max_workers=max_workers) as executor:
+            list(executor.map(download_partial, range(num_parts)))
+        logger.debug("Done with download_partials.")
+        self._ioqueue.put(SHUTDOWN_SENTINEL)
+        logger.debug("Adding SHUTDOWN_SENTINEL to io queue.")
 
     def _download_range(self, bucket, key, filename,
-                        part_size, num_parts, callback, fileobj, i):
+                        part_size, num_parts, callback, i):
+        logger.debug("In _download_range.")
         start_range = i * part_size
         if i == num_parts - 1:
             end_range = ''
@@ -345,21 +376,38 @@ class MultipartDownloader(object):
             response['Body'], callback)
         buffer_size = 1024 * 16
         current_index = start_range
+        logger.debug("Starting: %s", i)
         for chunk in iter(lambda: streaming_body.read(buffer_size), b''):
-            fileobj.pwrite(chunk, current_index)
+            self._ioqueue.put((current_index, chunk))
             current_index += len(chunk)
+        logger.debug("Part done: %s", i)
+
+    def _perform_io_writes(self, filename):
+        with self._os.open(filename, 'wb') as f:
+            while True:
+                task = self._ioqueue.get()
+                if task is SHUTDOWN_SENTINEL:
+                    logger.debug("Shutdown sentinel received in IO handler, "
+                                "shutting down IO handler.")
+                    return
+                else:
+                    offset, data = task
+                    f.seek(offset)
+                    f.write(data)
 
 
 class TransferConfig(object):
     def __init__(self,
                  multipart_threshold=8 * MB,
-                 max_concurrency=2,
+                 max_concurrency=10,
                  multipart_chunksize=8 * MB,
-                 num_download_attempts=5):
+                 num_download_attempts=5,
+                 max_io_queue=100):
         self.multipart_threshold = multipart_threshold
         self.max_concurrency = max_concurrency
         self.multipart_chunksize = multipart_chunksize
         self.num_download_attempts = num_download_attempts
+        self.max_io_queue = max_io_queue
 
 
 class S3Transfer(object):

--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -1,0 +1,447 @@
+"""Abstractions over S3's upload/download operations.
+
+This module provides high level abstractions for efficient
+uploads/downloads.  It handles several things for the user:
+
+* Automatically switching to multipart transfers when
+  a file is over a specific size threshold
+* Uploading/downloading a file in parallel
+* Throttling based on max bandwidth
+* Progress callbacks to monitor transfers
+* Retries.  While botocore handles retries for streaming uploads,
+  it is not possible for it to handle retries for streaming
+  downloads.  This module handles retries for both cases so
+  you don't need to implement any retry logic yourself.
+
+This module has a reasonable set of defaults.  It also allows you
+to configure many aspects of the transfer process including:
+
+* Multipart threshold size
+* Max parallel downloads
+* Max bandwidth
+* Socket timeouts
+* Retry amounts
+
+There is no support for s3->s3 multipart copies at this
+time.
+
+
+Usage
+=====
+
+The simplest way to use this module is:
+
+.. code-block:: python
+
+    client = boto3.client('s3', 'us-west-2')
+    transfer = S3Transfer(client)
+    # Upload /tmp/myfile to s3://bucket/key
+    transfer.upload_file('/tmp/myfile', 'bucket', 'key')
+
+    # Download s3://bucket/key to /tmp/myfile
+    transfer.download_file('bucket', 'key', '/tmp/myfile')
+
+The ``upload_file`` and ``download_file`` methods also accept
+``**kwargs``, which will be forwarded through to the corresponding
+client operation.  Here are a few examples using ``upload_file``::
+
+    # Making the object public
+    transfer.upload_file('/tmp/myfile', 'bucket', 'key', ACL='public-read')
+
+    # Setting metadata
+    transfer.upload_file('/tmp/myfile', 'bucket', 'key',
+                         Metadata={'a': 'b', 'c': 'd'})
+
+    # Setting content type
+    transfer.upload_file('/tmp/myfile.json', 'bucket', 'key',
+                         ContentType="application/json")
+
+
+
+The ``S3Transfer`` clas also supports progress callbacks so you can
+provide transfer progress to users.  Both the ``upload_file`` and
+``download_file`` methods take an optional ``callback`` parameter.
+Here's an example of how to print a simple progress percentage
+to the user:
+
+.. code-block:: python
+
+    class ProgressPercentage(object):
+        def __init__(self, filename):
+            self._filename = filename
+            self._size = float(os.path.getsize(filename))
+            self._seen_so_far = 0
+            self._lock = threading.Lock()
+
+        def __call__(self, filename, bytes_amount):
+            # To simplify we'll assume this is hooked up
+            # to a single filename.
+            with self._lock:
+                self._seen_so_far += bytes_amount
+                percentage = (self._seen_so_far / self._size) * 100
+                sys.stdout.write(
+                    "\r%s  %s / %s  (%.2f%%)" % (filename, self._seen_so_far,
+                                                 self._size, percentage))
+                sys.stdout.flush()
+
+
+    transfer = S3Transfer(boto3.client('s3', 'us-west-2'))
+    # Upload /tmp/myfile to s3://bucket/key and print upload progress.
+    transfer.upload_file('/tmp/myfile', 'bucket', 'key',
+                         callback=ProgressPercentage('/tmp/myfile'))
+
+
+
+You can also provide an TransferConfig object to the S3Transfer
+object that gives you more fine grained control over the
+transfer.  For example:
+
+.. code-block:: python
+
+    client = boto3.client('s3', 'us-west-2')
+    config = TransferConfig(
+        multipart_threshold=8 * 1024 * 1024,
+        max_concurrency=10,
+        max_retries=10,
+        socket_timeout=120,
+    )
+    transfer = S3Transfer(client, config)
+    transfer.upload_file('/tmp/foo', 'bucket', 'key')
+
+
+"""
+import os
+import math
+import threading
+import functools
+import logging
+import socket
+from concurrent import futures
+
+from botocore.vendored.requests.packages.urllib3.exceptions import \
+    ReadTimeoutError
+from botocore.exceptions import IncompleteReadError
+
+from boto3.exceptions import RetriesExceededError
+
+
+logger = logging.getLogger(__name__)
+MB = 1024 * 1024
+
+
+class ReadFileChunk(object):
+    def __init__(self, fileobj, start_byte, chunk_size, full_file_size,
+                 callback=None):
+        """
+
+        Given a file object shown below:
+
+            |___________________________________________________|
+            0          |                 |                 full_file_size
+                       |----chunk_size---|
+                 start_byte
+
+        :type fileobj: file
+        :param fileobj: File like object
+
+        :type start_byte: int
+        :param start_byte: The first byte from which to start reading.
+
+        :type chunk_size: int
+        :param chunk_size: The max chunk size to read.  Trying to read
+            pass the end of the chunk size will behave like you've
+            reached the end of the file.
+
+        :type full_file_size: int
+        :param full_file_size: The entire content length associated
+            with ``fileobj``.
+
+        :type callback: function(amount_read)
+        :param callback: Called whenever data is read from this object.
+
+        """
+        self._fileobj = fileobj
+        self._start_byte = start_byte
+        self._size = self._calculate_file_size(
+            self._fileobj, requested_size=chunk_size,
+            start_byte=start_byte, actual_file_size=full_file_size)
+        self._fileobj.seek(self._start_byte)
+        self._amount_read = 0
+        self._callback = callback
+
+    @classmethod
+    def from_filename(cls, filename, start_byte, chunk_size, callback=None):
+        """Convenience factory function to create from a filename."""
+        f = open(filename, 'rb')
+        file_size = os.fstat(f.fileno()).st_size
+        return cls(f, start_byte, chunk_size, file_size, callback)
+
+    def _calculate_file_size(self, fileobj, requested_size, start_byte,
+                             actual_file_size):
+        max_chunk_size = actual_file_size - start_byte
+        return min(max_chunk_size, requested_size)
+
+    def read(self, amount=None):
+        if amount is None:
+            amount_to_read = self._size - self._amount_read
+        else:
+            amount_to_read = min(self._size - self._amount_read, amount)
+        data = self._fileobj.read(amount_to_read)
+        self._amount_read += len(data)
+        if self._callback is not None:
+            self._callback(len(data))
+        return data
+
+    def seek(self, where):
+        self._fileobj.seek(self._start_byte + where)
+        self._amount_read = where
+
+    def close(self):
+        self._fileobj.close()
+
+    def tell(self):
+        return self._amount_read
+
+    def __len__(self):
+        # __len__ is defined because requests will try to determine the length
+        # of the stream to set a content length.  In the normal case
+        # of the file it will just stat the file, but we need to change that
+        # behavior.  By providing a __len__, requests will use that instead
+        # of stat'ing the file.
+        return self._size
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.close()
+
+    def __iter__(self):
+        # This is a workaround for http://bugs.python.org/issue17575
+        # Basically httplib will try to iterate over the contents, even
+        # if its a file like object.  This wasn't noticed because we've
+        # already exhausted the stream so iterating over the file immediately
+        # steps, which is what we're simulating here.
+        return iter([])
+
+
+class StreamReaderProgress(object):
+    """Wrapper for a read only stream that adds progress callbacks."""
+    def __init__(self, stream, callback=None):
+        self._stream = stream
+        self._callback = callback
+
+    def read(self, *args, **kwargs):
+        value = self._stream.read(*args, **kwargs)
+        if self._callback is not None:
+            self._callback(len(value))
+        return value
+
+
+class ThreadSafeWriter(object):
+    def __init__(self, write_stream):
+        self._write_stream = write_stream
+        self._lock = threading.Lock()
+
+    def pwrite(self, data, offset):
+        with self._lock:
+            self._write_stream.seek(offset)
+            self._write_stream.write(data)
+
+    def close(self):
+        return self._write_stream.close()
+
+
+class OSUtils(object):
+    def get_file_size(self, filename):
+        return os.path.getsize(filename)
+
+    def open_file_chunk_reader(self, filename, start_byte, size, callback):
+        return ReadFileChunk.from_filename(filename, start_byte,
+                                           size, callback)
+
+    def open(self, filename, mode):
+        return open(filename, mode)
+
+    def wrap_stream_with_callback(self, stream, callback):
+        return StreamReaderProgress(stream, callback)
+
+    def wrap_thread_safe_writer(self, stream):
+        return ThreadSafeWriter(stream)
+
+
+class MultipartUploader(object):
+    def __init__(self, client, config, osutil,
+                 executor_cls=futures.ThreadPoolExecutor):
+        self._client = client
+        self._config = config
+        self._os = osutil
+        self._executor_cls = executor_cls
+
+    def upload_file(self, filename, bucket, key, callback, extra_args):
+        response = self._client.create_multipart_upload(Bucket=bucket,
+                                                        Key=key, **extra_args)
+        upload_id = response['UploadId']
+        parts = []
+        part_size = self._config.multipart_chunksize
+        num_parts = int(
+            math.ceil(self._os.get_file_size(filename) / float(part_size)))
+        max_workers = self._config.max_concurrency
+        with self._executor_cls(max_workers=max_workers) as executor:
+            upload_partial = functools.partial(
+                self._upload_one_part, filename, bucket, key, upload_id,
+                part_size, callback)
+            for part in executor.map(upload_partial, range(1, num_parts + 1)):
+                parts.append(part)
+        # Parts have to be ordered by part number.
+        parts.sort(key=lambda x: x['PartNumber'])
+        self._client.complete_multipart_upload(
+            Bucket=bucket, Key=key, UploadId=upload_id,
+            MultipartUpload={'Parts': parts})
+
+    def _upload_one_part(self, filename, bucket, key,
+                         upload_id, part_size, callback, part_number):
+        open_chunk_reader = self._os.open_file_chunk_reader
+        with open_chunk_reader(filename, part_size * (part_number - 1),
+                               part_size, callback) as body:
+            response = self._client.upload_part(
+                Bucket=bucket, Key=key,
+                UploadId=upload_id, PartNumber=part_number, Body=body)
+            etag = response['ETag']
+            return {'ETag': etag, 'PartNumber': part_number}
+
+
+class MultipartDownloader(object):
+    def __init__(self, client, config, osutil,
+                 executor_cls=futures.ThreadPoolExecutor):
+        self._client = client
+        self._config = config
+        self._os = osutil
+        self._executor_cls = executor_cls
+
+    def download_file(self, bucket, key, filename, object_size,
+                      callback=None):
+        part_size = self._config.multipart_chunksize
+        num_parts = int(math.ceil(object_size / float(part_size)))
+        max_workers = self._config.max_concurrency
+        with open(filename, 'wb') as f:
+            download_partial = functools.partial(
+                self._download_range, bucket, key, filename,
+                part_size, num_parts, callback, f)
+            with self._executor_cls(max_workers=max_workers) as executor:
+                list(executor.map(download_partial, range(num_parts)))
+
+    def _download_range(self, bucket, key, filename,
+                        part_size, num_parts, callback, fileobj, i):
+        start_range = i * part_size
+        if i == num_parts - 1:
+            end_range = ''
+        else:
+            end_range = start_range + part_size - 1
+        range_param = 'bytes=%s-%s' % (start_range, end_range)
+        response = self._client.get_object(
+            Bucket=bucket, Key=key, Range=range_param)
+        streaming_body = self._os.wrap_stream_with_callback(
+            response['Body'], callback)
+        buffer_size = 1024 * 16
+        current_index = start_range
+        safe_writer = self._os.wrap_thread_safe_writer(fileobj)
+        for chunk in iter(lambda: streaming_body.read(buffer_size), b''):
+            safe_writer.pwrite(chunk, current_index)
+            current_index += len(chunk)
+
+
+class TransferConfig(object):
+    def __init__(self,
+                 multipart_threshold=8 * MB,
+                 max_concurrency=1,
+                 multipart_chunksize=8 * MB,
+                 num_download_attempts=5):
+        self.multipart_threshold = multipart_threshold
+        self.max_concurrency = max_concurrency
+        self.multipart_chunksize = multipart_chunksize
+        self.num_download_attempts = num_download_attempts
+
+
+class S3Transfer(object):
+
+    def __init__(self, client, config=None, osutil=None):
+        self._client = client
+        if config is None:
+            config = TransferConfig()
+        self._config = config
+        if osutil is None:
+            osutil = OSUtils()
+        self._osutil = osutil
+
+    def upload_file(self, filename, bucket, key,
+                    callback=None, extra_args=None):
+        if extra_args is None:
+            extra_args = {}
+        if self._osutil.get_file_size(filename) >= \
+                self._config.multipart_threshold:
+            self._multipart_upload(filename, bucket, key, callback, extra_args)
+        else:
+            self._put_object(filename, bucket, key, callback, extra_args)
+
+    def _put_object(self, filename, bucket, key, callback, extra_args):
+        # We're using open_file_chunk_reader so we can take advantage of the
+        # progress callback functionality.
+        open_chunk_reader = self._osutil.open_file_chunk_reader
+        with open_chunk_reader(filename, 0,
+                               self._osutil.get_file_size(filename),
+                               callback=callback) as body:
+            self._client.put_object(Bucket=bucket, Key=key, Body=body,
+                                    **extra_args)
+
+    def download_file(self, bucket, key, filename, callback=None):
+        """Download an S3 object to a file.
+
+        This method will issue a ``head_object`` request to determine
+        the size of the S3 object.  This is used to determine if the
+        object is downloaded in parallel.
+
+        """
+        object_size = self._object_size(bucket, key)
+        if object_size >= self._config.multipart_threshold:
+            self._ranged_download(bucket, key, filename, object_size, callback)
+        else:
+            self._get_object(bucket, key, filename, callback)
+
+    def _ranged_download(self, bucket, key, filename, object_size, callback):
+        downloader = MultipartDownloader(self._client, self._config,
+                                         self._osutil)
+        downloader.download_file(bucket, key, filename, object_size,
+                                 callback)
+
+    def _get_object(self, bucket, key, filename, callback):
+        # precondition: num_download_attempts > 0
+        max_attempts = self._config.num_download_attempts
+        for i in range(max_attempts):
+            try:
+                return self._do_get_object(bucket, key, filename, callback)
+            except (socket.timeout, socket.error,
+                    ReadTimeoutError, IncompleteReadError) as e:
+                # TODO: we need a way to reset the callback if the
+                # download failed.
+                logger.debug("Retrying exception caught (%s), "
+                             "retrying request, (attempt %s / %s)", e, i,
+                             max_attempts, exc_info=True)
+                continue
+        raise RetriesExceededError(e)
+
+    def _do_get_object(self, bucket, key, filename, callback):
+        response = self._client.get_object(Bucket=bucket, Key=key)
+        streaming_body = self._osutil.wrap_stream_with_callback(
+            response['Body'], callback)
+        with self._osutil.open(filename, 'wb') as f:
+            for chunk in iter(lambda: streaming_body.read(8192), b''):
+                f.write(chunk)
+
+    def _object_size(self, bucket, key):
+        return self._client.head_object(
+            Bucket=bucket, Key=key)['ContentLength']
+
+    def _multipart_upload(self, filename, bucket, key, callback, extra_args):
+        uploader = MultipartUploader(self._client, self._config, self._osutil)
+        uploader.upload_file(filename, bucket, key, callback, extra_args)

--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -273,20 +273,6 @@ class StreamReaderProgress(object):
         return value
 
 
-class ThreadSafeWriter(object):
-    def __init__(self, write_stream):
-        self._write_stream = write_stream
-        self._lock = threading.Lock()
-
-    def pwrite(self, data, offset):
-        with self._lock:
-            self._write_stream.seek(offset)
-            self._write_stream.write(data)
-
-    def close(self):
-        return self._write_stream.close()
-
-
 class OSUtils(object):
     def get_file_size(self, filename):
         return os.path.getsize(filename)

--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -128,7 +128,6 @@ import functools
 import logging
 import socket
 from concurrent import futures
-import contextlib
 
 import six
 from botocore.vendored.requests.packages.urllib3.exceptions import \
@@ -400,7 +399,7 @@ class MultipartDownloader(object):
                 task = self._ioqueue.get()
                 if task is SHUTDOWN_SENTINEL:
                     logger.debug("Shutdown sentinel received in IO handler, "
-                                "shutting down IO handler.")
+                                 "shutting down IO handler.")
                     return
                 else:
                     offset, data = task

--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -46,16 +46,16 @@ The ``upload_file`` and ``download_file`` methods also accept
 client operation.  Here are a few examples using ``upload_file``::
 
     # Making the object public
-    transfer.upload_file('/tmp/myfile', 'bucket', 'key', ACL='public-read')
+    transfer.upload_file('/tmp/myfile', 'bucket', 'key',
+                         extra_args={'ACL': 'public-read'})
 
     # Setting metadata
     transfer.upload_file('/tmp/myfile', 'bucket', 'key',
-                         Metadata={'a': 'b', 'c': 'd'})
+                         extra_args={'Metadata': {'a': 'b', 'c': 'd'}})
 
     # Setting content type
     transfer.upload_file('/tmp/myfile.json', 'bucket', 'key',
-                         ContentType="application/json")
-
+                         extra_args={'ContentType': "application/json"})
 
 
 The ``S3Transfer`` clas also supports progress callbacks so you can
@@ -102,8 +102,7 @@ transfer.  For example:
     config = TransferConfig(
         multipart_threshold=8 * 1024 * 1024,
         max_concurrency=10,
-        max_retries=10,
-        socket_timeout=120,
+        num_download_attempts=10,
     )
     transfer = S3Transfer(client, config)
     transfer.upload_file('/tmp/foo', 'bucket', 'key')

--- a/requirements2.txt
+++ b/requirements2.txt
@@ -1,0 +1,4 @@
+# Python2 needs the concurrent.futures backport.
+# We handle this logic in setup.py but we need
+# a separate file to track this in our requirements file.
+futures==2.2.0

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ distutils/setuptools install script.
 """
 import os
 import re
+import sys
 
 try:
     from setuptools import setup
@@ -30,6 +31,12 @@ requires = [
     'bcdoc==0.12.2',
     'jmespath==0.6.1',
 ]
+
+if sys.version_info[0] == 2:
+    # concurrent.futures is only in python3, so for
+    # python2 we need to install the backport.
+    requires.append('futures==2.2.0')
+
 
 setup(
     name='boto3',

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -307,6 +307,7 @@ class TestS3Transfers(unittest.TestCase):
             '6mb.txt', filesize=6 * 1024 * 1024)
         transfer.upload_file(filename, self.bucket_name,
                              '6mb.txt', extra_args=extra_args)
+        self.addCleanup(self.delete_object, '6mb.txt')
         # A head object will fail if it has a customer key
         # associated with it and it's not provided in the HeadObject
         # request so we can use this to verify our functionality.

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -20,7 +20,7 @@ import shutil
 import hashlib
 
 from tests import unittest, unique_id
-from botocore.vendored import six
+from botocore.compat import six
 
 import boto3.session
 import boto3.s3.transfer
@@ -245,11 +245,14 @@ class TestS3Transfers(unittest.TestCase):
                                 Key=key)
         return True
 
-    def create_s3_transfer(self):
-        return boto3.s3.transfer.S3Transfer(self.client)
+    def create_s3_transfer(self, config=None):
+        return boto3.s3.transfer.S3Transfer(self.client,
+                                            config=config)
 
     def test_upload_below_threshold(self):
-        transfer = self.create_s3_transfer()
+        config = boto3.s3.transfer.TransferConfig(
+            multipart_threshold=2 * 1024 * 1024)
+        transfer = self.create_s3_transfer(config)
         filename = self.files.create_file_with_size(
             'foo.txt', filesize=1024 * 1024)
         transfer.upload_file(filename, self.bucket_name,
@@ -259,7 +262,9 @@ class TestS3Transfers(unittest.TestCase):
         self.assertTrue(self.object_exists('foo.txt'))
 
     def test_upload_above_threshold(self):
-        transfer = self.create_s3_transfer()
+        config = boto3.s3.transfer.TransferConfig(
+            multipart_threshold=2 * 1024 * 1024)
+        transfer = self.create_s3_transfer(config)
         filename = self.files.create_file_with_size(
             '20mb.txt', filesize=20 * 1024 * 1024)
         transfer.upload_file(filename, self.bucket_name,
@@ -307,7 +312,7 @@ class TestS3Transfers(unittest.TestCase):
         config = boto3.s3.transfer.TransferConfig(
             multipart_threshold=6 * 1024 * 1024
         )
-        transfer = boto3.s3.transfer.S3Transfer(self.client, config)
+        transfer = self.create_s3_transfer(config)
         filename = self.files.create_file_with_size(
             'foo.txt', filesize=8 * 1024 * 1024)
         transfer.upload_file(filename, self.bucket_name,

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -10,10 +10,108 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-
-import boto3.session
+import os
+import threading
+import math
+import time
+import random
+import tempfile
+import shutil
+import hashlib
 
 from tests import unittest, unique_id
+from botocore.vendored import six
+
+import boto3.session
+import boto3.s3.transfer
+
+
+urlopen = six.moves.urllib.request.urlopen
+
+
+def assert_files_equal(first, second):
+    if os.path.getsize(first) != os.path.getsize(second):
+        raise AssertionError("Files are not equal: %s, %s" % (first, second))
+    first_md5 = md5_checksum(first)
+    second_md5 = md5_checksum(second)
+    if first_md5 != second_md5:
+        raise AssertionError(
+            "Files are not equal: %s(md5=%s) != %s(md5=%s)" % (
+                first, first_md5, second, second_md5))
+
+
+def md5_checksum(filename):
+    checksum = hashlib.md5()
+    with open(filename, 'rb') as f:
+        for chunk in iter(lambda: f.read(8192), b''):
+            checksum.update(chunk)
+    return checksum.hexdigest()
+
+
+class FileCreator(object):
+    def __init__(self):
+        self.rootdir = tempfile.mkdtemp()
+
+    def remove_all(self):
+        shutil.rmtree(self.rootdir)
+
+    def create_file(self, filename, contents, mtime=None, mode='w'):
+        """Creates a file in a tmpdir
+
+        ``filename`` should be a relative path, e.g. "foo/bar/baz.txt"
+        It will be translated into a full path in a tmp dir.
+
+        If the ``mtime`` argument is provided, then the file's
+        mtime will be set to the provided value (must be an epoch time).
+        Otherwise the mtime is left untouched.
+
+        ``mode`` is the mode the file should be opened either as ``w`` or
+        `wb``.
+
+        Returns the full path to the file.
+
+        """
+        full_path = os.path.join(self.rootdir, filename)
+        if not os.path.isdir(os.path.dirname(full_path)):
+            os.makedirs(os.path.dirname(full_path))
+        with open(full_path, mode) as f:
+            f.write(contents)
+        current_time = os.path.getmtime(full_path)
+        # Subtract a few years off the last modification date.
+        os.utime(full_path, (current_time, current_time - 100000000))
+        if mtime is not None:
+            os.utime(full_path, (mtime, mtime))
+        return full_path
+
+    def create_file_with_size(self, filename, filesize):
+        filename = self.create_file(filename, contents='')
+        chunksize = 8192
+        with open(filename, 'wb') as f:
+            for i in range(int(math.ceil(filesize / float(chunksize)))):
+                f.write(b'a' * chunksize)
+        return filename
+
+    def append_file(self, filename, contents):
+        """Append contents to a file
+
+        ``filename`` should be a relative path, e.g. "foo/bar/baz.txt"
+        It will be translated into a full path in a tmp dir.
+
+        Returns the full path to the file.
+        """
+        full_path = os.path.join(self.rootdir, filename)
+        if not os.path.isdir(os.path.dirname(full_path)):
+            os.makedirs(os.path.dirname(full_path))
+        with open(full_path, 'a') as f:
+            f.write(contents)
+        return full_path
+
+    def full_path(self, filename):
+        """Translate relative path to full path in temp dir.
+
+        f.full_path('foo/bar.txt') -> /tmp/asdfasd/foo/bar.txt
+        """
+        return os.path.join(self.rootdir, filename)
 
 
 class TestS3Resource(unittest.TestCase):
@@ -74,7 +172,6 @@ class TestS3Resource(unittest.TestCase):
         self.assertIn(self.bucket_name,
                       [b.name for b in self.s3.buckets.all()])
 
-
         # Create an object
         obj = bucket.Object('test.txt')
         obj.put(
@@ -121,3 +218,146 @@ class TestS3Resource(unittest.TestCase):
 
         contents = bucket.Object('mp-test.txt').get()['Body'].read()
         self.assertEqual(contents, b'hello, world!')
+
+
+class TestS3Transfers(unittest.TestCase):
+    """Tests for the high level boto3.s3.transfer module."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.region = 'us-west-2'
+        cls.session = boto3.session.Session(region_name=cls.region)
+        cls.client = cls.session.client('s3', cls.region)
+        cls.bucket_name = 'boto3-integ-transfer-%s-%s' % (
+            int(time.time()), random.randint(1, 100))
+        cls.client.create_bucket(
+            Bucket=cls.bucket_name,
+            CreateBucketConfiguration={'LocationConstraint': cls.region})
+
+    def setUp(self):
+        self.files = FileCreator()
+
+    def tearDown(self):
+        self.files.remove_all()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.client.delete_bucket(Bucket=cls.bucket_name)
+
+    def delete_object(self, key):
+        self.client.delete_object(
+            Bucket=self.bucket_name,
+            Key=key)
+
+    def object_exists(self, key):
+        self.client.head_object(Bucket=self.bucket_name,
+                                Key=key)
+        return True
+
+    def create_s3_transfer(self):
+        return boto3.s3.transfer.S3Transfer(self.client)
+
+    def test_upload_below_threshold(self):
+        transfer = self.create_s3_transfer()
+        filename = self.files.create_file_with_size(
+            'foo.txt', filesize=1024 * 1024)
+        transfer.upload_file(filename, self.bucket_name,
+                             'foo.txt')
+        self.addCleanup(self.delete_object, 'foo.txt')
+
+        self.assertTrue(self.object_exists('foo.txt'))
+
+    def test_upload_above_threshold(self):
+        transfer = self.create_s3_transfer()
+        filename = self.files.create_file_with_size(
+            '20mb.txt', filesize=20 * 1024 * 1024)
+        transfer.upload_file(filename, self.bucket_name,
+                             '20mb.txt')
+        self.addCleanup(self.delete_object, '20mb.txt')
+        self.assertTrue(self.object_exists('20mb.txt'))
+
+    def test_progress_callback_on_upload(self):
+        self.amount_seen = 0
+        lock = threading.Lock()
+
+        def progress_callback(amount):
+            with lock:
+                self.amount_seen += amount
+
+        transfer = self.create_s3_transfer()
+        filename = self.files.create_file_with_size(
+            '20mb.txt', filesize=20 * 1024 * 1024)
+        transfer.upload_file(filename, self.bucket_name,
+                             '20mb.txt', callback=progress_callback)
+        self.addCleanup(self.delete_object, '20mb.txt')
+
+        # The callback should have been called enough times such that
+        # the total amount of bytes we've seen (via the "amount"
+        # arg to the callback function) should be the size
+        # of the file we uploaded.
+        self.assertEqual(self.amount_seen, 20 * 1024 * 1024)
+
+    def test_can_send_extra_params_on_upload(self):
+        pass
+
+    def test_can_configure_threshold(self):
+        config = boto3.s3.transfer.TransferConfig(
+            multipart_threshold=6 * 1024 * 1024
+        )
+        transfer = boto3.s3.transfer.S3Transfer(self.client, config)
+        filename = self.files.create_file_with_size(
+            'foo.txt', filesize=8 * 1024 * 1024)
+        transfer.upload_file(filename, self.bucket_name,
+                             'foo.txt')
+        self.addCleanup(self.delete_object, 'foo.txt')
+
+        self.assertTrue(self.object_exists('foo.txt'))
+
+    def test_can_send_extra_params_on_download(self):
+        transfer = self.create_s3_transfer()
+        extra_args = {'ACL': 'public-read'}
+        filename = self.files.create_file_with_size(
+            'foo.txt', filesize=1024 * 1024)
+        transfer.upload_file(filename, self.bucket_name,
+                             'foo.txt', extra_args=extra_args)
+        self.addCleanup(self.delete_object, 'foo.txt')
+
+        self.assertTrue(self.object_exists('foo.txt'))
+        # TODO: Verify we can download the object
+        # I'd like to create an anonymous client in boto3, but that doesn't
+        # appear possible.
+
+    def test_progress_callback_on_download(self):
+        pass
+
+    def test_download_below_threshold(self):
+        transfer = self.create_s3_transfer()
+
+        filename = self.files.create_file_with_size(
+            'foo.txt', filesize=1024 * 1024)
+        with open(filename, 'rb') as f:
+            self.client.put_object(Bucket=self.bucket_name,
+                                   Key='foo.txt',
+                                   Body=f)
+            self.addCleanup(self.delete_object, 'foo.txt')
+
+        download_path = os.path.join(self.files.rootdir, 'downloaded.txt')
+        transfer.download_file(self.bucket_name, 'foo.txt',
+                               download_path)
+        assert_files_equal(filename, download_path)
+
+    def test_download_above_threshold(self):
+        transfer = self.create_s3_transfer()
+
+        filename = self.files.create_file_with_size(
+            'foo.txt', filesize=20 * 1024 * 1024)
+        with open(filename, 'rb') as f:
+            self.client.put_object(Bucket=self.bucket_name,
+                                   Key='foo.txt',
+                                   Body=f)
+            self.addCleanup(self.delete_object, 'foo.txt')
+
+        download_path = os.path.join(self.files.rootdir, 'downloaded.txt')
+        transfer.download_file(self.bucket_name, 'foo.txt',
+                               download_path)
+        assert_files_equal(filename, download_path)

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -55,15 +55,11 @@ class FileCreator(object):
     def remove_all(self):
         shutil.rmtree(self.rootdir)
 
-    def create_file(self, filename, contents, mtime=None, mode='w'):
+    def create_file(self, filename, contents, mode='w'):
         """Creates a file in a tmpdir
 
         ``filename`` should be a relative path, e.g. "foo/bar/baz.txt"
         It will be translated into a full path in a tmp dir.
-
-        If the ``mtime`` argument is provided, then the file's
-        mtime will be set to the provided value (must be an epoch time).
-        Otherwise the mtime is left untouched.
 
         ``mode`` is the mode the file should be opened either as ``w`` or
         `wb``.
@@ -76,11 +72,6 @@ class FileCreator(object):
             os.makedirs(os.path.dirname(full_path))
         with open(full_path, mode) as f:
             f.write(contents)
-        current_time = os.path.getmtime(full_path)
-        # Subtract a few years off the last modification date.
-        os.utime(full_path, (current_time, current_time - 100000000))
-        if mtime is not None:
-            os.utime(full_path, (mtime, mtime))
         return full_path
 
     def create_file_with_size(self, filename, filesize):

--- a/tests/unit/s3/test_transfer.py
+++ b/tests/unit/s3/test_transfer.py
@@ -134,14 +134,6 @@ class TestOSUtils(unittest.TestCase):
         fileobj = OSUtils().open(os.path.join(self.tempdir, 'foo'), 'w')
         self.assertTrue(hasattr(fileobj, 'write'))
 
-    def test_wrap_thread_safe_writer(self):
-        wrapped = OSUtils().wrap_thread_safe_writer(None)
-        self.assertIsInstance(wrapped, ThreadSafeWriter)
-
-    def test_wrap_stream_with_callback(self):
-        wrapped = OSUtils().wrap_stream_with_callback(None, None)
-        self.assertIsInstance(wrapped, StreamReaderProgress)
-
 
 class TestReadFileChunk(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/s3/test_transfer.py
+++ b/tests/unit/s3/test_transfer.py
@@ -358,6 +358,14 @@ class TestS3Transfer(unittest.TestCase):
             transfer.download_file('bucket', 'key', '/tmp/smallfile',
                                    extra_args={'BadValue': 'foo'})
 
+    def test_upload_file_with_invalid_extra_args(self):
+        osutil = InMemoryOSLayer({})
+        transfer = S3Transfer(self.client, osutil=osutil)
+        bad_args = {"WebsiteRedirectLocation": "/foo"}
+        with self.assertRaises(ValueError):
+            transfer.upload_file('bucket', 'key', '/tmp/smallfile',
+                                  extra_args=bad_args)
+
     def test_download_file_fowards_extra_args(self):
         extra_args = {
             'SSECustomerKey': 'foo',

--- a/tests/unit/s3/test_transfer.py
+++ b/tests/unit/s3/test_transfer.py
@@ -20,6 +20,7 @@ from contextlib import closing
 import mock
 from botocore.vendored import six
 from botocore.client import BaseClient
+from concurrent import futures
 
 from boto3.exceptions import RetriesExceededError
 from boto3.s3.transfer import ReadFileChunk, StreamReaderProgress
@@ -37,7 +38,6 @@ class InMemoryOSLayer(OSUtils):
         return len(self._filemap[filename])
 
     def open_file_chunk_reader(self, filename, start_byte, size, callback):
-        # TODO: handle the case for partial reads.
         return closing(six.BytesIO(self._filemap[filename]))
 
     def open(self, filename, mode):
@@ -66,6 +66,11 @@ class SequentialExecutor(object):
         for arg in args:
             results.append(function(arg))
         return results
+
+    def submit(self, function):
+        future = futures.Future()
+        future.set_result(function())
+        return future
 
 
 class TestThreadSafeWriter(unittest.TestCase):

--- a/tests/unit/s3/test_transfer.py
+++ b/tests/unit/s3/test_transfer.py
@@ -1,0 +1,446 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the 'license' file accompanying this file. This file is
+# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import os
+import tempfile
+import shutil
+import socket
+from tests import unittest
+from contextlib import closing
+
+import mock
+from botocore.vendored import six
+from botocore.client import BaseClient
+
+from boto3.exceptions import RetriesExceededError
+from boto3.s3.transfer import ReadFileChunk, StreamReaderProgress
+from boto3.s3.transfer import S3Transfer
+from boto3.s3.transfer import OSUtils, TransferConfig
+from boto3.s3.transfer import ThreadSafeWriter
+from boto3.s3.transfer import MultipartDownloader, MultipartUploader
+
+
+class InMemoryOSLayer(OSUtils):
+    def __init__(self, filemap):
+        self._filemap = filemap
+
+    def get_file_size(self, filename):
+        return len(self._filemap[filename])
+
+    def open_file_chunk_reader(self, filename, start_byte, size, callback):
+        # TODO: handle the case for partial reads.
+        return closing(six.BytesIO(self._filemap[filename]))
+
+    def open(self, filename, mode):
+        if 'wb' in mode:
+            fileobj = six.BytesIO()
+            self._filemap = fileobj
+            return closing(fileobj)
+        else:
+            return closing(self._filemap[filename])
+
+
+class SequentialExecutor(object):
+    def __init__(self, max_workers):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        pass
+
+    # The real map() interface actually takes *args, but we specifically do
+    # _not_ use this interface.
+    def map(self, function, args):
+        results = []
+        for arg in args:
+            results.append(function(arg))
+        return results
+
+
+class TestThreadSafeWriter(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+        self.filename = os.path.join(self.tempdir, 'foo')
+        self.fileobj = open(self.filename, 'w')
+
+    def tearDown(self):
+        self.fileobj.close()
+        shutil.rmtree(self.tempdir)
+
+    def test_pwrite_to_beginning_of_file(self):
+        # We're not actually interested in unit testing the threading logic
+        # via a unit test.  Any concurrency issues will crop up in integration
+        # tests.
+        writer = ThreadSafeWriter(self.fileobj)
+        writer.pwrite('foobar', 0)
+        self.fileobj.flush()
+        with open(self.filename, 'r') as f:
+            self.assertEqual(f.read(), 'foobar')
+        writer.close()
+
+    def test_pwrite_to_offset_not_at_start(self):
+        writer = ThreadSafeWriter(self.fileobj)
+        writer.pwrite('foobar', 5)
+        self.fileobj.flush()
+        with open(self.filename, 'r') as f:
+            # Because we used an offset of 5 above, we should have
+            # the first 5 bytes filled with 0.
+            self.assertEqual(
+                f.read(), '\x00\x00\x00\x00\x00foobar')
+
+    def test_multiple_pwrite_calls(self):
+        writer = ThreadSafeWriter(self.fileobj)
+        writer.pwrite('first', 8)
+        writer.pwrite('second', 1)
+        self.fileobj.flush()
+        with open(self.filename, 'r') as f:
+            self.assertEqual(f.read(), '\x00second\x00first')
+
+
+class TestOSUtils(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    def test_get_file_size(self):
+        with mock.patch('os.path.getsize') as m:
+            OSUtils().get_file_size('myfile')
+            m.assert_called_with('myfile')
+
+    def test_open_file_chunk_reader(self):
+        with mock.patch('boto3.s3.transfer.ReadFileChunk') as m:
+            OSUtils().open_file_chunk_reader('myfile', 0, 100, None)
+            m.from_filename.assert_called_with('myfile', 0, 100, None)
+
+    def test_open_file(self):
+        fileobj = OSUtils().open(os.path.join(self.tempdir, 'foo'), 'w')
+        self.assertTrue(hasattr(fileobj, 'write'))
+
+    def test_wrap_thread_safe_writer(self):
+        wrapped = OSUtils().wrap_thread_safe_writer(None)
+        self.assertIsInstance(wrapped, ThreadSafeWriter)
+
+    def test_wrap_stream_with_callback(self):
+        wrapped = OSUtils().wrap_stream_with_callback(None, None)
+        self.assertIsInstance(wrapped, StreamReaderProgress)
+
+
+class TestReadFileChunk(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    def test_read_entire_chunk(self):
+        filename = os.path.join(self.tempdir, 'foo')
+        f = open(filename, 'wb')
+        f.write(b'onetwothreefourfivesixseveneightnineten')
+        f.flush()
+        chunk = ReadFileChunk.from_filename(
+            filename, start_byte=0, chunk_size=3)
+        self.assertEqual(chunk.read(), b'one')
+        self.assertEqual(chunk.read(), b'')
+
+    def test_read_with_amount_size(self):
+        filename = os.path.join(self.tempdir, 'foo')
+        f = open(filename, 'wb')
+        f.write(b'onetwothreefourfivesixseveneightnineten')
+        f.flush()
+        chunk = ReadFileChunk.from_filename(
+            filename, start_byte=11, chunk_size=4)
+        self.assertEqual(chunk.read(1), b'f')
+        self.assertEqual(chunk.read(1), b'o')
+        self.assertEqual(chunk.read(1), b'u')
+        self.assertEqual(chunk.read(1), b'r')
+        self.assertEqual(chunk.read(1), b'')
+
+    def test_reset_stream_emulation(self):
+        filename = os.path.join(self.tempdir, 'foo')
+        f = open(filename, 'wb')
+        f.write(b'onetwothreefourfivesixseveneightnineten')
+        f.flush()
+        chunk = ReadFileChunk.from_filename(
+            filename, start_byte=11, chunk_size=4)
+        self.assertEqual(chunk.read(), b'four')
+        chunk.seek(0)
+        self.assertEqual(chunk.read(), b'four')
+
+    def test_read_past_end_of_file(self):
+        filename = os.path.join(self.tempdir, 'foo')
+        f = open(filename, 'wb')
+        f.write(b'onetwothreefourfivesixseveneightnineten')
+        f.flush()
+        chunk = ReadFileChunk.from_filename(
+            filename, start_byte=36, chunk_size=100000)
+        self.assertEqual(chunk.read(), b'ten')
+        self.assertEqual(chunk.read(), b'')
+        self.assertEqual(len(chunk), 3)
+
+    def test_tell_and_seek(self):
+        filename = os.path.join(self.tempdir, 'foo')
+        f = open(filename, 'wb')
+        f.write(b'onetwothreefourfivesixseveneightnineten')
+        f.flush()
+        chunk = ReadFileChunk.from_filename(
+            filename, start_byte=36, chunk_size=100000)
+        self.assertEqual(chunk.tell(), 0)
+        self.assertEqual(chunk.read(), b'ten')
+        self.assertEqual(chunk.tell(), 3)
+        chunk.seek(0)
+        self.assertEqual(chunk.tell(), 0)
+
+    def test_callback_is_invoked_on_read(self):
+        filename = os.path.join(self.tempdir, 'foo')
+        f = open(filename, 'wb')
+        f.write(b'abc')
+        f.flush()
+        amounts_seen = []
+        def callback(amount):
+            amounts_seen.append(amount)
+        chunk = ReadFileChunk.from_filename(
+            filename, start_byte=0, chunk_size=3, callback=callback)
+        chunk.read(1)
+        chunk.read(1)
+        chunk.read(1)
+
+        self.assertEqual(amounts_seen, [1, 1, 1])
+
+    def test_file_chunk_supports_context_manager(self):
+        filename = os.path.join(self.tempdir, 'foo')
+        f = open(filename, 'wb')
+        f.write(b'abc')
+        f.flush()
+        with ReadFileChunk.from_filename(filename,
+                                         start_byte=0,
+                                         chunk_size=2) as chunk:
+            val = chunk.read()
+            self.assertEqual(val, b'ab')
+
+    def test_iter_is_always_empty(self):
+        # This tests the workaround for the httplib bug (see
+        # the source for more info).
+        filename = os.path.join(self.tempdir, 'foo')
+        f = open(filename, 'wb').close()
+        chunk = ReadFileChunk.from_filename(
+            filename, start_byte=0, chunk_size=10)
+        self.assertEqual(list(chunk), [])
+
+
+class TestStreamReaderProgress(unittest.TestCase):
+
+    def test_proxies_to_wrapped_stream(self):
+        original_stream = six.StringIO('foobarbaz')
+        wrapped = StreamReaderProgress(original_stream)
+        self.assertEqual(wrapped.read(), 'foobarbaz')
+
+    def test_callback_invoked(self):
+        amounts_seen = []
+        def callback(amount):
+            amounts_seen.append(amount)
+        original_stream = six.StringIO('foobarbaz')
+        wrapped = StreamReaderProgress(original_stream, callback)
+        self.assertEqual(wrapped.read(), 'foobarbaz')
+        self.assertEqual(amounts_seen, [9])
+
+
+class TestMultipartUploader(unittest.TestCase):
+    def test_multipart_upload_uses_correct_client_calls(self):
+        client = mock.Mock()
+        uploader = MultipartUploader(client, TransferConfig(),
+                                     InMemoryOSLayer({'filename': b'foobar'}), SequentialExecutor)
+        client.create_multipart_upload.return_value = {'UploadId': 'upload_id'}
+        client.upload_part.return_value = {'ETag': 'first'}
+
+        uploader.upload_file('filename', 'bucket', 'key', None, {})
+
+
+        # We need to check both the sequence of calls (create/upload/complete)
+        # as well as the params passed between the calls, including
+        # 1. The upload_id was plumbed through
+        # 2. The collected etags were added to the complete call.
+        client.create_multipart_upload.assert_called_with(
+            Bucket='bucket', Key='key')
+        # Should be two parts.
+        client.upload_part.assert_called_with(
+            Body=mock.ANY, Bucket='bucket',
+            UploadId='upload_id', Key='key', PartNumber=1)
+        client.complete_multipart_upload.assert_called_with(
+            MultipartUpload={'Parts': [{'PartNumber': 1, 'ETag': 'first'}]},
+            Bucket='bucket',
+            UploadId='upload_id',
+            Key='key')
+
+
+class TestMultipartDownloader(unittest.TestCase):
+    def test_multipart_download_uses_correct_client_calls(self):
+        client = mock.Mock()
+        response_body = b'foobarbaz'
+        client.get_object.return_value = {'Body': six.BytesIO(response_body)}
+
+
+        downloader = MultipartDownloader(client, TransferConfig(),
+                                         InMemoryOSLayer({}),
+                                         SequentialExecutor)
+        downloader.download_file('bucket', 'key', 'filename', len(response_body))
+
+        client.get_object.assert_called_with(
+            Range='bytes=0-',
+            Bucket='bucket',
+            Key='key'
+        )
+
+    def test_multipart_download_with_multiple_parts(self):
+        client = mock.Mock()
+        response_body = b'foobarbaz'
+        client.get_object.return_value = {'Body': six.BytesIO(response_body)}
+        # For testing purposes, we're testing with a multipart threshold
+        # of 4 bytes and a chunksize of 4 bytes.  Given b'foobarbaz',
+        # this should result in 3 calls.  In python slices this would be:
+        # r[0:4], r[4:8], r[8:9].  But the Range param will be slightly
+        # different because they use inclusive ranges.
+        config = TransferConfig(multipart_threshold=4,
+                                multipart_chunksize=4)
+
+        downloader = MultipartDownloader(client, config,
+                                         InMemoryOSLayer({}),
+                                         SequentialExecutor)
+        downloader.download_file('bucket', 'key', 'filename', len(response_body))
+
+        # We're storing these in **extra because the assertEqual
+        # below is really about verifying we have the correct value
+        # for the Range param.
+        extra = {'Bucket': 'bucket', 'Key': 'key'}
+        self.assertEqual(client.get_object.call_args_list,
+                         # Note these are inclusive ranges.
+                         [mock.call(Range='bytes=0-3', **extra),
+                          mock.call(Range='bytes=4-7', **extra),
+                          mock.call(Range='bytes=8-', **extra)])
+
+    def test_retry_on_failures_from_stream_reads(self):
+        # If we get an exception during a call to the response body's .read()
+        # method, we should retry the request.
+        pass
+
+
+class TestS3Transfer(unittest.TestCase):
+    def setUp(self):
+        self.client = mock.Mock()
+
+    def test_upload_below_multipart_threshold_uses_put_object(self):
+        below_multipart_threshold = 10
+        fake_files = {
+            'smallfile': b'foobar',
+        }
+        osutil = InMemoryOSLayer(fake_files)
+        transfer = S3Transfer(self.client, osutil=osutil)
+        transfer.upload_file('smallfile', 'bucket', 'key')
+        self.client.put_object.assert_called_with(
+            Bucket='bucket', Key='key', Body=mock.ANY
+        )
+
+    def test_extra_args_on_uploaded_passed_to_api_call(self):
+        below_multipart_threshold = 10
+        extra_args = {'ACL': 'public-read'}
+        fake_files = {
+            'smallfile': b'hello world'
+        }
+        osutil = InMemoryOSLayer(fake_files)
+        transfer = S3Transfer(self.client, osutil=osutil)
+        transfer.upload_file('smallfile', 'bucket', 'key',
+                             extra_args=extra_args)
+        self.client.put_object.assert_called_with(
+            Bucket='bucket', Key='key', Body=mock.ANY,
+            ACL='public-read'
+        )
+
+    def test_uses_multipart_upload_when_over_threshold(self):
+        with mock.patch('boto3.s3.transfer.MultipartUploader') as uploader:
+            fake_files = {
+                'smallfile': b'foobar',
+            }
+            osutil = InMemoryOSLayer(fake_files)
+            config = TransferConfig(multipart_threshold=2,
+                                    multipart_chunksize=2)
+            transfer = S3Transfer(self.client, osutil=osutil, config=config)
+            transfer.upload_file('smallfile', 'bucket', 'key')
+
+            uploader.return_value.upload_file.assert_called_with(
+                'smallfile', 'bucket', 'key', None, {})
+
+    def test_uses_multipart_download_when_over_threshold(self):
+        with mock.patch('boto3.s3.transfer.MultipartDownloader') as downloader:
+            osutil = InMemoryOSLayer({})
+            over_multipart_threshold = 100 * 1024 * 1024
+            transfer = S3Transfer(self.client, osutil=osutil)
+            callback = mock.sentinel.CALLBACK
+            self.client.head_object.return_value = {
+                'ContentLength': over_multipart_threshold,
+            }
+            transfer.download_file('bucket', 'key', 'filename',
+                                   callback=callback)
+
+            downloader.return_value.download_file.assert_called_with(
+                'bucket', 'key', 'filename', over_multipart_threshold,
+                callback)
+
+    def test_get_object_stream_is_retried_and_succeeds(self):
+        below_threshold = 20
+        osutil = InMemoryOSLayer({'smallfile': b'hello world'})
+        transfer = S3Transfer(self.client, osutil=osutil)
+        self.client.head_object.return_value = {
+            'ContentLength': below_threshold}
+        self.client.get_object.side_effect = [
+            # First request fails.
+            socket.error("fake error"),
+            # Second succeeds.
+            {'Body': six.BytesIO(b'foobar')}
+        ]
+        transfer.download_file('bucket', 'key', '/tmp/smallfile')
+
+        self.assertEqual(self.client.get_object.call_count, 2)
+
+    def test_get_object_stream_uses_all_retries_and_errors_out(self):
+        below_threshold = 20
+        osutil = InMemoryOSLayer({'smallfile': b'hello world'})
+        transfer = S3Transfer(self.client, osutil=osutil)
+        self.client.head_object.return_value = {
+            'ContentLength': below_threshold}
+        # Here we're raising an exception every single time, which
+        # will exhaust our retry count and propogate a
+        # RetriesExceededError.
+        self.client.get_object.side_effect = socket.error("fake error")
+        with self.assertRaises(RetriesExceededError):
+            transfer.download_file('bucket', 'key', '/tmp/smallfile')
+
+        self.assertEqual(self.client.get_object.call_count, 5)
+
+    def test_download_below_multipart_threshold(self):
+        below_threshold = 20
+        osutil = InMemoryOSLayer({'smallfile': b'hello world'})
+        transfer = S3Transfer(self.client, osutil=osutil)
+        self.client.head_object.return_value = {
+            'ContentLength': below_threshold}
+        self.client.get_object.return_value = {
+            'Body': six.BytesIO(b'foobar')
+        }
+        transfer.download_file('bucket', 'key', '/tmp/smallfile')
+
+        self.client.get_object.assert_called_with(Bucket='bucket', Key='key')
+
+    def test_can_create_with_just_client(self):
+        transfer = S3Transfer(client=mock.Mock())
+        self.assertIsInstance(transfer, S3Transfer)

--- a/tests/unit/s3/test_transfer.py
+++ b/tests/unit/s3/test_transfer.py
@@ -415,7 +415,7 @@ class TestMultipartDownloader(unittest.TestCase):
                                          SequentialExecutor)
         with self.assertRaises(RetriesExceededError):
             downloader.download_file('bucket', 'key', 'filename',
-                                    len(response_body), {})
+                                     len(response_body), {})
 
     def test_io_thread_failure_triggers_shutdown(self):
         client = mock.Mock()
@@ -433,11 +433,9 @@ class TestMultipartDownloader(unittest.TestCase):
         # propogates back up via download_file().
         with self.assertRaisesRegexp(Exception, "fake IO error"):
             downloader.download_file('bucket', 'key', 'filename',
-                                    len(response_body), {})
+                                     len(response_body), {})
 
     def test_download_futures_fail_triggers_shutdown(self):
-        fake_io_error = Exception("fake IO error")
-
         class FailedDownloadParts(SequentialExecutor):
             def __init__(self, max_workers):
                 self.is_first = True
@@ -446,7 +444,8 @@ class TestMultipartDownloader(unittest.TestCase):
                 future = super(FailedDownloadParts, self).submit(function)
                 if self.is_first:
                     # This is the download_parts_thread.
-                    future.set_exception(Exception("fake download parts error"))
+                    future.set_exception(
+                        Exception("fake download parts error"))
                     self.is_first = False
                 return future
 
@@ -459,7 +458,7 @@ class TestMultipartDownloader(unittest.TestCase):
                                          FailedDownloadParts)
         with self.assertRaisesRegexp(Exception, "fake download parts error"):
             downloader.download_file('bucket', 'key', 'filename',
-                                    len(response_body), {})
+                                     len(response_body), {})
 
 
 class TestS3Transfer(unittest.TestCase):
@@ -545,7 +544,7 @@ class TestS3Transfer(unittest.TestCase):
         bad_args = {"WebsiteRedirectLocation": "/foo"}
         with self.assertRaises(ValueError):
             transfer.upload_file('bucket', 'key', '/tmp/smallfile',
-                                  extra_args=bad_args)
+                                 extra_args=bad_args)
 
     def test_download_file_fowards_extra_args(self):
         extra_args = {

--- a/tests/unit/s3/test_transfer.py
+++ b/tests/unit/s3/test_transfer.py
@@ -152,9 +152,8 @@ class TestReadFileChunk(unittest.TestCase):
 
     def test_read_entire_chunk(self):
         filename = os.path.join(self.tempdir, 'foo')
-        f = open(filename, 'wb')
-        f.write(b'onetwothreefourfivesixseveneightnineten')
-        f.flush()
+        with open(filename, 'wb') as f:
+            f.write(b'onetwothreefourfivesixseveneightnineten')
         chunk = ReadFileChunk.from_filename(
             filename, start_byte=0, chunk_size=3)
         self.assertEqual(chunk.read(), b'one')
@@ -162,9 +161,8 @@ class TestReadFileChunk(unittest.TestCase):
 
     def test_read_with_amount_size(self):
         filename = os.path.join(self.tempdir, 'foo')
-        f = open(filename, 'wb')
-        f.write(b'onetwothreefourfivesixseveneightnineten')
-        f.flush()
+        with open(filename, 'wb') as f:
+            f.write(b'onetwothreefourfivesixseveneightnineten')
         chunk = ReadFileChunk.from_filename(
             filename, start_byte=11, chunk_size=4)
         self.assertEqual(chunk.read(1), b'f')
@@ -175,9 +173,8 @@ class TestReadFileChunk(unittest.TestCase):
 
     def test_reset_stream_emulation(self):
         filename = os.path.join(self.tempdir, 'foo')
-        f = open(filename, 'wb')
-        f.write(b'onetwothreefourfivesixseveneightnineten')
-        f.flush()
+        with open(filename, 'wb') as f:
+            f.write(b'onetwothreefourfivesixseveneightnineten')
         chunk = ReadFileChunk.from_filename(
             filename, start_byte=11, chunk_size=4)
         self.assertEqual(chunk.read(), b'four')
@@ -186,9 +183,8 @@ class TestReadFileChunk(unittest.TestCase):
 
     def test_read_past_end_of_file(self):
         filename = os.path.join(self.tempdir, 'foo')
-        f = open(filename, 'wb')
-        f.write(b'onetwothreefourfivesixseveneightnineten')
-        f.flush()
+        with open(filename, 'wb') as f:
+            f.write(b'onetwothreefourfivesixseveneightnineten')
         chunk = ReadFileChunk.from_filename(
             filename, start_byte=36, chunk_size=100000)
         self.assertEqual(chunk.read(), b'ten')
@@ -197,9 +193,8 @@ class TestReadFileChunk(unittest.TestCase):
 
     def test_tell_and_seek(self):
         filename = os.path.join(self.tempdir, 'foo')
-        f = open(filename, 'wb')
-        f.write(b'onetwothreefourfivesixseveneightnineten')
-        f.flush()
+        with open(filename, 'wb') as f:
+            f.write(b'onetwothreefourfivesixseveneightnineten')
         chunk = ReadFileChunk.from_filename(
             filename, start_byte=36, chunk_size=100000)
         self.assertEqual(chunk.tell(), 0)
@@ -210,9 +205,8 @@ class TestReadFileChunk(unittest.TestCase):
 
     def test_callback_is_invoked_on_read(self):
         filename = os.path.join(self.tempdir, 'foo')
-        f = open(filename, 'wb')
-        f.write(b'abc')
-        f.flush()
+        with open(filename, 'wb') as f:
+            f.write(b'abc')
         amounts_seen = []
         def callback(amount):
             amounts_seen.append(amount)
@@ -226,9 +220,8 @@ class TestReadFileChunk(unittest.TestCase):
 
     def test_file_chunk_supports_context_manager(self):
         filename = os.path.join(self.tempdir, 'foo')
-        f = open(filename, 'wb')
-        f.write(b'abc')
-        f.flush()
+        with open(filename, 'wb') as f:
+            f.write(b'abc')
         with ReadFileChunk.from_filename(filename,
                                          start_byte=0,
                                          chunk_size=2) as chunk:


### PR DESCRIPTION
This PR adds support for an intelligent upload_file/download_file method for boto3.

The module docstring provides some general information and an overview of how to use the module.

I'd like to get some initial feedback on this.  There's unit/integ tests added (there's a few integration tests I've haven't fleshed out yet), and the code is fully functional, but I will be pushing some changes in a bit.

There are two changes I plan on making:

* I'm going to be changing the logic for the _download_range function.  The single lock writer on the file unnecessarily slows down the parallel downloads.  I'm likely going to port some version of the what the AWS CLI does to improve this.
* The callback interface may need to change.  It requires a lot of information that's not technically necessary and could be provided.  It also doesn't handle retries.  In order to do this, I might need to change the interface from a simple callback to an actual class that has a few required methods.


Also, the socket timeouts and bandwidth throttling are not implemented.  Those are stretch features I might end up deferring for now.

There will also be another pull request that integrates this with the s3 client and s3 resource objects.

cc @kyleknap @danielgtaylor