### PR TITLE
Rename paginate

### DIFF
--- a/boto3/resources/collection.py
+++ b/boto3/resources/collection.py
@@ -151,7 +151,8 @@ class ResourceCollection(object):
                         self._py_operation_name, params)
             paginator = client.get_paginator(self._py_operation_name)
             pages = paginator.paginate(
-                max_items=limit, page_size=page_size, **params)
+                PaginationConfig={
+                    'MaxItems': limit, 'PageSize': page_size}, **params)
         else:
             logger.info('Calling %s:%s with %r',
                         self._parent.meta.service_name,

--- a/boto3/resources/collection.py
+++ b/boto3/resources/collection.py
@@ -179,7 +179,7 @@ class ResourceCollection(object):
             if limit is not None and count >= limit:
                 break
 
-    def all(self, limit=None, page_size=None):
+    def all(self):
         """
         Get all items from the collection, optionally with a custom
         page size and item count limit.
@@ -197,14 +197,8 @@ class ResourceCollection(object):
             >>> queues = list(sqs.queues.all())
             >>> len(queues)
             2
-
-        :type limit: int
-        :param limit: Return no more than this many items
-        :type page_size: int
-        :param page_size: Fetch this many items per request
-        :rtype: :py:class:`ResourceCollection`
         """
-        return self._clone(limit=limit, page_size=page_size)
+        return self._clone()
 
     def filter(self, **kwargs):
         """
@@ -338,8 +332,8 @@ class CollectionManager(object):
                                     self._handler, **kwargs)
 
     # Set up some methods to proxy ResourceCollection methods
-    def all(self, limit=None, page_size=None):
-        return self.iterator(limit=limit, page_size=page_size)
+    def all(self):
+        return self.iterator()
     all.__doc__ = ResourceCollection.all.__doc__
 
     def filter(self, **kwargs):

--- a/docs/source/guide/collections.rst
+++ b/docs/source/guide/collections.rst
@@ -93,15 +93,10 @@ Limiting Results
 ----------------
 It is possible to limit the number of items returned from a collection
 by using either the
-:py:meth:`~boto3.resources.collection.ResourceCollection.limit` method or
-keyword argument::
+:py:meth:`~boto3.resources.collection.ResourceCollection.limit` method::
 
     # S3 iterate over first ten buckets
     for bucket in s3.buckets.limit(10):
-        print(bucket.name)
-
-    # Keyword argument example
-    for bucket in s3.buckets.filter(limit=10):
         print(bucket.name)
 
 In both cases, up to 10 items total will be returned. If you do not
@@ -112,16 +107,12 @@ Controlling Page Size
 Collections automatically handle paging through results, but you may want
 to control the number of items returned from a single service operation
 call. You can do so using the
-:py:meth:`~boto3.resources.collection.ResourceCollection.page_size` method
-or keyword argument::
+:py:meth:`~boto3.resources.collection.ResourceCollection.page_size` method::
 
     # S3 iterate over all objects 100 at a time
     for obj in bucket.objects.page_size(100):
         print(obj.key)
 
-    # Keyword argument example
-    for obj in bucket.objects.all(page_size=100):
-        print(obj.key)
 
 By default, S3 will return 1000 objects at a time, so the above code
 would let you process the items in smaller batches, which could be

--- a/tests/unit/resources/test_collection.py
+++ b/tests/unit/resources/test_collection.py
@@ -225,7 +225,7 @@ class TestResourceCollection(BaseTestCase):
             ]
         }
         collection = self.get_collection()
-        items = list(collection.all(limit=2))
+        items = list(collection.all().limit(2))
         self.assertEqual(len(items), 2)
 
         # Only the first two should be present
@@ -279,7 +279,7 @@ class TestResourceCollection(BaseTestCase):
         handler.return_value.return_value = []
         collection = self.get_collection()
 
-        list(collection.filter(limit=2, Param1='foo', Param2=3))
+        list(collection.filter(Param1='foo', Param2=3).limit(2))
 
         # Note - limit is not passed through to the low-level call
         self.client.get_frobs.assert_called_with(Param1='foo', Param2=3)
@@ -421,7 +421,7 @@ class TestResourceCollection(BaseTestCase):
             }
         ]
         collection = self.get_collection()
-        items = list(collection.all(limit=2))
+        items = list(collection.all().limit(2))
         self.assertEqual(len(items), 2)
 
         # Only the first two should be present
@@ -459,7 +459,7 @@ class TestResourceCollection(BaseTestCase):
             }
         ]
         collection = self.get_collection()
-        items = list(collection.all(limit=2))
+        items = list(collection.all().limit(2))
         self.assertEqual(len(items), 2)
 
         # Only the first two should be present
@@ -473,7 +473,7 @@ class TestResourceCollection(BaseTestCase):
         handler.return_value.return_value = []
         collection = self.get_collection()
 
-        list(collection.filter(limit=2, Param1='foo', Param2=3))
+        list(collection.filter(Param1='foo', Param2=3).limit(2))
 
         paginator = self.client.get_paginator.return_value
         paginator.paginate.assert_called_with(
@@ -487,7 +487,7 @@ class TestResourceCollection(BaseTestCase):
         handler.return_value.return_value = []
         collection = self.get_collection()
 
-        list(collection.all(page_size=1))
+        list(collection.all().page_size(1))
 
         paginator = self.client.get_paginator.return_value
         paginator.paginate.assert_called_with(

--- a/tests/unit/resources/test_collection.py
+++ b/tests/unit/resources/test_collection.py
@@ -343,7 +343,8 @@ class TestResourceCollection(BaseTestCase):
         collection = self.get_collection()
         list(collection.page_size(5).pages())
 
-        paginator.paginate.assert_called_with(page_size=5, max_items=None)
+        paginator.paginate.assert_called_with(
+            PaginationConfig={'PageSize': 5, 'MaxItems': None})
 
     def test_iteration_paginated(self):
         self.collection_def = {
@@ -386,7 +387,8 @@ class TestResourceCollection(BaseTestCase):
         # Low-level pagination should have been called
         self.client.get_paginator.assert_called_with('get_frobs')
         paginator = self.client.get_paginator.return_value
-        paginator.paginate.assert_called_with(page_size=None, max_items=None)
+        paginator.paginate.assert_called_with(
+            PaginationConfig={'PageSize': None, 'MaxItems': None})
 
     def test_limit_param_paginated(self):
         self.collection_def = {
@@ -475,7 +477,8 @@ class TestResourceCollection(BaseTestCase):
 
         paginator = self.client.get_paginator.return_value
         paginator.paginate.assert_called_with(
-            page_size=None, max_items=2, Param1='foo', Param2=3)
+            PaginationConfig={'PageSize': None, 'MaxItems': 2},
+            Param1='foo', Param2=3)
 
     @mock.patch('boto3.resources.collection.ResourceHandler')
     def test_page_size_param(self, handler):
@@ -487,7 +490,8 @@ class TestResourceCollection(BaseTestCase):
         list(collection.all(page_size=1))
 
         paginator = self.client.get_paginator.return_value
-        paginator.paginate.assert_called_with(page_size=1, max_items=None)
+        paginator.paginate.assert_called_with(
+            PaginationConfig={'PageSize': 1, 'MaxItems': None})
 
     @mock.patch('boto3.resources.collection.ResourceHandler')
     def test_page_size_method(self, handler):
@@ -499,7 +503,8 @@ class TestResourceCollection(BaseTestCase):
         list(collection.page_size(1))
 
         paginator = self.client.get_paginator.return_value
-        paginator.paginate.assert_called_with(page_size=1, max_items=None)
+        paginator.paginate.assert_called_with(
+            PaginationConfig={'PageSize': 1, 'MaxItems': None})
 
     def test_chaining(self):
         self.collection_def = {
@@ -546,7 +551,7 @@ class TestResourceCollection(BaseTestCase):
 
         paginator = self.client.get_paginator.return_value
         paginator.paginate.assert_called_with(
-            page_size=3, max_items=3, CustomArg=1)
+            PaginationConfig={'PageSize': 3, 'MaxItems': 3}, CustomArg=1)
 
     def test_chained_repr(self):
         collection = self.get_collection()


### PR DESCRIPTION
This updates the collections API to botocore's pagination api change: https://github.com/boto/botocore/pull/547

This also introduces a breaking change where  I removed some parameters to make the collections api less confusing by having only one canonical way of limiting the number of results (``limit()`` method) and sizes of pages (``page_size()`` method). Also this ensures consistency of casing of arguments passed to collections method).

Note that for the ``filter()`` method, the ``limit`` and ``page_size`` arguments were just undocumented to signify we do not officially support those parameters. Let me know what you think about this. I also considered throwing an error if those parameters were ran into in the ``filter()`` since ``filter()`` takes in only kwargs.

cc @jamesls @mtdowling