### PR TITLE
Fix DynamoDB leaking tables in integ tests

### DIFF
--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -70,7 +70,7 @@ class TestDynamoDBConditions(BaseDynamoDBTest):
     @classmethod
     def tearDownClass(cls):
         cls.table.delete_item(Key={'MyHashKey': 'mykey'})
-        super(TestDynamoDBConditions, cls).setUpClass()
+        super(TestDynamoDBConditions, cls).tearDownClass()
 
     def test_filter_expression(self):
         r = self.table.scan(


### PR DESCRIPTION
This would actually leak 2 tables because we'd create
a table in setupClass, and then create another one in
tearDownClass because we called setupClass again.


cc @kyleknap @mtdowling