### PR TITLE
Add condition expression builder

### DIFF
--- a/boto3/dynamodb/conditions.py
+++ b/boto3/dynamodb/conditions.py
@@ -367,15 +367,7 @@ class ConditionExpressionBuilder(object):
         attribute_name_parts = ATTR_NAME_REGEX.findall(attribute_name)
 
         # Add a temporary placeholder for each of these parts.
-        # We need to create a new method because 2.6 does not support {}
-        # style of string format.
-        def create_format_arg(matching_object_list, matching_object):
-            length_of_list = len(matching_object_list)
-            matching_object_list.append(matching_object)
-            return '{%s}' % length_of_list
-        sub_function = functools.partial(create_format_arg, [])
-
-        placeholder_format = ATTR_NAME_REGEX.sub(sub_function, attribute_name)
+        placeholder_format = ATTR_NAME_REGEX.sub('%s', attribute_name)
         str_format_args = []
         for part in attribute_name_parts:
             name_placeholder = self._get_name_placeholder()
@@ -384,7 +376,7 @@ class ConditionExpressionBuilder(object):
             # Add the placeholder and value to dictionary of name placeholders.
             attribute_name_placeholders[name_placeholder] = part
         # Replace the temporary placeholders with the designated placeholders.
-        return placeholder_format.format(*str_format_args)
+        return placeholder_format % tuple(str_format_args)
 
     def _build_value_placeholder(self, value, attribute_value_placeholders,
                                  has_grouped_values=False):

--- a/boto3/dynamodb/conditions.py
+++ b/boto3/dynamodb/conditions.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from collections import namedtuple
 import functools
 import re
 
@@ -273,6 +274,13 @@ class Attr(AttributeBase):
         return AttributeType(self, value)
 
 
+BuiltConditionExpression = namedtuple(
+    'BuiltConditionExpression',
+    ['condition_expression', 'attribute_name_placeholders',
+     'attribute_value_placeholders']
+)
+
+
 class ConditionExpressionBuilder(object):
     """This class is used to build condition expressions with placeholders"""
     def __init__(self):
@@ -313,9 +321,10 @@ class ConditionExpressionBuilder(object):
         condition_expression = self._build_expression(
             condition, attribute_name_placeholders,
             attribute_value_placeholders, is_key_condition=is_key_condition)
-        return (
-            condition_expression, attribute_name_placeholders,
-            attribute_value_placeholders
+        return BuiltConditionExpression(
+            condition_expression=condition_expression,
+            attribute_name_placeholders=attribute_name_placeholders,
+            attribute_value_placeholders=attribute_value_placeholders
         )
 
     def _build_expression(self, condition, attribute_name_placeholders,

--- a/boto3/dynamodb/conditions.py
+++ b/boto3/dynamodb/conditions.py
@@ -128,7 +128,7 @@ class AttributeBase(object):
 class ConditionAttributeBase(ConditionBase, AttributeBase):
     """This base class is for conditions that can have attribute methods.
 
-    One example is the SIZE condition. To complete a condition, you need
+    One example is the Size condition. To complete a condition, you need
     to apply another AttributeBase method like eq().
     """
     def __init__(self, *values):
@@ -221,11 +221,11 @@ class Not(ConditionBase):
     expression_format = '({operator} {0})'
 
 
-class K(AttributeBase):
+class Key(AttributeBase):
     pass
 
 
-class A(AttributeBase):
+class Attr(AttributeBase):
     """Represents an DynamoDB item's attribute."""
     def ne(self, value):
         """Creates a condtion where the attribute is not equal to the value
@@ -348,11 +348,11 @@ class ConditionExpressionBuilder(object):
         # So we check if it is an attribute and add placeholders for
         # its name
         elif isinstance(value, AttributeBase):
-            if is_key_condition and not isinstance(value, K):
+            if is_key_condition and not isinstance(value, Key):
                 raise DynamoDBNeedsKeyConditionError(
                     'Attribute object %s is of type %s. '
                     'KeyConditionExpression only supports Attribute objects '
-                    'of type K' % (value.name, type(value)))
+                    'of type Key' % (value.name, type(value)))
             return self._build_name_placeholder(
                 value, attribute_name_placeholders)
         # If it is anything else, we treat it as a value and thus placeholders

--- a/boto3/dynamodb/conditions.py
+++ b/boto3/dynamodb/conditions.py
@@ -33,15 +33,15 @@ class ConditionBase(object):
     def __and__(self, other):
         if not isinstance(other, ConditionBase):
             raise DynanmoDBOperationNotSupportedError('AND', other)
-        return AND(self, other)
+        return And(self, other)
 
     def __or__(self, other):
         if not isinstance(other, ConditionBase):
             raise DynanmoDBOperationNotSupportedError('OR', other)
-        return OR(self, other)
+        return Or(self, other)
 
     def __invert__(self):
-        return NOT(self)
+        return Not(self)
 
     def get_expression(self):
         return {'format': self.expression_format,
@@ -76,14 +76,14 @@ class AttributeBase(object):
 
         :param value: The value that the attribute is equal to.
         """
-        return EQ(self, value)
+        return Equals(self, value)
 
     def lt(self, value):
         """Creates a condtion where the attribute is less than the value.
 
         :param value: The value that the attribute is less than.
         """
-        return LT(self, value)
+        return LessThan(self, value)
 
     def lte(self, value):
         """Creates a condtion where the attribute is less than or equal to the
@@ -91,14 +91,14 @@ class AttributeBase(object):
 
         :param value: The value that the attribute is less than or equal to.
         """
-        return LTE(self, value)
+        return LessThanEquals(self, value)
 
     def gt(self, value):
         """Creates a condtion where the attribute is greater than the value.
 
         :param value: The value that the attribute is greater than.
         """
-        return GT(self, value)
+        return GreaterThan(self, value)
 
     def gte(self, value):
         """Creates a condtion where the attribute is greater than or equal to
@@ -106,14 +106,14 @@ class AttributeBase(object):
 
         :param value: The value that the attribute is greater than or equal to.
         """
-        return GTE(self, value)
+        return GreaterThanEquals(self, value)
 
     def begins_with(self, value):
         """Creates a condtion where the attribute begins with the value.
 
         :param value: The value that the attribute begins with.
         """
-        return BEG(self, value)
+        return BeginsWith(self, value)
 
     def between(self, low_value, high_value):
         """Creates a condtion where the attribute is between the low value and
@@ -122,7 +122,7 @@ class AttributeBase(object):
         :param low_value: The value that the attribute is greater than.
         :param high_value: The value that the attribute is less than.
         """
-        return BET(self, low_value, high_value)
+        return Between(self, low_value, high_value)
 
 
 class ConditionAttributeBase(ConditionBase, AttributeBase):
@@ -142,81 +142,81 @@ class ComparisonCondition(ConditionBase):
     expression_format = '{0} {operator} {1}'
 
 
-class EQ(ComparisonCondition):
+class Equals(ComparisonCondition):
     expression_operator = '='
 
 
-class NE(ComparisonCondition):
+class NotEquals(ComparisonCondition):
     expression_operator = '<>'
 
 
-class LT(ComparisonCondition):
+class LessThan(ComparisonCondition):
     expression_operator = '<'
 
 
-class LTE(ComparisonCondition):
+class LessThanEquals(ComparisonCondition):
     expression_operator = '<='
 
 
-class GT(ComparisonCondition):
+class GreaterThan(ComparisonCondition):
     expression_operator = '>'
 
 
-class GTE(ComparisonCondition):
+class GreaterThanEquals(ComparisonCondition):
     expression_operator = '>='
 
 
-class IN(ComparisonCondition):
+class In(ComparisonCondition):
     expression_operator = 'IN'
     has_grouped_values = True
 
 
-class BET(ConditionBase):
+class Between(ConditionBase):
     expression_operator = 'BETWEEN'
     expression_format = '{0} {operator} {1} AND {2}'
 
 
-class BEG(ConditionBase):
+class BeginsWith(ConditionBase):
     expression_operator = 'begins_with'
     expression_format = '{operator}({0}, {1})'
 
 
-class CONT(ConditionBase):
+class Contains(ConditionBase):
     expression_operator = 'contains'
     expression_format = '{operator}({0}, {1})'
 
 
-class SIZE(ConditionAttributeBase):
+class Size(ConditionAttributeBase):
     expression_operator = 'size'
     expression_format = '{operator}({0})'
 
 
-class AT(ConditionBase):
+class AttributeType(ConditionBase):
     expression_operator = 'attribute_type'
     expression_format = '{operator}({0}, {1})'
 
 
-class AE(ConditionBase):
+class AttributeExists(ConditionBase):
     expression_operator = 'attribute_exists'
     expression_format = '{operator}({0})'
 
 
-class ANE(ConditionBase):
+class AttributeNotExists(ConditionBase):
     expression_operator = 'attribute_not_exists'
     expression_format = '{operator}({0})'
 
 
-class AND(ConditionBase):
+class And(ConditionBase):
     expression_operator = 'AND'
     expression_format = '({0} {operator} {1})'
 
 
-class OR(ConditionBase):
+class Or(ConditionBase):
     expression_operator = 'OR'
     expression_format = '({0} {operator} {1})'
 
 
-class NOT(ConditionBase):
+class Not(ConditionBase):
     expression_operator = 'NOT'
     expression_format = '({operator} {0})'
 
@@ -232,7 +232,7 @@ class A(AttributeBase):
 
         :param value: The value that the attribute is not equal to.
         """
-        return NE(self, value)
+        return NotEquals(self, value)
 
     def is_in(self, value):
         """Creates a condtion where the attribute is in the value,
@@ -240,22 +240,22 @@ class A(AttributeBase):
         :type value: list
         :param value: The value that the attribute is in.
         """
-        return IN(self, value)
+        return In(self, value)
 
     def exists(self):
         """Creates a condtion where the attribute exists."""
-        return AE(self)
+        return AttributeExists(self)
 
     def not_exists(self):
         """Creates a condtion where the attribute does not exist."""
-        return ANE(self)
+        return AttributeNotExists(self)
 
     def contains(self, value):
         """Creates a condition where the attribute contains the value.
 
         :param value: The value the attribute contains.
         """
-        return CONT(self, value)
+        return Contains(self, value)
 
     def size(self):
         """Creates a condition for the attribute size.
@@ -263,14 +263,14 @@ class A(AttributeBase):
         Note another AttributeBase method must be called on the returned
         size condition to be a valid DynamoDB condition.
         """
-        return SIZE(self)
+        return Size(self)
 
     def attribute_type(self, value):
         """Creates a condition for the attribute type.
 
         :param value: The type of the attribute.
         """
-        return AT(self, value)
+        return AttributeType(self, value)
 
 
 class ConditionExpressionBuilder(object):

--- a/boto3/dynamodb/conditions.py
+++ b/boto3/dynamodb/conditions.py
@@ -1,0 +1,400 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import re
+
+from boto3.exceptions import DynanmoDBOperationNotSupportedError
+from boto3.exceptions import DynamoDBNeedsConditionError
+from boto3.exceptions import DynamoDBNeedsKeyConditionError
+
+
+ATTR_NAME_REGEX = re.compile(r'[^.\[\]]+(?![^\[]*\])')
+
+
+class ConditionBase(object):
+
+    expression_format = ''
+    expression_operator = ''
+    has_grouped_values = False
+
+    def __init__(self, *values):
+        self._values = values
+
+    def __and__(self, other):
+        if not isinstance(other, ConditionBase):
+            raise DynanmoDBOperationNotSupportedError('AND', other)
+        return AND(self, other)
+
+    def __or__(self, other):
+        if not isinstance(other, ConditionBase):
+            raise DynanmoDBOperationNotSupportedError('OR', other)
+        return OR(self, other)
+
+    def __invert__(self):
+        return NOT(self)
+
+    def get_expression(self):
+        return {'format': self.expression_format,
+                'operator': self.expression_operator,
+                'values': self._values}
+
+    def __eq__(self, other):
+        if isinstance(other, type(self)):
+            if self._values == other._values:
+                return True
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+class AttributeBase(object):
+    def __init__(self, name):
+        self.name = name
+
+    def __and__(self, value):
+        raise DynanmoDBOperationNotSupportedError('AND', self)
+
+    def __or__(self, value):
+        raise DynanmoDBOperationNotSupportedError('OR', self)
+
+    def __invert__(self):
+        raise DynanmoDBOperationNotSupportedError('NOT', self)
+
+    def eq(self, value):
+        """Creates a condtion where the attribute is equal to the value.
+
+        :param value: The value that the attribute is equal to.
+        """
+        return EQ(self, value)
+
+    def lt(self, value):
+        """Creates a condtion where the attribute is less than the value.
+
+        :param value: The value that the attribute is less than.
+        """
+        return LT(self, value)
+
+    def lte(self, value):
+        """Creates a condtion where the attribute is less than or equal to the
+           value.
+
+        :param value: The value that the attribute is less than or equal to.
+        """
+        return LTE(self, value)
+
+    def gt(self, value):
+        """Creates a condtion where the attribute is greater than the value.
+
+        :param value: The value that the attribute is greater than.
+        """
+        return GT(self, value)
+
+    def gte(self, value):
+        """Creates a condtion where the attribute is greater than or equal to
+           the value.
+
+        :param value: The value that the attribute is greater than or equal to.
+        """
+        return GTE(self, value)
+
+    def begins_with(self, value):
+        """Creates a condtion where the attribute begins with the value.
+
+        :param value: The value that the attribute begins with.
+        """
+        return BEG(self, value)
+
+    def between(self, low_value, high_value):
+        """Creates a condtion where the attribute is between the low value and
+           the high value.
+
+        :param low_value: The value that the attribute is greater than.
+        :param high_value: The value that the attribute is less than.
+        """
+        return BET(self, low_value, high_value)
+
+
+class ConditionAttributeBase(ConditionBase, AttributeBase):
+    """This base class is for conditions that can have attribute methods.
+
+    One example is the SIZE condition. To complete a condition, you need
+    to apply another AttributeBase method like eq().
+    """
+    def __init__(self, *values):
+        ConditionBase.__init__(self, *values)
+        # This is assuming the first value to the condition is the attribute
+        # in which can be used to generate its attribute base.
+        AttributeBase.__init__(self, values[0].name)
+
+
+class ComparisonCondition(ConditionBase):
+    expression_format = '{0} {operator} {1}'
+
+
+class EQ(ComparisonCondition):
+    expression_operator = '='
+
+
+class NE(ComparisonCondition):
+    expression_operator = '<>'
+
+
+class LT(ComparisonCondition):
+    expression_operator = '<'
+
+
+class LTE(ComparisonCondition):
+    expression_operator = '<='
+
+
+class GT(ComparisonCondition):
+    expression_operator = '>'
+
+
+class GTE(ComparisonCondition):
+    expression_operator = '>='
+
+
+class IN(ComparisonCondition):
+    expression_operator = 'IN'
+    has_grouped_values = True
+
+
+class BET(ConditionBase):
+    expression_operator = 'BETWEEN'
+    expression_format = '{0} {operator} {1} AND {2}'
+
+
+class BEG(ConditionBase):
+    expression_operator = 'begins_with'
+    expression_format = '{operator}({0}, {1})'
+
+
+class CONT(ConditionBase):
+    expression_operator = 'contains'
+    expression_format = '{operator}({0}, {1})'
+
+
+class SIZE(ConditionAttributeBase):
+    expression_operator = 'size'
+    expression_format = '{operator}({0})'
+
+
+class AT(ConditionBase):
+    expression_operator = 'attribute_type'
+    expression_format = '{operator}({0}, {1})'
+
+
+class AE(ConditionBase):
+    expression_operator = 'attribute_exists'
+    expression_format = '{operator}({0})'
+
+
+class ANE(ConditionBase):
+    expression_operator = 'attribute_not_exists'
+    expression_format = '{operator}({0})'
+
+
+class AND(ConditionBase):
+    expression_operator = 'AND'
+    expression_format = '({0} {operator} {1})'
+
+
+class OR(ConditionBase):
+    expression_operator = 'OR'
+    expression_format = '({0} {operator} {1})'
+
+
+class NOT(ConditionBase):
+    expression_operator = 'NOT'
+    expression_format = '({operator} {0})'
+
+
+class K(AttributeBase):
+    pass
+
+
+class A(AttributeBase):
+    """Represents an DynamoDB item's attribute."""
+    def ne(self, value):
+        """Creates a condtion where the attribute is not equal to the value
+
+        :param value: The value that the attribute is not equal to.
+        """
+        return NE(self, value)
+
+    def is_in(self, value):
+        """Creates a condtion where the attribute is in the value,
+
+        :type value: list
+        :param value: The value that the attribute is in.
+        """
+        return IN(self, value)
+
+    def exists(self):
+        """Creates a condtion where the attribute exists."""
+        return AE(self)
+
+    def not_exists(self):
+        """Creates a condtion where the attribute does not exist."""
+        return ANE(self)
+
+    def contains(self, value):
+        """Creates a condition where the attribute contains the value.
+
+        :param value: The value the attribute contains.
+        """
+        return CONT(self, value)
+
+    def size(self):
+        """Creates a condition for the attribute size.
+
+        Note another AttributeBase method must be called on the returned
+        size condition to be a valid DynamoDB condition.
+        """
+        return SIZE(self)
+
+    def attribute_type(self, value):
+        """Creates a condition for the attribute type.
+
+        :param value: The type of the attribute.
+        """
+        return AT(self, value)
+
+
+class ConditionExpressionBuilder(object):
+    """This class is used to build condition expressions with placeholders"""
+    def __init__(self):
+        self._name_count = 0
+        self._value_count = 0
+        self._name_placeholder = 'n'
+        self._value_placeholder = 'v'
+
+    def _get_name_placeholder(self):
+        return '#' + self._name_placeholder + str(self._name_count)
+
+    def _get_value_placeholder(self):
+        return ':' + self._value_placeholder + str(self._value_count)
+
+    def build_expression(self, condition, is_key_condition=False):
+        """Builds the condition expression and the dictionary of placeholders.
+
+        :type condition: ConditionBase
+        :param condition: A condition to be built into a condition expression
+            string with any necessary placeholders.
+
+        :type is_key_condition: Boolean
+        :param is_key_condition: True if the expression is for a
+            KeyConditionExpression. False otherwise.
+
+        :rtype: (string, dict, dict)
+        :returns: Will return a string representing the condition with
+            placeholders inserted where necessary, a dictionary of
+            placeholders for attribute names, and a dictionary of
+            placeholders for attribute values. Here is a sample return value:
+
+            ('#n0 = :v0', {'#n0': 'myattribute'}, {':v1': 'myvalue'})
+        """
+        if not isinstance(condition, ConditionBase):
+            raise DynamoDBNeedsConditionError(condition)
+        attribute_name_placeholders = {}
+        attribute_value_placeholders = {}
+        condition_expression = self._build_expression(
+            condition, attribute_name_placeholders,
+            attribute_value_placeholders, is_key_condition=is_key_condition)
+        return (
+            condition_expression, attribute_name_placeholders,
+            attribute_value_placeholders
+        )
+
+    def _build_expression(self, condition, attribute_name_placeholders,
+                          attribute_value_placeholders, is_key_condition):
+        expression_dict = condition.get_expression()
+        replaced_values = []
+        for value in expression_dict['values']:
+            # Build the necessary placeholders for that value.
+            # Placeholders are built for both attribute names and values.
+            replaced_value = self._build_expression_component(
+                value, attribute_name_placeholders,
+                attribute_value_placeholders, condition.has_grouped_values,
+                is_key_condition)
+            replaced_values.append(replaced_value)
+        # Fill out the expression using the operator and the
+        # values that have been replaced with placeholders.
+        return expression_dict['format'].format(
+            *replaced_values, operator=expression_dict['operator'])
+
+    def _build_expression_component(self, value, attribute_name_placeholders,
+                                    attribute_value_placeholders,
+                                    has_grouped_values, is_key_condition):
+        # Continue to recurse if the value is a ConditionBase in order
+        # to extract out all parts of the expression.
+        if isinstance(value, ConditionBase):
+            return self._build_expression(
+                value, attribute_name_placeholders,
+                attribute_value_placeholders, is_key_condition)
+        # If it is not a ConditionBase, we can recurse no further.
+        # So we check if it is an attribute and add placeholders for
+        # its name
+        elif isinstance(value, AttributeBase):
+            if is_key_condition and not isinstance(value, K):
+                raise DynamoDBNeedsKeyConditionError(
+                    'Attribute object %s is of type %s. '
+                    'KeyConditionExpression only supports Attribute objects '
+                    'of type K' % (value.name, type(value)))
+            return self._build_name_placeholder(
+                value, attribute_name_placeholders)
+        # If it is anything else, we treat it as a value and thus placeholders
+        # are needed for the value.
+        else:
+            return self._build_value_placeholder(
+                value, attribute_value_placeholders, has_grouped_values)
+
+    def _build_name_placeholder(self, value, attribute_name_placeholders):
+        attribute_name = value.name
+        # Figure out which parts of the attribute name that needs replacement.
+        attribute_name_parts = ATTR_NAME_REGEX.findall(attribute_name)
+        # Add a temporary placeholder for each of these parts.
+        placeholder_format = ATTR_NAME_REGEX.sub('{}', attribute_name)
+        str_format_args = []
+        for part in attribute_name_parts:
+            name_placeholder = self._get_name_placeholder()
+            self._name_count += 1
+            str_format_args.append(name_placeholder)
+            # Add the placeholder and value to dictionary of name placeholders.
+            attribute_name_placeholders[name_placeholder] = part
+        # Replace the temporary placeholders with the designated placeholders.
+        return placeholder_format.format(*str_format_args)
+
+    def _build_value_placeholder(self, value, attribute_value_placeholders,
+                                 has_grouped_values=False):
+        # If the values are grouped, we need to add a placeholder for
+        # each element inside of the actual value.
+        if has_grouped_values:
+            placeholder_list = []
+            for v in value:
+                value_placeholder = self._get_value_placeholder()
+                self._value_count += 1
+                placeholder_list.append(value_placeholder)
+                attribute_value_placeholders[value_placeholder] = v
+            # Assuming the values are grouped by parenthesis.
+            # IN is the currently the only one that uses this so it maybe
+            # needed to be changed in future.
+            return '(' + ', '.join(placeholder_list) + ')'
+        # Otherwise, treat the value as a single value that needs only
+        # one placeholder.
+        else:
+            value_placeholder = self._get_value_placeholder()
+            self._value_count += 1
+            attribute_value_placeholders[value_placeholder] = value
+            return value_placeholder

--- a/boto3/dynamodb/conditions.py
+++ b/boto3/dynamodb/conditions.py
@@ -295,6 +295,11 @@ class ConditionExpressionBuilder(object):
     def _get_value_placeholder(self):
         return ':' + self._value_placeholder + str(self._value_count)
 
+    def reset(self):
+        """Resets the placeholder name and values"""
+        self._name_count = 0
+        self._value_count = 0
+
     def build_expression(self, condition, is_key_condition=False):
         """Builds the condition expression and the dictionary of placeholders.
 

--- a/boto3/exceptions.py
+++ b/boto3/exceptions.py
@@ -38,7 +38,7 @@ class DynanmoDBOperationNotSupportedError(Exception):
     def __init__(self, operation, value):
         msg = (
             '%s operation cannot be applied to value %s of type %s directly. '
-            'Must use AttributeBase object methods (i.e. A().eq()). to '
+            'Must use AttributeBase object methods (i.e. Attr().eq()). to '
             'generate ConditionBase instances first.' %
             (operation, value, type(value)))
         Exception.__init__(self, msg)
@@ -49,7 +49,7 @@ class DynamoDBNeedsConditionError(Exception):
     def __init__(self, value):
         msg = (
             'Expecting a ConditionBase object. Got %s of type %s. '
-            'Use AttributeBase object methods (i.e. A().eq()). to '
+            'Use AttributeBase object methods (i.e. Attr().eq()). to '
             'generate ConditionBase instances.' % (value, type(value)))
         Exception.__init__(self, msg)
 

--- a/boto3/exceptions.py
+++ b/boto3/exceptions.py
@@ -31,3 +31,28 @@ class S3TransferFailedError(Exception):
 
 class S3UploadFailedError(Exception):
     pass
+
+
+class DynanmoDBOperationNotSupportedError(Exception):
+    """Raised for operantions that are not supported for an operand"""
+    def __init__(self, operation, value):
+        msg = (
+            '%s operation cannot be applied to value %s of type %s directly. '
+            'Must use AttributeBase object methods (i.e. A().eq()). to '
+            'generate ConditionBase instances first.' %
+            (operation, value, type(value)))
+        Exception.__init__(self, msg)
+
+
+class DynamoDBNeedsConditionError(Exception):
+    """Raised when input is not a condition"""
+    def __init__(self, value):
+        msg = (
+            'Expecting a ConditionBase object. Got %s of type %s. '
+            'Use AttributeBase object methods (i.e. A().eq()). to '
+            'generate ConditionBase instances.' % (value, type(value)))
+        Exception.__init__(self, msg)
+
+
+class DynamoDBNeedsKeyConditionError(Exception):
+    pass

--- a/tests/unit/dynamodb/test_conditions.py
+++ b/tests/unit/dynamodb/test_conditions.py
@@ -15,7 +15,7 @@ from tests import unittest
 from boto3.exceptions import DynanmoDBOperationNotSupportedError
 from boto3.exceptions import DynamoDBNeedsConditionError
 from boto3.exceptions import DynamoDBNeedsKeyConditionError
-from boto3.dynamodb.conditions import A, K
+from boto3.dynamodb.conditions import Attr, Key
 from boto3.dynamodb.conditions import And, Or, Not, Equals, LessThan
 from boto3.dynamodb.conditions import LessThanEquals, GreaterThan
 from boto3.dynamodb.conditions import GreaterThanEquals, BeginsWith, Between
@@ -27,8 +27,8 @@ from boto3.dynamodb.conditions import ConditionExpressionBuilder
 
 class TestK(unittest.TestCase):
     def setUp(self):
-        self.attr = K('mykey')
-        self.attr2 = K('myotherkey')
+        self.attr = Key('mykey')
+        self.attr2 = Key('myotherkey')
         self.value = 'foo'
         self.value2 = 'foo2'
 
@@ -79,8 +79,8 @@ class TestK(unittest.TestCase):
 
 class TestA(TestK):
     def setUp(self):
-        self.attr = A('mykey')
-        self.attr2 = A('myotherkey')
+        self.attr = Attr('mykey')
+        self.attr2 = Attr('myotherkey')
         self.value = 'foo'
         self.value2 = 'foo2'
 
@@ -112,7 +112,7 @@ class TestA(TestK):
 
 class TestConditions(unittest.TestCase):
     def setUp(self):
-        self.value = A('mykey')
+        self.value = Attr('mykey')
         self.value2 = 'foo'
 
     def assert_expression_dict(self, condition, exp_format,
@@ -297,156 +297,154 @@ class TestConditionExpressionBuilder(unittest.TestCase):
             is_key_condition=False):
         exp_string, names, values = self.builder.build_expression(
             condition, is_key_condition=is_key_condition)
-        print(names)
-        print(values)
         self.assertEqual(exp_string, ref_string)
         self.assertEqual(names, ref_names)
         self.assertEqual(values, ref_values)
 
     def test_bad_input(self):
-        a = A('myattr')
+        a = Attr('myattr')
         with self.assertRaises(DynamoDBNeedsConditionError):
             self.builder.build_expression(a)
 
     def test_build_expression_eq(self):
-        a = A('myattr')
+        a = Attr('myattr')
         self.assert_condition_expression_build(
             a.eq('foo'), '#n0 = :v0', {'#n0': 'myattr'}, {':v0': 'foo'})
 
     def test_build_expression_lt(self):
-        a = A('myattr')
+        a = Attr('myattr')
         self.assert_condition_expression_build(
             a.lt('foo'), '#n0 < :v0', {'#n0': 'myattr'}, {':v0': 'foo'})
 
     def test_build_expression_lte(self):
-        a1 = A('myattr')
+        a1 = Attr('myattr')
         self.assert_condition_expression_build(
             a1.lte('foo'), '#n0 <= :v0', {'#n0': 'myattr'}, {':v0': 'foo'})
 
     def test_build_expression_gt(self):
-        a = A('myattr')
+        a = Attr('myattr')
         self.assert_condition_expression_build(
             a.gt('foo'), '#n0 > :v0', {'#n0': 'myattr'}, {':v0': 'foo'})
 
     def test_build_expression_gte(self):
-        a = A('myattr')
+        a = Attr('myattr')
         self.assert_condition_expression_build(
             a.gte('foo'), '#n0 >= :v0', {'#n0': 'myattr'}, {':v0': 'foo'})
 
     def test_build_expression_begins_with(self):
-        a = A('myattr')
+        a = Attr('myattr')
         self.assert_condition_expression_build(
             a.begins_with('foo'), 'begins_with(#n0, :v0)',
             {'#n0': 'myattr'}, {':v0': 'foo'})
 
     def test_build_expression_between(self):
-        a = A('myattr')
+        a = Attr('myattr')
         self.assert_condition_expression_build(
             a.between('foo', 'foo2'), '#n0 BETWEEN :v0 AND :v1',
             {'#n0': 'myattr'}, {':v0': 'foo', ':v1': 'foo2'})
 
     def test_build_expression_ne(self):
-        a = A('myattr')
+        a = Attr('myattr')
         self.assert_condition_expression_build(
             a.ne('foo'), '#n0 <> :v0', {'#n0': 'myattr'}, {':v0': 'foo'})
 
     def test_build_expression_in(self):
-        a = A('myattr')
+        a = Attr('myattr')
         self.assert_condition_expression_build(
             a.is_in([1, 2, 3]), '#n0 IN (:v0, :v1, :v2)',
             {'#n0': 'myattr'}, {':v0': 1, ':v1': 2, ':v2': 3})
 
     def test_build_expression_exists(self):
-        a = A('myattr')
+        a = Attr('myattr')
         self.assert_condition_expression_build(
             a.exists(), 'attribute_exists(#n0)', {'#n0': 'myattr'}, {})
 
     def test_build_expression_not_exists(self):
-        a = A('myattr')
+        a = Attr('myattr')
         self.assert_condition_expression_build(
             a.not_exists(), 'attribute_not_exists(#n0)', {'#n0': 'myattr'}, {})
 
     def test_build_contains(self):
-        a = A('myattr')
+        a = Attr('myattr')
         self.assert_condition_expression_build(
             a.contains('foo'), 'contains(#n0, :v0)',
             {'#n0': 'myattr'}, {':v0': 'foo'})
 
     def test_build_size(self):
-        a = A('myattr')
+        a = Attr('myattr')
         self.assert_condition_expression_build(
             a.size(), 'size(#n0)', {'#n0': 'myattr'}, {})
 
     def test_build_size_with_other_conditons(self):
-        a = A('myattr')
+        a = Attr('myattr')
         self.assert_condition_expression_build(
             a.size().eq(5), 'size(#n0) = :v0', {'#n0': 'myattr'}, {':v0': 5})
 
     def test_build_attribute_type(self):
-        a = A('myattr')
+        a = Attr('myattr')
         self.assert_condition_expression_build(
             a.attribute_type('foo'), 'attribute_type(#n0, :v0)',
             {'#n0': 'myattr'}, {':v0': 'foo'})
 
     def test_build_and(self):
-        a = A('myattr')
-        a2 = A('myattr2')
+        a = Attr('myattr')
+        a2 = Attr('myattr2')
         self.assert_condition_expression_build(
             a.eq('foo') & a2.eq('bar'), '(#n0 = :v0 AND #n1 = :v1)',
             {'#n0': 'myattr', '#n1': 'myattr2'}, {':v0': 'foo', ':v1': 'bar'})
 
     def test_build_or(self):
-        a = A('myattr')
-        a2 = A('myattr2')
+        a = Attr('myattr')
+        a2 = Attr('myattr2')
         self.assert_condition_expression_build(
             a.eq('foo') | a2.eq('bar'), '(#n0 = :v0 OR #n1 = :v1)',
             {'#n0': 'myattr', '#n1': 'myattr2'}, {':v0': 'foo', ':v1': 'bar'})
 
     def test_build_not(self):
-        a = A('myattr')
+        a = Attr('myattr')
         self.assert_condition_expression_build(
             ~a.eq('foo'), '(NOT #n0 = :v0)',
             {'#n0': 'myattr'}, {':v0': 'foo'})
 
     def test_build_attribute_with_attr_value(self):
-        a = A('myattr')
-        value = A('myreference')
+        a = Attr('myattr')
+        value = Attr('myreference')
         self.assert_condition_expression_build(
             a.eq(value), '#n0 = #n1',
             {'#n0': 'myattr', '#n1': 'myreference'}, {})
 
     def test_build_with_is_key_condition(self):
-        k = K('myattr')
+        k = Key('myattr')
         self.assert_condition_expression_build(
             k.eq('foo'), '#n0 = :v0',
             {'#n0': 'myattr'}, {':v0': 'foo'}, is_key_condition=True)
 
     def test_build_with_is_key_condition_throws_error(self):
-        a = A('myattr')
+        a = Attr('myattr')
         with self.assertRaises(DynamoDBNeedsKeyConditionError):
             self.builder.build_expression(a.eq('foo'), is_key_condition=True)
 
     def test_build_attr_map(self):
-        a = A('MyMap.MyKey')
+        a = Attr('MyMap.MyKey')
         self.assert_condition_expression_build(
             a.eq('foo'), '#n0.#n1 = :v0', {'#n0': 'MyMap', '#n1': 'MyKey'},
             {':v0': 'foo'})
 
     def test_build_attr_list(self):
-        a = A('MyList[0]')
+        a = Attr('MyList[0]')
         self.assert_condition_expression_build(
             a.eq('foo'), '#n0[0] = :v0', {'#n0': 'MyList'}, {':v0': 'foo'})
 
     def test_build_nested_attr_map_list(self):
-        a = A('MyMap.MyList[2].MyElement')
+        a = Attr('MyMap.MyList[2].MyElement')
         self.assert_condition_expression_build(
             a.eq('foo'), '#n0.#n1[2].#n2 = :v0',
             {'#n0': 'MyMap', '#n1': 'MyList', '#n2': 'MyElement'},
             {':v0': 'foo'})
 
     def test_build_double_nested_and_or(self):
-        a = A('myattr')
-        a2 = A('myattr2')
+        a = Attr('myattr')
+        a2 = Attr('myattr2')
         self.assert_condition_expression_build(
             (a.eq('foo') & a2.eq('foo2')) | (a.eq('bar') & a2.eq('bar2')),
             '((#n0 = :v0 AND #n1 = :v1) OR (#n2 = :v2 AND #n3 = :v3))',

--- a/tests/unit/dynamodb/test_conditions.py
+++ b/tests/unit/dynamodb/test_conditions.py
@@ -115,14 +115,10 @@ class TestConditions(unittest.TestCase):
         self.value = Attr('mykey')
         self.value2 = 'foo'
 
-    def assert_expression_dict(self, condition, exp_format,
-                               exp_operator, values):
+    def build_and_assert_expression(self, condition,
+                                    reference_expression_dict):
         expression_dict = condition.get_expression()
-        self.assertEqual(expression_dict['format'], exp_format)
-        self.assertEqual(expression_dict['operator'], exp_operator)
-        self.assertEqual(len(expression_dict['values']), len(values))
-        for i, value in enumerate(expression_dict['values']):
-            self.assertEqual(value, values[i])
+        self.assertDictEqual(expression_dict, reference_expression_dict)
 
     def test_equal_operator(self):
         cond1 = Equals(self.value, self.value2)
@@ -171,121 +167,133 @@ class TestConditions(unittest.TestCase):
         self.assertEqual(~cond1, Not(cond1))
 
     def test_eq(self):
-        self.assert_expression_dict(
-            Equals(self.value, self.value2), exp_format='{0} {operator} {1}',
-            exp_operator='=', values=[self.value, self.value2])
+        self.build_and_assert_expression(
+            Equals(self.value, self.value2),
+            {'format': '{0} {operator} {1}',
+             'operator': '=', 'values': (self.value, self.value2)})
 
     def test_ne(self):
-        self.assert_expression_dict(
+        self.build_and_assert_expression(
             NotEquals(self.value, self.value2),
-            exp_format='{0} {operator} {1}',
-            exp_operator='<>', values=[self.value, self.value2])
+            {'format': '{0} {operator} {1}',
+             'operator': '<>', 'values': (self.value, self.value2)})
 
     def test_lt(self):
-        self.assert_expression_dict(
+        self.build_and_assert_expression(
             LessThan(self.value, self.value2),
-            exp_format='{0} {operator} {1}',
-            exp_operator='<', values=[self.value, self.value2])
+            {'format': '{0} {operator} {1}',
+             'operator': '<', 'values': (self.value, self.value2)})
 
     def test_lte(self):
-        self.assert_expression_dict(
+        self.build_and_assert_expression(
             LessThanEquals(self.value, self.value2),
-            exp_format='{0} {operator} {1}',
-            exp_operator='<=', values=[self.value, self.value2])
+            {'format': '{0} {operator} {1}',
+             'operator': '<=', 'values': (self.value, self.value2)})
 
     def test_gt(self):
-        self.assert_expression_dict(
+        self.build_and_assert_expression(
             GreaterThan(self.value, self.value2),
-            exp_format='{0} {operator} {1}',
-            exp_operator='>', values=[self.value, self.value2])
+            {'format': '{0} {operator} {1}',
+             'operator': '>', 'values': (self.value, self.value2)})
 
     def test_gte(self):
-        self.assert_expression_dict(
+        self.build_and_assert_expression(
             GreaterThanEquals(self.value, self.value2),
-            exp_format='{0} {operator} {1}',
-            exp_operator='>=', values=[self.value, self.value2])
+            {'format': '{0} {operator} {1}',
+             'operator': '>=', 'values': (self.value, self.value2)})
 
     def test_in(self):
         cond = In(self.value, (self.value2))
-        self.assert_expression_dict(
-            cond, exp_format='{0} {operator} {1}',
-            exp_operator='IN', values=[self.value, (self.value2)])
+        self.build_and_assert_expression(
+            cond,
+            {'format': '{0} {operator} {1}',
+             'operator': 'IN', 'values': (self.value, (self.value2))})
         self.assertTrue(cond.has_grouped_values)
 
     def test_bet(self):
-        self.assert_expression_dict(
+        self.build_and_assert_expression(
             Between(self.value, self.value2, 'foo2'),
-            exp_format='{0} {operator} {1} AND {2}',
-            exp_operator='BETWEEN', values=[self.value, self.value2, 'foo2'])
+            {'format': '{0} {operator} {1} AND {2}',
+             'operator': 'BETWEEN',
+             'values': (self.value, self.value2, 'foo2')})
 
     def test_beg(self):
-        self.assert_expression_dict(
+        self.build_and_assert_expression(
             BeginsWith(self.value, self.value2),
-            exp_format='{operator}({0}, {1})',
-            exp_operator='begins_with', values=[self.value, self.value2])
+            {'format': '{operator}({0}, {1})',
+             'operator': 'begins_with', 'values': (self.value, self.value2)})
 
     def test_cont(self):
-        self.assert_expression_dict(
+        self.build_and_assert_expression(
             Contains(self.value, self.value2),
-            exp_format='{operator}({0}, {1})',
-            exp_operator='contains', values=[self.value, self.value2])
+            {'format': '{operator}({0}, {1})',
+             'operator': 'contains', 'values': (self.value, self.value2)})
 
     def test_ae(self):
-        self.assert_expression_dict(
-            AttributeExists(self.value), exp_format='{operator}({0})',
-            exp_operator='attribute_exists', values=[self.value])
+        self.build_and_assert_expression(
+            AttributeExists(self.value),
+            {'format': '{operator}({0})',
+             'operator': 'attribute_exists', 'values': (self.value,)})
 
     def test_ane(self):
-        self.assert_expression_dict(
-            AttributeNotExists(self.value), exp_format='{operator}({0})',
-            exp_operator='attribute_not_exists', values=[self.value])
+        self.build_and_assert_expression(
+            AttributeNotExists(self.value),
+            {'format': '{operator}({0})',
+             'operator': 'attribute_not_exists', 'values': (self.value,)})
 
     def test_size(self):
-        self.assert_expression_dict(
-            Size(self.value), exp_format='{operator}({0})',
-            exp_operator='size', values=[self.value])
+        self.build_and_assert_expression(
+            Size(self.value),
+            {'format': '{operator}({0})',
+             'operator': 'size', 'values': (self.value,)})
 
     def test_size_can_use_attr_methods(self):
         size = Size(self.value)
-        self.assert_expression_dict(
-            size.eq(self.value), exp_format='{0} {operator} {1}',
-            exp_operator='=', values=[size, self.value])
+        self.build_and_assert_expression(
+            size.eq(self.value),
+            {'format': '{0} {operator} {1}',
+             'operator': '=', 'values': (size, self.value)})
 
     def test_size_can_use_and(self):
         size = Size(self.value)
         ae = AttributeExists(self.value)
-        self.assert_expression_dict(
-            size & ae, exp_format='({0} {operator} {1})',
-            exp_operator='AND', values=[size, ae])
+        self.build_and_assert_expression(
+            size & ae,
+            {'format': '({0} {operator} {1})',
+             'operator': 'AND', 'values': (size, ae)})
 
     def test_attribute_type(self):
-        self.assert_expression_dict(
+        self.build_and_assert_expression(
             AttributeType(self.value, self.value2),
-            exp_format='{operator}({0}, {1})',
-            exp_operator='attribute_type', values=[self.value, self.value2])
+            {'format': '{operator}({0}, {1})',
+             'operator': 'attribute_type',
+             'values': (self.value, self.value2)})
 
     def test_and(self):
         cond1 = Equals(self.value, self.value2)
         cond2 = Equals(self.value, self.value2)
         and_cond = And(cond1, cond2)
-        self.assert_expression_dict(
-            and_cond, exp_format='({0} {operator} {1})',
-            exp_operator='AND', values=[cond1, cond2])
+        self.build_and_assert_expression(
+            and_cond,
+            {'format': '({0} {operator} {1})',
+             'operator': 'AND', 'values': (cond1, cond2)})
 
     def test_or(self):
         cond1 = Equals(self.value, self.value2)
         cond2 = Equals(self.value, self.value2)
         or_cond = Or(cond1, cond2)
-        self.assert_expression_dict(
-            or_cond, exp_format='({0} {operator} {1})',
-            exp_operator='OR', values=[cond1, cond2])
+        self.build_and_assert_expression(
+            or_cond,
+            {'format': '({0} {operator} {1})',
+             'operator': 'OR', 'values': (cond1, cond2)})
 
     def test_not(self):
         cond = Equals(self.value, self.value2)
         not_cond = Not(cond)
-        self.assert_expression_dict(
-            not_cond, exp_format='({operator} {0})',
-            exp_operator='NOT', values=[cond])
+        self.build_and_assert_expression(
+            not_cond,
+            {'format': '({operator} {0})',
+             'operator': 'NOT', 'values': (cond,)})
 
 
 class TestConditionExpressionBuilder(unittest.TestCase):

--- a/tests/unit/dynamodb/test_conditions.py
+++ b/tests/unit/dynamodb/test_conditions.py
@@ -319,6 +319,18 @@ class TestConditionExpressionBuilder(unittest.TestCase):
         self.assert_condition_expression_build(
             a.eq('foo'), '#n0 = :v0', {'#n0': 'myattr'}, {':v0': 'foo'})
 
+    def test_reset(self):
+        a = Attr('myattr')
+        self.assert_condition_expression_build(
+            a.eq('foo'), '#n0 = :v0', {'#n0': 'myattr'}, {':v0': 'foo'})
+
+        self.assert_condition_expression_build(
+            a.eq('foo'), '#n1 = :v1', {'#n1': 'myattr'}, {':v1': 'foo'})
+
+        self.builder.reset()
+        self.assert_condition_expression_build(
+            a.eq('foo'), '#n0 = :v0', {'#n0': 'myattr'}, {':v0': 'foo'})
+
     def test_build_expression_lt(self):
         a = Attr('myattr')
         self.assert_condition_expression_build(


### PR DESCRIPTION
This is an easy way to build conditional expressions for operations like query, scan, etc. It helps build both the conditional expression string and any placeholders that may be required for the attribute name or value. This can be applied whenever the dynamodb shape is ``ConditionExpression`` or any other similar shapes like ``KeyExpression``

To get a sense of all of the different options I would first checkout the TestConditionExpressionBuilder to see what the end output of using the builder with the various attribute and attribute methods is.

cc @jamesls 