### PR TITLE
Add events property to boto3.session.Session

### DIFF
--- a/boto3/session.py
+++ b/boto3/session.py
@@ -88,6 +88,13 @@ class Session(object):
         """
         return self._session.profile or 'default'
 
+    @property
+    def events(self):
+        """
+        The event emitter for a session
+        """
+        return self._session.get_component('event_emitter')
+
     def _setup_loader(self):
         """
         Setup loader paths so that we can load resources.

--- a/tests/functional/test_session.py
+++ b/tests/functional/test_session.py
@@ -1,0 +1,34 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests import unittest
+
+import boto3.session
+
+
+class TestSession(unittest.TestCase):
+    def setUp(self):
+        self.session = boto3.session.Session(region_name='us-west-2')
+
+    def test_events_attribute(self):
+        # Create some function to register.
+        def my_handler(my_list, **kwargs):
+            return my_list.append('my_handler called')
+
+        # Register the handler to the event.
+        self.session.events.register('myevent', my_handler)
+
+        initial_list = []
+        # Emit the event.
+        self.session.events.emit('myevent', my_list=initial_list)
+        # Ensure that the registered handler was called.
+        self.assertEqual(initial_list, ['my_handler called'])

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -201,3 +201,9 @@ class TestSession(BaseTestCase):
         session = Session(botocore_session=mock_bc_session)
         with self.assertRaises(DataNotFoundError):
             session.resource('sqs')
+
+    def test_can_reach_events(self):
+        mock_bc_session = self.bc_session_cls()
+        session = Session(botocore_session=mock_bc_session)
+        session.events
+        mock_bc_session.get_component.assert_called_with('event_emitter')


### PR DESCRIPTION
Before the only way to hook into the ``'creating-client-class'`` and ``'creating-resource-class'`` events was to first create a botocore session and pass that to the instantiation of the ``boto3.session.Session`` object and register using the botocore session. This gives users access to the event system through the ``boto3.session.Session`` object much like you have access to it via the ``client.meta.events`` property.

cc @jamesls @mtdowling @rayluo 