### PR TITLE
Corrected A/An in docs

### DIFF
--- a/boto3/docs/method.py
+++ b/boto3/docs/method.py
@@ -38,7 +38,7 @@ def document_model_driven_resource_method(
         if 'return' in section.available_sections:
             section.delete_section('return')
 		
-		resource_type = resource_action_model.resource.type
+	resource_type = resource_action_model.resource.type
 		
         new_return_section = section.add_new_section('return')
         return_resource_type = '%s.%s' % (

--- a/boto3/docs/method.py
+++ b/boto3/docs/method.py
@@ -14,54 +14,53 @@ from botocore.docs.method import document_model_driven_method
 
 
 def document_model_driven_resource_method(
-        section, method_name, operation_model, event_emitter,
-        method_description=None, example_prefix=None, include_input=None,
-        include_output=None, exclude_input=None, exclude_output=None,
-        document_output=True, resource_action_model=None):
+	section, method_name, operation_model, event_emitter,
+	method_description=None, example_prefix=None, include_input=None,
+	include_output=None, exclude_input=None, exclude_output=None,
+	document_output=True, resource_action_model=None):
 
     document_model_driven_method(
-        section=section, method_name=method_name,
-        operation_model=operation_model,
-        event_emitter=event_emitter,
-        method_description=method_description,
-        example_prefix=example_prefix,
-        include_input=include_input,
-        include_output=include_output,
-        exclude_input=exclude_input,
-        exclude_output=exclude_output,
-        document_output=document_output
+	section=section, method_name=method_name,
+	operation_model=operation_model,
+	event_emitter=event_emitter,
+	method_description=method_description,
+	example_prefix=example_prefix,
+	include_input=include_input,
+	include_output=include_output,
+	exclude_input=exclude_input,
+	exclude_output=exclude_output,
+	document_output=document_output
     )
 
     # If this action returns a reource modify the return example to
     # appropriately reflect that.
     if resource_action_model.resource:
-        if 'return' in section.available_sections:
-            section.delete_section('return')
-		
+	if 'return' in section.available_sections:
+	    section.delete_section('return')
 	resource_type = resource_action_model.resource.type
 		
-        new_return_section = section.add_new_section('return')
-        return_resource_type = '%s.%s' % (
-            operation_model.service_model.service_name,
-            resource_type)
+	new_return_section = section.add_new_section('return')
+	return_resource_type = '%s.%s' % (
+	    operation_model.service_model.service_name,
+	    resource_type)
 
-        return_type = ':py:class:`%s`' % return_resource_type
+	return_type = ':py:class:`%s`' % return_resource_type
 	if resource_type.startswith('A') or resource_type.startswith('a'):
 		return_description = 'An %s resource' % (
-			resource_type)	
-        else:
+			resource_type)  
+	else:
 		return_description = 'A %s resource' % (
 			resource_type)
 
-        if resource_action_model.path and '[]' in resource_action_model.path:
-            return_type = 'list(%s)' % return_type
-            return_description = 'A list of %s resources' % (
-                resource_type)
+	if resource_action_model.path and '[]' in resource_action_model.path:
+	    return_type = 'list(%s)' % return_type
+	    return_description = 'A list of %s resources' % (
+		resource_type)
 
-        new_return_section.style.new_line()
-        new_return_section.write(
-            ':rtype: %s' % return_type)
-        new_return_section.style.new_line()
-        new_return_section.write(
-            ':returns: %s' % return_description)
-        new_return_section.style.new_line()
+	new_return_section.style.new_line()
+	new_return_section.write(
+	    ':rtype: %s' % return_type)
+	new_return_section.style.new_line()
+	new_return_section.write(
+	    ':returns: %s' % return_description)
+	new_return_section.style.new_line()

--- a/boto3/docs/method.py
+++ b/boto3/docs/method.py
@@ -46,12 +46,12 @@ def document_model_driven_resource_method(
             resource_type)
 
         return_type = ':py:class:`%s`' % return_resource_type
-		if resource_type.startswith('A') or resource_type.startswith('a'):
-			return_description = 'An %s resource' % (
-				resource_type)	
+	if resource_type.startswith('A') or resource_type.startswith('a'):
+		return_description = 'An %s resource' % (
+			resource_type)	
         else:
-			return_description = 'A %s resource' % (
-				resource_type)
+		return_description = 'A %s resource' % (
+			resource_type)
 
         if resource_action_model.path and '[]' in resource_action_model.path:
             return_type = 'list(%s)' % return_type

--- a/boto3/docs/method.py
+++ b/boto3/docs/method.py
@@ -14,53 +14,53 @@ from botocore.docs.method import document_model_driven_method
 
 
 def document_model_driven_resource_method(
-	section, method_name, operation_model, event_emitter,
-	method_description=None, example_prefix=None, include_input=None,
-	include_output=None, exclude_input=None, exclude_output=None,
-	document_output=True, resource_action_model=None):
+        section, method_name, operation_model, event_emitter,
+        method_description=None, example_prefix=None, include_input=None,
+        include_output=None, exclude_input=None, exclude_output=None,
+        document_output=True, resource_action_model=None):
 
     document_model_driven_method(
-	section=section, method_name=method_name,
-	operation_model=operation_model,
-	event_emitter=event_emitter,
-	method_description=method_description,
-	example_prefix=example_prefix,
-	include_input=include_input,
-	include_output=include_output,
-	exclude_input=exclude_input,
-	exclude_output=exclude_output,
-	document_output=document_output
+        section=section, method_name=method_name,
+        operation_model=operation_model,
+        event_emitter=event_emitter,
+        method_description=method_description,
+        example_prefix=example_prefix,
+        include_input=include_input,
+        include_output=include_output,
+        exclude_input=exclude_input,
+        exclude_output=exclude_output,
+        document_output=document_output
     )
 
     # If this action returns a reource modify the return example to
     # appropriately reflect that.
     if resource_action_model.resource:
-	if 'return' in section.available_sections:
-	    section.delete_section('return')
-	resource_type = resource_action_model.resource.type
-		
-	new_return_section = section.add_new_section('return')
-	return_resource_type = '%s.%s' % (
-	    operation_model.service_model.service_name,
-	    resource_type)
+        if 'return' in section.available_sections:
+            section.delete_section('return')
+        resource_type = resource_action_model.resource.type
+                
+        new_return_section = section.add_new_section('return')
+        return_resource_type = '%s.%s' % (
+            operation_model.service_model.service_name,
+            resource_type)
 
-	return_type = ':py:class:`%s`' % return_resource_type
-	if resource_type.startswith('A') or resource_type.startswith('a'):
-		return_description = 'An %s resource' % (
-			resource_type)  
-	else:
-		return_description = 'A %s resource' % (
-			resource_type)
+        return_type = ':py:class:`%s`' % return_resource_type
+        if resource_type.startswith('A') or resource_type.startswith('a'):
+                return_description = 'An %s resource' % (
+                        resource_type)  
+        else:
+                return_description = 'A %s resource' % (
+                        resource_type)
 
-	if resource_action_model.path and '[]' in resource_action_model.path:
-	    return_type = 'list(%s)' % return_type
-	    return_description = 'A list of %s resources' % (
-		resource_type)
+        if resource_action_model.path and '[]' in resource_action_model.path:
+            return_type = 'list(%s)' % return_type
+            return_description = 'A list of %s resources' % (
+                resource_type)
 
-	new_return_section.style.new_line()
-	new_return_section.write(
-	    ':rtype: %s' % return_type)
-	new_return_section.style.new_line()
-	new_return_section.write(
-	    ':returns: %s' % return_description)
-	new_return_section.style.new_line()
+        new_return_section.style.new_line()
+        new_return_section.write(
+            ':rtype: %s' % return_type)
+        new_return_section.style.new_line()
+        new_return_section.write(
+            ':returns: %s' % return_description)
+        new_return_section.style.new_line()

--- a/boto3/docs/method.py
+++ b/boto3/docs/method.py
@@ -37,19 +37,26 @@ def document_model_driven_resource_method(
     if resource_action_model.resource:
         if 'return' in section.available_sections:
             section.delete_section('return')
+		
+		resource_type = resource_action_model.resource.type
+		
         new_return_section = section.add_new_section('return')
         return_resource_type = '%s.%s' % (
             operation_model.service_model.service_name,
-            resource_action_model.resource.type)
+            resource_type)
 
         return_type = ':py:class:`%s`' % return_resource_type
-        return_description = 'A %s resource' % (
-            resource_action_model.resource.type)
+		if resource_type.startswith('A') or resource_type.startswith('a'):
+			return_description = 'An %s resource' % (
+				resource_type)	
+        else:
+			return_description = 'A %s resource' % (
+				resource_type)
 
         if resource_action_model.path and '[]' in resource_action_model.path:
             return_type = 'list(%s)' % return_type
             return_description = 'A list of %s resources' % (
-                resource_action_model.resource.type)
+                resource_type)
 
         new_return_section.style.new_line()
         new_return_section.write(

--- a/boto3/docs/method.py
+++ b/boto3/docs/method.py
@@ -45,12 +45,7 @@ def document_model_driven_resource_method(
             resource_type)
 
         return_type = ':py:class:`%s`' % return_resource_type
-        if resource_type.startswith('A') or resource_type.startswith('a'):
-                return_description = 'An %s resource' % (
-                        resource_type)  
-        else:
-                return_description = 'A %s resource' % (
-                        resource_type)
+        return_description = '%s resource' % (resource_type)
 
         if resource_action_model.path and '[]' in resource_action_model.path:
             return_type = 'list(%s)' % return_type


### PR DESCRIPTION
I added logic to make sure that the article before a resource type that starts with 'A' is 'An.'

See line notes.

