### PR TITLE
Update requirements for botocore

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ VERSION_RE = re.compile(r'''__version__ = ['"]([0-9.]+)['"]''')
 
 
 requires = [
-    'botocore==0.103.0',
+    'botocore>=0.104.0,<1.0.0',
     'bcdoc==0.12.2',
     'jmespath==0.6.2',
 ]


### PR DESCRIPTION
By adding this requirement, we do not worry about having to do a release of boto3 everytime we do a release of botocore. This should be fine given we do not expect botocore breaking boto3 in the near future.

cc @jamesls 