### PR TITLE
Fix regression in older versions of pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,12 @@ requires = [
 ]
 
 
+if sys.version_info[0] == 2:
+    # concurrent.futures is only in python3, so for
+    # python2 we need to install the backport.
+    requires.append('futures==2.2.0')
+
+
 def get_version():
     init = open(os.path.join(ROOT, 'boto3', '__init__.py')).read()
     return VERSION_RE.search(init).group(1)


### PR DESCRIPTION
Verified it as well. By using python 2.6, pip 1.4.1, and installing the sdist with pip.

cc @jamesls @mtdowling