### PR TITLE
Extract out CI scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ tests/.coverage
 # Test state / virtualenvs
 .tox
 .coverage
+coverage.xml
+nosetests.xml
 
 # Common virtualenv names
 venv

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ sudo: false
 install:
   - python scripts/ci/install
 script: python scripts/ci/run-tests
-after_success: coveralls
+after_success: cd tests && coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,15 @@ python:
 sudo: false
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then travis_retry pip install -r requirements26.txt; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.* ]]; then travis_retry pip install -r requirements2.txt; fi
+  - "rm -rf dist/*"
   - travis_retry pip install -r requirements.txt
   - travis_retry pip install coverage python-coveralls
-script: nosetests --with-coverage --cover-erase
-after_success: coveralls
+  # We're building and installing from a whl file to ensure that
+  # there aren't any packaging issues.
+  - python setup.py bdist_wheel
+  - "pip install dist/*.whl"
+# We're running from a directory other than the repo root so that
+# we can ensure we're importing from our installed whl package
+# instead of the current directory.
+script: cd tests/unit && nosetests --with-coverage --cover-erase --cover-package boto3
+after_success: cp -f tests/unit/.coverage .coverage && coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ install:
 # we can ensure we're importing from our installed whl package
 # instead of the current directory.
 script: cd tests/unit && nosetests --with-coverage --cover-erase --cover-package boto3
-after_success: cp -f tests/unit/.coverage .coverage && coveralls
+after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,6 @@ python:
   - "3.4"
 sudo: false
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then travis_retry pip install -r requirements26.txt; fi
-  - "rm -rf dist/*"
-  - travis_retry pip install -r requirements.txt
-  - travis_retry pip install coverage python-coveralls
-  # We're building and installing from a whl file to ensure that
-  # there aren't any packaging issues.
-  - python setup.py bdist_wheel
-  - "pip install dist/*.whl"
-# We're running from a directory other than the repo root so that
-# we can ensure we're importing from our installed whl package
-# instead of the current directory.
-script: cd tests/unit && nosetests --with-coverage --cover-erase --cover-package boto3
+  - python scripts/ci/install
+script: python scripts/ci/run-tests
 after_success: coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@
 -e git://github.com/boto/jmespath.git@develop#egg=jmespath
 nose==1.3.3
 mock==1.0.1
+wheel==0.24.0

--- a/requirements2.txt
+++ b/requirements2.txt
@@ -1,4 +1,0 @@
-# Python2 needs the concurrent.futures backport.
-# We handle this logic in setup.py but we need
-# a separate file to track this in our requirements file.
-futures==2.2.0

--- a/requirements26.txt
+++ b/requirements26.txt
@@ -1,3 +1,1 @@
-simplejson==3.3.0
-ordereddict==1.1
 unittest2==0.5.1

--- a/scripts/ci/install
+++ b/scripts/ci/install
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+import os
+import sys
+from subprocess import check_call
+
+_dname = os.path.dirname
+
+REPO_ROOT = _dname(_dname(_dname(os.path.abspath(__file__))))
+os.chdir(REPO_ROOT)
+
+
+def run(command):
+    return check_call(command, shell=True)
+
+
+try:
+    # Has the form "major.minor"
+    python_version = os.environ['PYTHON_VERSION']
+except KeyError:
+    python_version = '.'.join([str(i) for i in sys.version_info[:2]])
+
+if python_version == '2.6':
+    run('pip install -r requirements26.txt')
+
+run('pip install -r requirements.txt')
+run('pip install coverage python-coveralls')
+run('rm -rf dist/*')
+run('python setup.py bdist_wheel')
+run('pip install dist/*.whl')

--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# Don't run tests from the root repo dir.
+# We want to ensure we're importing from the installed
+# binary package not from the CWD.
+
+import os
+from subprocess import check_call
+
+_dname = os.path.dirname
+
+REPO_ROOT = _dname(_dname(_dname(os.path.abspath(__file__))))
+os.chdir(os.path.join(REPO_ROOT, 'tests'))
+
+
+def run(command):
+    return check_call(command, shell=True)
+
+
+run('nosetests --with-coverage --cover-erase --cover-package boto3 '
+    '--with-xunit --cover-xml -v unit/')

--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,6 @@ requires = [
 ]
 
 
-if sys.version_info[0] == 2:
-    # concurrent.futures is only in python3, so for
-    # python2 we need to install the backport.
-    requires.append('futures==2.2.0')
-
-
 def get_version():
     init = open(os.path.join(ROOT, 'boto3', '__init__.py')).read()
     return VERSION_RE.search(init).group(1)
@@ -48,6 +42,9 @@ setup(
     },
     include_package_data=True,
     install_requires=requires,
+    extras_require={
+        ':python_version=="2.6" or python_version=="2.7"': ['futures==2.2.0']
+    },
     license="Apache License 2.0",
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     },
     include_package_data=True,
     install_requires=requires,
-    license=open("LICENSE").read(),
+    license="Apache License 2.0",
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,9 @@ VERSION_RE = re.compile(r'''__version__ = ['"]([0-9.]+)['"]''')
 requires = [
     'botocore>=0.104.0,<1.0.0',
     'bcdoc==0.12.2',
-    'jmespath==0.6.2',
+    'jmespath>=0.6.2,<1.0.0',
 ]
+
 
 if sys.version_info[0] == 2:
     # concurrent.futures is only in python3, so for

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,pypy
+envlist = py26,py27,py33,py34
 
 # Comment to build sdist and install into virtualenv
 # This is helpful to test installation but takes extra time
@@ -8,9 +8,7 @@ skipsdist = True
 [testenv:py26]
 # Python 2.6 requires two extra test dependencies
 deps =
-    simplejson
     unittest2
-    ordereddict
     -rrequirements.txt
 
 [testenv]


### PR DESCRIPTION
For easier integration with non travis systems.

Note that this builds on https://github.com/boto/boto3/pull/99, but pulls out all that logic into separate scripts.

That way integrating with our CI systems besides travis don't require code duplication.  They just need to call `scripts/ci/install` to setup the env, then `scripts/ci/run-tests` to run the tests.  And when we need to make logic changes to how we install packages or run tests we can just make them in a single place.

cc @kyleknap