### PR TITLE
Use module names for service reference titles

### DIFF
--- a/boto3/docs/service.py
+++ b/boto3/docs/service.py
@@ -64,9 +64,7 @@ class ServiceDocumenter(object):
         return doc_structure.flush_structure()
 
     def _document_title(self, section):
-        official_service_name = get_official_service_name(
-            self._client.meta.service_model)
-        section.style.h1(official_service_name)
+        section.style.h1(self._client.__class__.__name__)
 
     def _document_table_of_contents(self, section):
         section.style.table_of_contents(title='Table of Contents', depth=2)

--- a/tests/functional/docs/test_smoke.py
+++ b/tests/functional/docs/test_smoke.py
@@ -28,6 +28,9 @@ def test_docs_generated():
         generated_docs = generated_docs.decode('utf-8')
         client = boto3.client(service_name, 'us-east-1')
 
+        # Check that all of the services have the appropriate title
+        yield (_assert_has_title, generated_docs, client)
+
         # Check that all services have the client documented.
         yield (_assert_has_client_documentation, generated_docs, service_name,
                client)
@@ -60,6 +63,16 @@ def _assert_contains_lines_in_order(lines, contents):
         assert_true(line in contents)
         beginning = contents.find(line)
         contents = contents[(beginning + len(line)):]
+
+
+def _assert_has_title(generated_docs, client):
+    title = client.__class__.__name__
+    ref_lines = [
+        '*' * len(title),
+        title,
+        '*' * len(title)
+    ]
+    _assert_contains_lines_in_order(ref_lines, generated_docs)
 
 
 def _assert_has_client_documentation(generated_docs, service_name, client):


### PR DESCRIPTION
Addresses: https://github.com/boto/boto3/issues/146

I made it so that the title use the module name instead of the full names. Here is how it will look:

Here is the sidebar:
![screen shot 2015-06-24 at 1 10 16 pm](https://cloud.githubusercontent.com/assets/4605355/8340411/277c2b6c-1a73-11e5-851a-06b6c48fcd35.png)

Here is the actual service page:
![screen shot 2015-06-24 at 1 10 26 pm](https://cloud.githubusercontent.com/assets/4605355/8340450/5f595e1a-1a73-11e5-8b84-07cf24dd710a.png)

And the descriptions still use the full name:
![screen shot 2015-06-24 at 1 10 37 pm](https://cloud.githubusercontent.com/assets/4605355/8340452/6fec3d60-1a73-11e5-923c-02843a430c47.png)

I will make a similar PR to botocore to update those.

cc @jamesls @mtdowling
