### PR TITLE
Update logic for ignore action parameters

### DIFF
--- a/boto3/docs/utils.py
+++ b/boto3/docs/utils.py
@@ -11,11 +11,23 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import inspect
+import re
 from botocore.compat import six
+
+TARGET_COMPONENT_RE = re.compile(r'[^.\[\]]+(?![^\[]*\])')
 
 
 def get_resource_ignore_params(params):
-    return [p.target.split('.')[0].strip('[]') for p in params]
+    """Helper method to determine which parameters to ignore for actions
+
+    :returns: A list of the parameter names that does not need to be
+        included in a resource's method call for documentation purposes.
+    """
+    ignore_params = []
+    for param in params:
+        components = TARGET_COMPONENT_RE.findall(param.target)
+        ignore_params.append(components[0])
+    return ignore_params
 
 
 def is_resource_action(action_handle):

--- a/tests/unit/docs/test_utils.py
+++ b/tests/unit/docs/test_utils.py
@@ -1,0 +1,42 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests import unittest
+
+from boto3.resources.model import Parameter
+from boto3.docs.utils import get_resource_ignore_params
+
+
+class TestGetResourceIgnoreParams(unittest.TestCase):
+    def test_target_is_single_resource(self):
+        param = Parameter('InstanceId', 'response')
+        ignore_params = get_resource_ignore_params([param])
+        self.assertEqual(ignore_params, ['InstanceId'])
+
+    def test_target_is_multiple_resources(self):
+        param = Parameter('InstanceIds[]', 'response')
+        ignore_params = get_resource_ignore_params([param])
+        self.assertEqual(ignore_params, ['InstanceIds'])
+
+    def test_target_is_element_of_multiple_resources(self):
+        param = Parameter('InstanceIds[0]', 'response')
+        ignore_params = get_resource_ignore_params([param])
+        self.assertEqual(ignore_params, ['InstanceIds'])
+
+    def test_target_is_nested_param(self):
+        param = Parameter('Filters[0].Name', 'response')
+        ignore_params = get_resource_ignore_params([param])
+        self.assertEqual(ignore_params, ['Filters'])
+
+        param = Parameter('Filters[0].Values[0]', 'response')
+        ignore_params = get_resource_ignore_params([param])
+        self.assertEqual(ignore_params, ['Filters'])


### PR DESCRIPTION
The logic before assumed that the JMESPath expression would not have an integer between square brackets. Thus some parameters were documented in a resource action when they were not supposed to be as the resource already provided their values.

Fixes https://github.com/boto/boto3/issues/187

Here is what it looks like now:
![screen shot 2015-07-30 at 2 57 10 pm](https://cloud.githubusercontent.com/assets/4605355/8996234/566c852e-36cb-11e5-9a8c-c4ebf12115a3.png)

Here is what it looks like after the fix:
![screen shot 2015-07-30 at 2 57 02 pm](https://cloud.githubusercontent.com/assets/4605355/8996244/60d5e028-36cb-11e5-9d76-d1f42df2dd00.png)

Note that ``report_status()`` is for the ``EC2.Instance`` object which should not require an ``Instances`` parameter to be included.

cc @jamesls @mtdowling @rayluo 