### PR TITLE
Distribute boto3.s3 in PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ def get_version():
 packages = [
     'boto3',
     'boto3.resources',
+    'boto3.s3',
 ]
 
 requires = [


### PR DESCRIPTION
The example in https://github.com/boto/boto3#quick-start doesn't work with https://pypi.python.org/pypi/boto3/0.0.14 without this.