### PR TITLE
SQS tutorial get() not get[]

### DIFF
--- a/docs/source/guide/tutorial.rst
+++ b/docs/source/guide/tutorial.rst
@@ -23,7 +23,7 @@ Before creating a queue, you must first get the SQS service resource::
 
     # You can now access identifiers and attributes
     print(queue.url)
-    print(queue.attributes.get['DelaySeconds'])
+    print(queue.attributes.get('DelaySeconds'))
 
 Reference: :py:meth:`sqs.ServiceResource.create_queue`
 


### PR DESCRIPTION
Current version 
```
queue.attributes.get['DelaySeconds']
```
throws
```
TypeError: 'builtin_function_or_method' object has no attribute '__getitem__'
```

Should instead be 
```
queue.attributes.get('DelaySeconds')
# or
queue.attributes['DelaySeconds']
```

Presuming former was intended.