### PR TITLE
Update migrations3.rst

### DIFF
--- a/docs/source/guide/migrations3.rst
+++ b/docs/source/guide/migrations3.rst
@@ -88,7 +88,7 @@ Bucket and key objects are no longer iterable, but now provide collection attrib
     # Boto 3
     for bucket in s3.buckets.all():
         for key in bucket.objects.all():
-            print(key.name)
+            print(key.key)
 
 Access Controls
 ---------------


### PR DESCRIPTION
There was an error in the Boto 3 example, you need to use the .key attribute in order to print the S3 key name.