### PR TITLE
Fix typo (Dynanmo->Dynamo).

### DIFF
--- a/boto3/dynamodb/conditions.py
+++ b/boto3/dynamodb/conditions.py
@@ -14,7 +14,7 @@ from collections import namedtuple
 import functools
 import re
 
-from boto3.exceptions import DynanmoDBOperationNotSupportedError
+from boto3.exceptions import DynamoDBOperationNotSupportedError
 from boto3.exceptions import DynamoDBNeedsConditionError
 from boto3.exceptions import DynamoDBNeedsKeyConditionError
 
@@ -33,12 +33,12 @@ class ConditionBase(object):
 
     def __and__(self, other):
         if not isinstance(other, ConditionBase):
-            raise DynanmoDBOperationNotSupportedError('AND', other)
+            raise DynamoDBOperationNotSupportedError('AND', other)
         return And(self, other)
 
     def __or__(self, other):
         if not isinstance(other, ConditionBase):
-            raise DynanmoDBOperationNotSupportedError('OR', other)
+            raise DynamoDBOperationNotSupportedError('OR', other)
         return Or(self, other)
 
     def __invert__(self):
@@ -64,13 +64,13 @@ class AttributeBase(object):
         self.name = name
 
     def __and__(self, value):
-        raise DynanmoDBOperationNotSupportedError('AND', self)
+        raise DynamoDBOperationNotSupportedError('AND', self)
 
     def __or__(self, value):
-        raise DynanmoDBOperationNotSupportedError('OR', self)
+        raise DynamoDBOperationNotSupportedError('OR', self)
 
     def __invert__(self):
-        raise DynanmoDBOperationNotSupportedError('NOT', self)
+        raise DynamoDBOperationNotSupportedError('NOT', self)
 
     def eq(self, value):
         """Creates a condtion where the attribute is equal to the value.

--- a/boto3/exceptions.py
+++ b/boto3/exceptions.py
@@ -33,7 +33,7 @@ class S3UploadFailedError(Exception):
     pass
 
 
-class DynanmoDBOperationNotSupportedError(Exception):
+class DynamoDBOperationNotSupportedError(Exception):
     """Raised for operantions that are not supported for an operand"""
     def __init__(self, operation, value):
         msg = (

--- a/boto3/exceptions.py
+++ b/boto3/exceptions.py
@@ -43,6 +43,8 @@ class DynamoDBOperationNotSupportedError(Exception):
             (operation, value, type(value)))
         Exception.__init__(self, msg)
 
+# FIXME: Backward compatibility
+DynanmoDBOperationNotSupportedError = DynamoDBOperationNotSupportedError
 
 class DynamoDBNeedsConditionError(Exception):
     """Raised when input is not a condition"""

--- a/tests/unit/dynamodb/test_conditions.py
+++ b/tests/unit/dynamodb/test_conditions.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 from tests import unittest
 
-from boto3.exceptions import DynanmoDBOperationNotSupportedError
+from boto3.exceptions import DynamoDBOperationNotSupportedError
 from boto3.exceptions import DynamoDBNeedsConditionError
 from boto3.exceptions import DynamoDBNeedsKeyConditionError
 from boto3.dynamodb.conditions import Attr, Key
@@ -34,17 +34,17 @@ class TestK(unittest.TestCase):
 
     def test_and(self):
         with self.assertRaisesRegexp(
-                DynanmoDBOperationNotSupportedError, 'AND'):
+                DynamoDBOperationNotSupportedError, 'AND'):
             self.attr & self.attr2
 
     def test_or(self):
         with self.assertRaisesRegexp(
-                DynanmoDBOperationNotSupportedError, 'OR'):
+                DynamoDBOperationNotSupportedError, 'OR'):
             self.attr | self.attr2
 
     def test_not(self):
         with self.assertRaisesRegexp(
-                DynanmoDBOperationNotSupportedError, 'NOT'):
+                DynamoDBOperationNotSupportedError, 'NOT'):
             ~self.attr
 
     def test_eq(self):
@@ -148,7 +148,7 @@ class TestConditions(unittest.TestCase):
     def test_and_operator_throws_excepetion(self):
         cond1 = Equals(self.value, self.value2)
         with self.assertRaisesRegexp(
-                DynanmoDBOperationNotSupportedError, 'AND'):
+                DynamoDBOperationNotSupportedError, 'AND'):
             cond1 & self.value2
 
     def test_or_operator(self):
@@ -159,7 +159,7 @@ class TestConditions(unittest.TestCase):
     def test_or_operator_throws_excepetion(self):
         cond1 = Equals(self.value, self.value2)
         with self.assertRaisesRegexp(
-                DynanmoDBOperationNotSupportedError, 'OR'):
+                DynamoDBOperationNotSupportedError, 'OR'):
             cond1 | self.value2
 
     def test_not_operator(self):


### PR DESCRIPTION
* Fixed typo in DynamoDB exception class name.
* Fixed tests.
* Provided alias for backward compatibility.