### PR TITLE
Update S3 transfer docs

### DIFF
--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -85,14 +85,14 @@ to the user:
             self._seen_so_far = 0
             self._lock = threading.Lock()
 
-        def __call__(self, filename, bytes_amount):
+        def __call__(self, bytes_amount):
             # To simplify we'll assume this is hooked up
             # to a single filename.
             with self._lock:
                 self._seen_so_far += bytes_amount
                 percentage = (self._seen_so_far / self._size) * 100
                 sys.stdout.write(
-                    "\r%s  %s / %s  (%.2f%%)" % (filename, self._seen_so_far,
+                    "\r%s  %s / %s  (%.2f%%)" % (self._filename, self._seen_so_far,
                                                  self._size, percentage))
                 sys.stdout.flush()
 


### PR DESCRIPTION
Transfer callback only passes bytes transferred, not filename