### PR TITLE
Clean up boto3 packaging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,15 @@ python:
 sudo: false
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then travis_retry pip install -r requirements26.txt; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.* ]]; then travis_retry pip install -r requirements2.txt; fi
+  - "rm -rf dist/*"
   - travis_retry pip install -r requirements.txt
   - travis_retry pip install coverage python-coveralls
-script: nosetests --with-coverage --cover-erase
-after_success: coveralls
+  # We're building and installing from a whl file to ensure that
+  # there aren't any packaging issues.
+  - python setup.py bdist_wheel
+  - "pip install dist/*.whl"
+# We're running from a directory other than the repo root so that
+# we can ensure we're importing from our installed whl package
+# instead of the current directory.
+script: cd tests/unit && nosetests --with-coverage --cover-erase --cover-package boto3
+after_success: cp -f tests/unit/.coverage .coverage && coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ install:
 # we can ensure we're importing from our installed whl package
 # instead of the current directory.
 script: cd tests/unit && nosetests --with-coverage --cover-erase --cover-package boto3
-after_success: cp -f tests/unit/.coverage .coverage && coveralls
+after_success: coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@
 -e git://github.com/boto/jmespath.git@develop#egg=jmespath
 nose==1.3.3
 mock==1.0.1
+wheel==0.24.0

--- a/requirements2.txt
+++ b/requirements2.txt
@@ -1,4 +1,0 @@
-# Python2 needs the concurrent.futures backport.
-# We handle this logic in setup.py but we need
-# a separate file to track this in our requirements file.
-futures==2.2.0

--- a/requirements26.txt
+++ b/requirements26.txt
@@ -1,3 +1,1 @@
-simplejson==3.3.0
-ordereddict==1.1
 unittest2==0.5.1

--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,6 @@ requires = [
 ]
 
 
-if sys.version_info[0] == 2:
-    # concurrent.futures is only in python3, so for
-    # python2 we need to install the backport.
-    requires.append('futures==2.2.0')
-
-
 def get_version():
     init = open(os.path.join(ROOT, 'boto3', '__init__.py')).read()
     return VERSION_RE.search(init).group(1)
@@ -48,6 +42,9 @@ setup(
     },
     include_package_data=True,
     install_requires=requires,
+    extras_require={
+        ':python_version=="2.6" or python_version=="2.7"': ['futures==2.2.0']
+    },
     license="Apache License 2.0",
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     },
     include_package_data=True,
     install_requires=requires,
-    license=open("LICENSE").read(),
+    license="Apache License 2.0",
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,9 @@ VERSION_RE = re.compile(r'''__version__ = ['"]([0-9.]+)['"]''')
 requires = [
     'botocore>=0.104.0,<1.0.0',
     'bcdoc==0.12.2',
-    'jmespath==0.6.2',
+    'jmespath>=0.6.2,<1.0.0',
 ]
+
 
 if sys.version_info[0] == 2:
     # concurrent.futures is only in python3, so for

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,pypy
+envlist = py26,py27,py33,py34
 
 # Comment to build sdist and install into virtualenv
 # This is helpful to test installation but takes extra time
@@ -8,9 +8,7 @@ skipsdist = True
 [testenv:py26]
 # Python 2.6 requires two extra test dependencies
 deps =
-    simplejson
     unittest2
-    ordereddict
     -rrequirements.txt
 
 [testenv]


### PR DESCRIPTION
This PR cleans up the way we package boto3 and the way we test packaging.  To summarize:

* Add conditional dependencies in a way that works with wheels.  By having a conditional dependency within the setup.py logic, the wheel file will differ depending on whether `bdist_wheel` is run on python2 or python3.
* Remove unused dependencies in our tox/travis files.  This just slows down the CI time without any benefit.
* Test against our installed wheel.  Rather than relying on the CWD being able to import boto3, we now generate a .whl file, install it, and test against the installed wheel file.  This will catch a number of issues we've run into in the past where the setup.py was incorrect or missing key pieces.
* Relax contraints on jmespath.  Similar to what was done for botocore.

This should give us more confidence in the release assets we generate.

Note: I will be sending another PR shortly that pulls much of the CI logic into separate scripts, so that we can interoperate with non-travis CI systems.  I just wanted to get this update to our CI logic reviewed before doing that.

cc @kyleknap