### PR TITLE
Wrong type in tutorial's SQS create_queue call

### DIFF
--- a/docs/source/guide/tutorial.rst
+++ b/docs/source/guide/tutorial.rst
@@ -19,7 +19,7 @@ Before creating a queue, you must first get the SQS service resource::
     sqs = boto3.resource('sqs')
 
     # Create the queue. This returns an SQS.Queue instance
-    queue = sqs.create_queue(QueueName='test', Attributes={'DelaySeconds': 5})
+    queue = sqs.create_queue(QueueName='test', Attributes={'DelaySeconds': '5'})
 
     # You can now access identifiers and attributes
     print(queue.url)


### PR DESCRIPTION
Current use of integer value throws following error:
```Invalid type for parameter Attributes.DelaySeconds, value: 5, type: <type 'int'>, valid types: <type 'basestring'>```
Should be strings in Attributes dict.