### PR TITLE
Generate shared examples in API documentation

### DIFF
--- a/boto3/docs/service.py
+++ b/boto3/docs/service.py
@@ -70,7 +70,8 @@ class ServiceDocumenter(object):
         section.style.table_of_contents(title='Table of Contents', depth=2)
 
     def _document_client(self, section):
-        Boto3ClientDocumenter(self._client).document_client(section)
+        examples = self._botocore_session.get_examples(self._service_name)
+        Boto3ClientDocumenter(self._client, examples).document_client(section)
 
     def _document_paginators(self, section):
         try:


### PR DESCRIPTION
Companion to [this PR for botocore](https://github.com/boto/botocore/pull/617). Loads examples for the Boto3ClientDocumenter.