### PR TITLE
Pinned boto3 to botocore alpha release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ VERSION_RE = re.compile(r'''__version__ = ['"]([0-9.]+)['"]''')
 
 
 requires = [
-    'botocore==1.0.0a2',
+    'botocore>=1.0.0a3,<1.0.0b',
     'bcdoc==0.12.2',
     'jmespath>=0.6.2,<1.0.0',
 ]


### PR DESCRIPTION
I tested this locally by changing my local botocore version to a beta release and than installed boto3. It successfully installed the latest alpha release of botocore instead of use the existing beta release version that was installed.

cc @jamesls 