### PR TITLE
Dynamodb types

### DIFF
--- a/boto3/dynamodb/__init__.py
+++ b/boto3/dynamodb/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/boto3/dynamodb/types.py
+++ b/boto3/dynamodb/types.py
@@ -1,0 +1,236 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from collections import Mapping
+from decimal import Decimal, Context, Clamped
+from decimal import Overflow, Inexact, Underflow, Rounded
+
+from botocore.compat import six
+
+
+STRING = 'S'
+NUMBER = 'N'
+BINARY = 'B'
+STRING_SET = 'SS'
+NUMBER_SET = 'NS'
+BINARY_SET = 'BS'
+NULL = 'NULL'
+BOOLEAN = 'BOOL'
+MAP = 'M'
+LIST = 'L'
+
+
+DYNAMODB_CONTEXT = Context(
+    Emin=-128, Emax=126, rounding=None, prec=38,
+    traps=[Clamped, Overflow, Inexact, Rounded, Underflow])
+
+
+class Binary(object):
+    def __init__(self, value):
+        if not isinstance(value, (bytearray, six.binary_type)):
+            raise TypeError('Value must be a string of binary data.')
+        self.value = value
+
+    def __eq__(self, other):
+        if isinstance(other, Binary):
+            return self.value == other.value
+        return self.value == other
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        return 'Binary(%r)' % self.value
+
+    def __str__(self):
+        return self.value
+
+    def __hash__(self):
+        return hash(self.value)
+
+
+class TypeSerializer(object):
+    def serialize(self, value):
+        dynamodb_type = self._get_dynamodb_type(value)
+        serializer = getattr(self, '_serialize_%s' % dynamodb_type.lower())
+        return {dynamodb_type: serializer(value)}
+
+    def _get_dynamodb_type(self, value):
+        dynamodb_type = None
+
+        if self._is_null(value):
+            dynamodb_type = NULL
+
+        elif self._is_boolean(value):
+            dynamodb_type = BOOLEAN
+
+        elif self._is_number(value):
+            dynamodb_type = NUMBER
+
+        elif self._is_string(value):
+            dynamodb_type = STRING
+
+        elif self._is_binary(value):
+            dynamodb_type = BINARY
+
+        elif self._is_type_set(value, self._is_number):
+            dynamodb_type = NUMBER_SET
+
+        elif self._is_type_set(value, self._is_string):
+            dynamodb_type = STRING_SET
+
+        elif self._is_type_set(value, self._is_binary):
+            dynamodb_type = BINARY_SET
+
+        elif self._is_map(value):
+            dynamodb_type = MAP
+
+        elif self._is_list(value):
+            dynamodb_type = LIST
+
+        else:
+            msg = 'Unsupported type "%s" for value "%s"' % (type(value), value)
+            raise TypeError(msg)
+
+        return dynamodb_type
+
+    def _is_null(self, value):
+        if value is None:
+            return True
+        return False
+
+    def _is_boolean(self, value):
+        if isinstance(value, bool):
+            return True
+        return False
+
+    def _is_number(self, value):
+        if isinstance(value, (six.integer_types, Decimal)):
+            return True
+        elif isinstance(value, float):
+            raise TypeError(
+                'Float types are not supported. Use Decimal types instead.')
+        return False
+
+    def _is_string(self, value):
+        if isinstance(value, six.string_types):
+            return True
+        return False
+
+    def _is_binary(self, value):
+        if isinstance(value, Binary):
+            return True
+        elif isinstance(value, bytearray):
+            return True
+        elif six.PY3 and isinstance(value, six.binary_type):
+            return True
+        return False
+
+    def _is_set(self, value):
+        if isinstance(value, (set, frozenset)):
+            return True
+        return False
+
+    def _is_type_set(self, value, type_validator):
+        if self._is_set(value):
+            if False not in map(type_validator, value):
+                return True
+        return False
+
+    def _is_map(self, value):
+        if isinstance(value, Mapping):
+            return True
+        return False
+
+    def _is_list(self, value):
+        if isinstance(value, list):
+            return True
+        return False
+
+    def _serialize_null(self, value):
+        return True
+
+    def _serialize_bool(self, value):
+        return value
+
+    def _serialize_n(self, value):
+        number = str(DYNAMODB_CONTEXT.create_decimal(value))
+        if number in ['Infinity', 'NaN']:
+            raise TypeError('Infinity and NaN not supported')
+        return number
+
+    def _serialize_s(self, value):
+        return value
+
+    def _serialize_b(self, value):
+        if isinstance(value, Binary):
+            value = value.value
+        return value
+
+    def _serialize_ss(self, value):
+        return [self._serialize_s(s) for s in value]
+
+    def _serialize_ns(self, value):
+        return [self._serialize_n(n) for n in value]
+
+    def _serialize_bs(self, value):
+        return [self._serialize_b(b) for b in value]
+
+    def _serialize_l(self, value):
+        return [self.serialize(v) for v in value]
+
+    def _serialize_m(self, value):
+        return dict([(k, self.serialize(v)) for k, v in value.items()])
+
+
+class TypeDeserializer(object):
+    def deserialize(self, value):
+        if not value:
+            return value
+        dynamodb_type = list(value.keys())[0]
+        try:
+            deserializer = getattr(
+                self, '_deserialize_%s' % dynamodb_type.lower())
+        except AttributeError:
+            raise TypeError(
+                'Dynamodb type %s is not supported' % dynamodb_type)
+        return deserializer(value[dynamodb_type])
+
+    def _deserialize_null(self, value):
+        return None
+
+    def _deserialize_bool(self, value):
+        return value
+
+    def _deserialize_n(self, value):
+        return DYNAMODB_CONTEXT.create_decimal(value)
+
+    def _deserialize_s(self, value):
+        return value
+
+    def _deserialize_b(self, value):
+        return Binary(value)
+
+    def _deserialize_ns(self, value):
+        return set(map(self._deserialize_n, value))
+
+    def _deserialize_ss(self, value):
+        return set(map(self._deserialize_s, value))
+
+    def _deserialize_bs(self, value):
+        return set(map(self._deserialize_b, value))
+
+    def _deserialize_l(self, value):
+        return [self.deserialize(v) for v in value]
+
+    def _deserialize_m(self, value):
+        return dict([(k, self.deserialize(v)) for k, v in value.items()])

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -15,6 +15,8 @@ import random
 import sys
 import time
 
+from botocore.compat import six
+
 
 # The unittest module got a significant overhaul
 # in 2.7, so if we're in 2.6 we can use the backported
@@ -30,6 +32,14 @@ if sys.version_info[0] == 2:
     import mock
 else:
     from unittest import mock
+
+
+# In python 3, order matters when calling assertEqual to
+# compare lists and dictionaries with lists. Therefore,
+# assertItemsEqual needs to be used but it is renamed to
+# assertCountEqual in python 3.
+if six.PY2:
+    unittest.TestCase.assertCountEqual = unittest.TestCase.assertItemsEqual
 
 
 def unique_id(name):

--- a/tests/unit/dynamodb/__init__.py
+++ b/tests/unit/dynamodb/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/tests/unit/dynamodb/test_types.py
+++ b/tests/unit/dynamodb/test_types.py
@@ -147,7 +147,8 @@ class TestDeserializer(unittest.TestCase):
             self.deserializer.deserialize({'FOO': 'bar'})
 
     def test_deserialize_empty_structure(self):
-        self.assertEqual(self.deserializer.deserialize({}), {})
+        with self.assertRaisesRegexp(TypeError, 'Value must be a nonempty'):
+            self.assertEqual(self.deserializer.deserialize({}), {})
 
     def test_deserialize_null(self):
         self.assertEqual(self.deserializer.deserialize({"NULL": True}), None)

--- a/tests/unit/dynamodb/test_types.py
+++ b/tests/unit/dynamodb/test_types.py
@@ -1,0 +1,202 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the 'license' file accompanying this file. This file is
+# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from decimal import Decimal
+from tests import unittest
+
+from botocore.compat import six
+
+from boto3.dynamodb.types import Binary, TypeSerializer, TypeDeserializer
+
+
+class TestBinary(unittest.TestCase):
+    def test_bytes_input(self):
+        data = Binary(b'\x01')
+        self.assertEqual(b'\x01', data)
+        self.assertEqual(b'\x01', data.value)
+
+    def test_non_ascii_bytes_input(self):
+        # Binary data that is out of ASCII range
+        data = Binary(b'\x88')
+        self.assertEqual(b'\x88', data)
+        self.assertEqual(b'\x88', data.value)
+
+    def test_bytearray_input(self):
+        data = Binary(bytearray([1]))
+        self.assertEqual(b'\x01', data)
+        self.assertEqual(b'\x01', data.value)
+
+    def test_unicode_throws_error(self):
+        with self.assertRaises(TypeError):
+            Binary(u'\u00e9')
+
+    def test_integer_throws_error(self):
+        with self.assertRaises(TypeError):
+            Binary(1)
+
+    def test_not_equal(self):
+        self.assertTrue(Binary(b'\x01') != b'\x02')
+
+    def test_str(self):
+        self.assertEqual(Binary(b'\x01').__str__(), b'\x01')
+
+    def test_repr(self):
+        self.assertEqual(repr(Binary(b'1')), 'Binary(b\'1\')')
+
+
+class TestSerializer(unittest.TestCase):
+    def setUp(self):
+        self.serializer = TypeSerializer()
+
+    def test_serialize_unsupported_type(self):
+        with self.assertRaisesRegexp(TypeError, 'Unsupported type'):
+            self.serializer.serialize(object())
+
+    def test_serialize_null(self):
+        self.assertEqual(self.serializer.serialize(None), {'NULL': True})
+
+    def test_serialize_boolean(self):
+        self.assertEqual(self.serializer.serialize(False), {'BOOL': False})
+
+    def test_serialize_integer(self):
+        self.assertEqual(self.serializer.serialize(1), {'N': '1'})
+
+    def test_serialize_decimal(self):
+        self.assertEqual(
+            self.serializer.serialize(Decimal('1.25')), {'N': '1.25'})
+
+    def test_serialize_float_error(self):
+        with self.assertRaisesRegexp(
+                TypeError,
+                'Float types are not supported. Use Decimal types instead'):
+            self.serializer.serialize(1.25)
+
+    def test_serialize_NaN_error(self):
+        with self.assertRaisesRegexp(
+                TypeError,
+                'Infinity and NaN not supported'):
+            self.serializer.serialize(Decimal('NaN'))
+
+    def test_serialize_string(self):
+        self.assertEqual(self.serializer.serialize('foo'), {'S': 'foo'})
+
+    def test_serialize_binary(self):
+        self.assertEqual(self.serializer.serialize(
+            Binary(b'\x01')), {'B': b'\x01'})
+
+    def test_serialize_bytearray(self):
+        self.assertEqual(self.serializer.serialize(bytearray([1])),
+                         {'B': b'\x01'})
+
+    @unittest.skipIf(six.PY2,
+                     'This is a test when using python3 version of bytes')
+    def test_serialize_bytes(self):
+        self.assertEqual(self.serializer.serialize(b'\x01'), {'B': b'\x01'})
+
+    def test_serialize_number_set(self):
+        serialized_value = self.serializer.serialize(set([1, 2, 3]))
+        self.assertEqual(len(serialized_value), 1)
+        self.assertIn('NS', serialized_value)
+        self.assertCountEqual(serialized_value['NS'], ['1', '2', '3'])
+
+    def test_serialize_string_set(self):
+        serialized_value = self.serializer.serialize(set(['foo', 'bar']))
+        self.assertEqual(len(serialized_value), 1)
+        self.assertIn('SS', serialized_value)
+        self.assertCountEqual(serialized_value['SS'], ['foo', 'bar'])
+
+    def test_serialize_binary_set(self):
+        serialized_value = self.serializer.serialize(
+            set([Binary(b'\x01'), Binary(b'\x02')]))
+        self.assertEqual(len(serialized_value), 1)
+        self.assertIn('BS', serialized_value)
+        self.assertCountEqual(serialized_value['BS'], [b'\x01', b'\x02'])
+
+    def test_serialize_list(self):
+        serialized_value = self.serializer.serialize(['foo', 1, [1]])
+        self.assertEqual(len(serialized_value), 1)
+        self.assertIn('L', serialized_value)
+        self.assertCountEqual(
+            serialized_value['L'],
+            [{'S': 'foo'}, {'N': '1'}, {'L': [{'N': '1'}]}]
+        )
+
+    def test_serialize_map(self):
+        serialized_value = self.serializer.serialize(
+            {'foo': 'bar', 'baz': {'biz': 1}})
+        self.assertEqual(
+            serialized_value,
+            {'M': {'foo': {'S': 'bar'}, 'baz': {'M': {'biz': {'N': '1'}}}}})
+
+
+class TestDeserializer(unittest.TestCase):
+    def setUp(self):
+        self.deserializer = TypeDeserializer()
+
+    def test_deserialize_invalid_type(self):
+        with self.assertRaisesRegexp(TypeError, 'FOO is not supported'):
+            self.deserializer.deserialize({'FOO': 'bar'})
+
+    def test_deserialize_empty_structure(self):
+        self.assertEqual(self.deserializer.deserialize({}), {})
+
+    def test_deserialize_null(self):
+        self.assertEqual(self.deserializer.deserialize({"NULL": True}), None)
+
+    def test_deserialize_boolean(self):
+        self.assertEqual(self.deserializer.deserialize({"BOOL": False}), False)
+
+    def test_deserialize_integer(self):
+        self.assertEqual(
+            self.deserializer.deserialize({'N': '1'}), Decimal('1'))
+
+    def test_deserialize_decimal(self):
+        self.assertEqual(
+            self.deserializer.deserialize({'N': '1.25'}), Decimal('1.25'))
+
+    def test_deserialize_string(self):
+        self.assertEqual(
+            self.deserializer.deserialize({'S': 'foo'}), 'foo')
+
+    def test_deserialize_binary(self):
+        self.assertEqual(
+            self.deserializer.deserialize({'B': b'\x00'}), Binary(b'\x00'))
+
+    def test_deserialize_number_set(self):
+        self.assertEqual(
+            self.deserializer.deserialize(
+                {'NS': ['1', '1.25']}), set([Decimal('1'), Decimal('1.25')]))
+
+    def test_deserialize_string_set(self):
+        self.assertEqual(
+            self.deserializer.deserialize(
+                {'SS': ['foo', 'bar']}), set(['foo', 'bar']))
+
+    def test_deserialize_binary_set(self):
+        self.assertEqual(
+            self.deserializer.deserialize(
+                {'BS': [b'\x00', b'\x01']}),
+            set([Binary(b'\x00'), Binary(b'\x01')]))
+
+    def test_deserialize_list(self):
+        self.assertEqual(
+            self.deserializer.deserialize(
+                {'L': [{'N': '1'}, {'S': 'foo'}, {'L': [{'N': '1.25'}]}]}),
+            [Decimal('1'), 'foo', [Decimal('1.25')]])
+
+    def test_deserialize_map(self):
+        self.assertEqual(
+            self.deserializer.deserialize(
+                {'M': {'foo': {'S': 'mystring'},
+                       'bar': {'M': {'baz': {'N': '1'}}}}}),
+            {'foo': 'mystring', 'bar': {'baz': Decimal('1')}}
+        )

--- a/tests/unit/dynamodb/test_types.py
+++ b/tests/unit/dynamodb/test_types.py
@@ -50,7 +50,7 @@ class TestBinary(unittest.TestCase):
         self.assertEqual(Binary(b'\x01').__str__(), b'\x01')
 
     def test_repr(self):
-        self.assertEqual(repr(Binary(b'1')), 'Binary(b\'1\')')
+        self.assertIn('Binary', repr(Binary(b'1')))
 
 
 class TestSerializer(unittest.TestCase):


### PR DESCRIPTION
This PR adds type serialization/deserialization for dynamodb. It works much like the ``Dynamizer`` class in boto. This interface is built specifically for botocore. So, stuff like base64 encoding/decoding binary is handed off to botocore.

cc @jamesls 