### PR TITLE
Support custom loader data_path by using os.pathsep

### DIFF
--- a/boto3/session.py
+++ b/boto3/session.py
@@ -92,10 +92,10 @@ class Session(object):
         Setup loader paths so that we can load resources.
         """
         self._loader = self._session.get_component('data_loader')
-        self._loader.data_path = ':'.join(
+        self._loader.data_path = os.pathsep.join(
             [self._loader.data_path,
              os.path.join(os.path.dirname(__file__), 'data',
-                          'resources')]).strip(':')
+                          'resources')]).strip(os.pathsep)
 
     def _get_resource_files(self):
         """


### PR DESCRIPTION
Currently on Windows you can't use a custom data_path for a loader due to a hardcoded colon used as a separator. This patch replaces the colon with `os.pathsep` which on Windows is a semicolon.