### PR TITLE
Inject upload/download file to s3 clients

### DIFF
--- a/boto3/s3/inject.py
+++ b/boto3/s3/inject.py
@@ -11,11 +11,12 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from boto3.s3.transfer import S3Transfer
+from boto3 import utils
 
 
 def inject_s3_transfer_methods(class_attributes, **kwargs):
-    class_attributes['upload_file'] = upload_file
-    class_attributes['download_file'] = download_file
+    utils.inject_attribute(class_attributes, 'upload_file', upload_file)
+    utils.inject_attribute(class_attributes, 'download_file', download_file)
 
 
 def upload_file(self, Filename, Bucket, Key, ExtraArgs=None,

--- a/boto3/s3/inject.py
+++ b/boto3/s3/inject.py
@@ -1,0 +1,34 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from boto3.s3.transfer import S3Transfer
+
+
+def inject_s3_transfer_methods(class_attributes, **kwargs):
+    class_attributes['upload_file'] = upload_file
+    class_attributes['download_file'] = download_file
+
+
+def upload_file(self, Filename, Bucket, Key, ExtraArgs=None,
+                Callback=None, Config=None):
+    transfer = S3Transfer(self, Config)
+    return transfer.upload_file(
+        filename=Filename, bucket=Bucket, key=Key,
+        extra_args=ExtraArgs, callback=Callback)
+
+
+def download_file(self, Bucket, Key, Filename, ExtraArgs=None,
+                  Callback=None, Config=None):
+    transfer = S3Transfer(self, Config)
+    return transfer.download_file(
+        bucket=Bucket, key=Key, filename=Filename,
+        extra_args=ExtraArgs, callback=Callback)

--- a/boto3/session.py
+++ b/boto3/session.py
@@ -16,6 +16,7 @@ import os
 import botocore.session
 
 import boto3
+import boto3.utils
 
 from .exceptions import NoVersionFound
 from .resources.factory import ResourceFactory
@@ -73,6 +74,7 @@ class Session(object):
 
         self.resource_factory = ResourceFactory()
         self._setup_loader()
+        self._register_default_handlers()
 
     def __repr__(self):
         return 'Session(region={0})'.format(
@@ -308,3 +310,9 @@ class Session(object):
             service_name, service_name, model['service'], model['resources'],
             service_model)
         return cls(client=client)
+
+    def _register_default_handlers(self):
+        self._session.register(
+            'creating-client-class.s3',
+            boto3.utils.lazy_call(
+                'boto3.s3.inject.inject_s3_transfer_methods'))

--- a/boto3/utils.py
+++ b/boto3/utils.py
@@ -1,0 +1,31 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import sys
+
+
+def import_module(name):
+    """Import module given a name.
+
+    Does not support relative imports.
+
+    """
+    __import__(name)
+    return sys.modules[name]
+
+
+def lazy_call(full_name):
+    def _handler(**kwargs):
+        module, function_name = full_name.rsplit('.', 1)
+        module = import_module(module)
+        return getattr(module, function_name)(**kwargs)
+    return _handler

--- a/boto3/utils.py
+++ b/boto3/utils.py
@@ -29,3 +29,12 @@ def lazy_call(full_name):
         module = import_module(module)
         return getattr(module, function_name)(**kwargs)
     return _handler
+
+
+def inject_attribute(class_attributes, name, value):
+    if name in class_attributes:
+        raise RuntimeError(
+            'Cannot inject class attribute "%s", attribute '
+            'already exists in class dict.' % name)
+    else:
+        class_attributes[name] = value

--- a/tests/integration/test_utils.py
+++ b/tests/integration/test_utils.py
@@ -1,0 +1,37 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests import unittest
+
+import botocore.session
+
+
+from boto3 import utils
+import boto3.session
+
+
+class TestUtils(unittest.TestCase):
+    def test_runtime_error_raised_when_shadowing_client_method(self):
+        botocore_session = botocore.session.get_session()
+        session = boto3.session.Session(region_name='us-west-2',
+                                        botocore_session=botocore_session)
+
+        def shadows_put_object(class_attributes, **kwargs):
+            utils.inject_attribute(class_attributes, 'put_object', 'invalid')
+
+        botocore_session.register('creating-client-class', shadows_put_object)
+
+        with self.assertRaises(RuntimeError):
+            # This should raise an exception because we're trying to
+            # shadow the put_object client method in the
+            # shadows_put_object handler above.
+            session.client('s3')

--- a/tests/unit/s3/test_inject.py
+++ b/tests/unit/s3/test_inject.py
@@ -1,0 +1,43 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the 'license' file accompanying this file. This file is
+# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests import unittest
+import mock
+
+from boto3.s3 import inject
+
+
+class TestInject(unittest.TestCase):
+    def test_inject_upload_download_file_to_client(self):
+        class_attributes = {}
+        inject.inject_s3_transfer_methods(class_attributes=class_attributes)
+        self.assertIn('upload_file', class_attributes)
+        self.assertIn('download_file', class_attributes)
+
+    def test_upload_file_proxies_to_transfer_object(self):
+        with mock.patch('boto3.s3.inject.S3Transfer') as transfer:
+            inject.upload_file(mock.sentinel.CLIENT,
+                               Filename='filename',
+                               Bucket='bucket', Key='key')
+            transfer.return_value.upload_file.assert_called_with(
+                filename='filename', bucket='bucket', key='key',
+                extra_args=None, callback=None)
+
+    def test_download_file_proxies_to_transfer_object(self):
+        with mock.patch('boto3.s3.inject.S3Transfer') as transfer:
+            inject.download_file(
+                mock.sentinel.CLIENT,
+                Bucket='bucket', Key='key',
+                Filename='filename')
+            transfer.return_value.download_file.assert_called_with(
+                bucket='bucket', key='key', filename='filename',
+                extra_args=None, callback=None)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -35,3 +35,13 @@ class TestUtils(unittest.TestCase):
         module = utils.import_module('boto3.s3.transfer')
         self.assertEqual(module.__name__, 'boto3.s3.transfer')
         self.assertIsInstance(module, types.ModuleType)
+
+    def test_inject_attributes_with_no_shadowing(self):
+        class_attributes = {}
+        utils.inject_attribute(class_attributes, 'foo', 'bar')
+        self.assertEqual(class_attributes['foo'], 'bar')
+
+    def test_shadowing_existing_var_raises_exception(self):
+        class_attributes = {'foo': 'preexisting'}
+        with self.assertRaises(RuntimeError):
+            utils.inject_attribute(class_attributes, 'foo', 'bar')

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,37 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import types
+from tests import unittest
+import mock
+
+from boto3 import utils
+
+
+class FakeModule(object):
+    @staticmethod
+    def entry_point(**kwargs):
+        return kwargs
+
+
+class TestUtils(unittest.TestCase):
+    def test_lazy_call(self):
+        with mock.patch('boto3.utils.import_module') as importer:
+            importer.return_value = FakeModule
+            lazy_function = utils.lazy_call(
+                'fakemodule.FakeModule.entry_point')
+            self.assertEqual(lazy_function(a=1, b=2), {'a': 1, 'b': 2})
+
+    def test_import_module(self):
+        module = utils.import_module('boto3.s3.transfer')
+        self.assertEqual(module.__name__, 'boto3.s3.transfer')
+        self.assertIsInstance(module, types.ModuleType)


### PR DESCRIPTION
This adds an upload/download file to clients.

The one deviation I made from the way we do this in botocore is to add lazy handlers that only import the module once they're actually invoked.

In this scenario, this means we only import `boto3.s3` when we create an S3 client.

cc @kyleknap @danielgtaylor