### PR TITLE
Remove if clause for py2 future dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,12 +20,6 @@ requires = [
 ]
 
 
-if sys.version_info[0] == 2:
-    # concurrent.futures is only in python3, so for
-    # python2 we need to install the backport.
-    requires.append('futures==2.2.0')
-
-
 def get_version():
     init = open(os.path.join(ROOT, 'boto3', '__init__.py')).read()
     return VERSION_RE.search(init).group(1)


### PR DESCRIPTION
Not needed, the environment markers already declare
this conditional dependency.

Fixes #163.

cc @kyleknap @mtdowling