### PR TITLE
Initial commit at resource extensibility

### DIFF
--- a/boto3/session.py
+++ b/boto3/session.py
@@ -48,7 +48,7 @@ class Session(object):
             self._session = botocore_session
         else:
             # Create a new default session
-            self._session = botocore.session.Session()
+            self._session = botocore.session.get_session()
 
         # Setup custom user-agent string if it isn't already customized
         if self._session.user_agent_name == 'Botocore':
@@ -71,7 +71,8 @@ class Session(object):
         if region_name is not None:
             self._session.set_config_variable('region', region_name)
 
-        self.resource_factory = ResourceFactory()
+        self.resource_factory = ResourceFactory(
+            self._session.get_component('event_emitter'))
         self._setup_loader()
         self._register_default_handlers()
 

--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -17,4 +17,4 @@ def run(command):
 
 
 run('nosetests --with-coverage --cover-erase --cover-package boto3 '
-    '--with-xunit --cover-xml -v unit/')
+    '--with-xunit --cover-xml -v unit/ functional/')

--- a/tests/functional/test_resource.py
+++ b/tests/functional/test_resource.py
@@ -1,0 +1,38 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import boto3
+
+import botocore.session
+from tests import unittest
+
+
+def identity(self, x):
+    return x
+
+
+class TestResourceCustomization(unittest.TestCase):
+    def setUp(self):
+        self.botocore_session = botocore.session.get_session()
+
+    def add_new_method(self, name):
+        def handler(class_attributes, **kwargs):
+            class_attributes[name] = identity
+        return handler
+
+    def test_can_inject_method_onto_resource(self):
+        session = boto3.Session(botocore_session=self.botocore_session)
+        self.botocore_session.register('creating-resource-class.s3',
+                                       self.add_new_method(name='my_method'))
+        resource = session.resource('s3')
+        self.assertTrue(hasattr(resource, 'my_method'))
+        self.assertEqual(resource.my_method('anything'), 'anything')

--- a/tests/unit/resources/test_collection.py
+++ b/tests/unit/resources/test_collection.py
@@ -28,7 +28,7 @@ class TestCollectionFactory(BaseTestCase):
         self.client.can_paginate.return_value = False
         self.parent = mock.Mock()
         self.parent.meta = ResourceMeta('test', client=self.client)
-        self.resource_factory = ResourceFactory()
+        self.resource_factory = ResourceFactory(mock.Mock())
         self.service_model = ServiceModel({})
 
         self.factory = CollectionFactory()
@@ -128,9 +128,9 @@ class TestResourceCollection(BaseTestCase):
         self.client.can_paginate.return_value = False
         self.parent = mock.Mock()
         self.parent.meta = ResourceMeta('test', client=self.client)
-        self.factory = ResourceFactory()
+        self.factory = ResourceFactory(mock.Mock())
         self.service_model = ServiceModel({})
-   
+
     def get_collection(self):
         resource_defs = {
             'Frob': {

--- a/tests/unit/resources/test_factory.py
+++ b/tests/unit/resources/test_factory.py
@@ -820,3 +820,6 @@ class TestServiceResourceSubresources(BaseTestResourceFactory):
         actual_class_attrs = sorted(call_args[1]['class_attributes'])
         self.assertEqual(actual_class_attrs,
                          ['Message', 'PriorityQueue', 'QueueObject', 'meta'])
+
+        base_classes = sorted(call_args[1]['base_classes'])
+        self.assertEqual(base_classes, [ServiceResource])

--- a/tests/unit/resources/test_response.py
+++ b/tests/unit/resources/test_response.py
@@ -297,7 +297,7 @@ class TestResourceHandler(BaseTestCase):
     def setUp(self):
         super(TestResourceHandler, self).setUp()
         self.identifier_path = ''
-        self.factory = ResourceFactory()
+        self.factory = ResourceFactory(mock.Mock())
         self.resource_defs = {
             'Frob': {
                 'shape': 'Frob',


### PR DESCRIPTION
Allows you to hook into the class creation of a resource.  Basically creating-client-class of botocore, but for resources.

I started adding functional tests (will likely add something that moves out the pre-existing functional tests over in this directory) that shows an example of this: https://github.com/boto/boto3/compare/boto:develop...jamesls:resource-ext?expand=1#diff-42a63ce0e2acdc06478bbda36a076e9aR32

cc @kyleknap

