### PR TITLE
Add docstrings to resource actions and sub-resources

### DIFF
--- a/boto3/docs/__init__.py
+++ b/boto3/docs/__init__.py
@@ -12,11 +12,10 @@
 # language governing permissions and limitations under the License.
 import os
 
-from boto3.session import Session
 from boto3.docs.service import ServiceDocumenter
 
 
-def generate_docs(root_dir):
+def generate_docs(root_dir, session):
     """Generates the reference documentation for botocore
 
     This will go through every available AWS service and output ReSTructured
@@ -25,16 +24,15 @@ def generate_docs(root_dir):
     :param root_dir: The directory to write the reference files to. Each
         service's reference documentation is loacated at
         root_dir/reference/services/service-name.rst
+
+    :param session: The boto3 session
     """
     services_doc_path = os.path.join(root_dir, 'reference', 'services')
     if not os.path.exists(services_doc_path):
         os.makedirs(services_doc_path)
 
-    # Generate reference docs and write them out.
-    session = Session()
     for service_name in session.get_available_services():
-        print(service_name)
-        docs = ServiceDocumenter(service_name).document_service()
+        docs = ServiceDocumenter(service_name, session).document_service()
         service_doc_path = os.path.join(
             services_doc_path, service_name + '.rst')
         with open(service_doc_path, 'wb') as f:

--- a/boto3/docs/attr.py
+++ b/boto3/docs/attr.py
@@ -1,0 +1,43 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from botocore.docs.utils import py_type_name
+
+from boto3.docs.utils import get_identifier_description
+
+
+def document_attribute(section, attr_name, attr_model, include_signature=True):
+    if include_signature:
+        section.style.start_sphinx_py_attr(attr_name)
+    attr_type = '*(%s)* ' % py_type_name(attr_model.type_name)
+    section.write(attr_type)
+    section.include_doc_string(attr_model.documentation)
+
+
+def document_identifier(section, resource_name, identifier_model,
+                        include_signature=True):
+    if include_signature:
+        section.style.start_sphinx_py_attr(identifier_model.name)
+    description = get_identifier_description(
+        resource_name, identifier_model.name)
+    description = '*(string)* ' + description
+    section.write(description)
+
+
+def document_reference(section, reference_model, include_signature=True):
+    if include_signature:
+        section.style.start_sphinx_py_attr(reference_model.name)
+    reference_type = '(:py:class:`%s`) ' % reference_model.resource.type
+    section.write(reference_type)
+    section.include_doc_string(
+        'The related %s if set, otherwise ``None``.' % reference_model.name
+    )

--- a/boto3/docs/docstring.py
+++ b/boto3/docs/docstring.py
@@ -1,0 +1,35 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from botocore.docs.method import LazyLoadedDocstring
+
+from boto3.docs.action import document_action
+from boto3.docs.action import document_load_reload_action
+from boto3.docs.subresource import document_sub_resource
+
+
+class ActionDocstring(LazyLoadedDocstring):
+    def __init__(self, *args, **kwargs):
+        super(ActionDocstring, self).__init__(*args, **kwargs)
+        self._docstring_writer = document_action
+
+
+class LoadReloadDocstring(LazyLoadedDocstring):
+    def __init__(self, *args, **kwargs):
+        super(LoadReloadDocstring, self).__init__(*args, **kwargs)
+        self._docstring_writer = document_load_reload_action
+
+
+class SubResourceDocstring(LazyLoadedDocstring):
+    def __init__(self, *args, **kwargs):
+        super(SubResourceDocstring, self).__init__(*args, **kwargs)
+        self._docstring_writer = document_sub_resource

--- a/boto3/docs/docstring.py
+++ b/boto3/docs/docstring.py
@@ -15,21 +15,36 @@ from botocore.docs.docstring import LazyLoadedDocstring
 from boto3.docs.action import document_action
 from boto3.docs.action import document_load_reload_action
 from boto3.docs.subresource import document_sub_resource
+from boto3.docs.attr import document_attribute
+from boto3.docs.attr import document_identifier
+from boto3.docs.attr import document_reference
 
 
 class ActionDocstring(LazyLoadedDocstring):
-    def __init__(self, *args, **kwargs):
-        super(ActionDocstring, self).__init__(*args, **kwargs)
-        self._docstring_writer = document_action
+    def _write_docstring(self, *args, **kwargs):
+        document_action(*args, **kwargs)
 
 
 class LoadReloadDocstring(LazyLoadedDocstring):
-    def __init__(self, *args, **kwargs):
-        super(LoadReloadDocstring, self).__init__(*args, **kwargs)
-        self._docstring_writer = document_load_reload_action
+    def _write_docstring(self, *args, **kwargs):
+        document_load_reload_action(*args, **kwargs)
 
 
 class SubResourceDocstring(LazyLoadedDocstring):
-    def __init__(self, *args, **kwargs):
-        super(SubResourceDocstring, self).__init__(*args, **kwargs)
-        self._docstring_writer = document_sub_resource
+    def _write_docstring(self, *args, **kwargs):
+        document_sub_resource(*args, **kwargs)
+
+
+class AttributeDocstring(LazyLoadedDocstring):
+    def _write_docstring(self, *args, **kwargs):
+        document_attribute(*args, **kwargs)
+
+
+class IdentifierDocstring(LazyLoadedDocstring):
+    def _write_docstring(self, *args, **kwargs):
+        document_identifier(*args, **kwargs)
+
+
+class ReferenceDocstring(LazyLoadedDocstring):
+    def _write_docstring(self, *args, **kwargs):
+        document_references(*args, **kwargs)

--- a/boto3/docs/docstring.py
+++ b/boto3/docs/docstring.py
@@ -47,4 +47,4 @@ class IdentifierDocstring(LazyLoadedDocstring):
 
 class ReferenceDocstring(LazyLoadedDocstring):
     def _write_docstring(self, *args, **kwargs):
-        document_references(*args, **kwargs)
+        document_reference(*args, **kwargs)

--- a/boto3/docs/docstring.py
+++ b/boto3/docs/docstring.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from botocore.docs.method import LazyLoadedDocstring
+from botocore.docs.docstring import LazyLoadedDocstring
 
 from boto3.docs.action import document_action
 from boto3.docs.action import document_load_reload_action

--- a/boto3/docs/method.py
+++ b/boto3/docs/method.py
@@ -17,7 +17,8 @@ def document_model_driven_resource_method(
         section, method_name, operation_model, event_emitter,
         method_description=None, example_prefix=None, include_input=None,
         include_output=None, exclude_input=None, exclude_output=None,
-        document_output=True, resource_action_model=None):
+        document_output=True, resource_action_model=None,
+        include_signature=True):
 
     document_model_driven_method(
         section=section, method_name=method_name,
@@ -29,7 +30,8 @@ def document_model_driven_resource_method(
         include_output=include_output,
         exclude_input=exclude_input,
         exclude_output=exclude_output,
-        document_output=document_output
+        document_output=document_output,
+        include_signature=include_signature
     )
 
     # If this action returns a resource modify the return example to

--- a/boto3/docs/resource.py
+++ b/boto3/docs/resource.py
@@ -12,13 +12,15 @@
 # language governing permissions and limitations under the License.
 from botocore import xform_name
 from botocore.docs.utils import get_official_service_name
-from botocore.docs.utils import py_type_name
 
 from boto3.docs.base import BaseDocumenter
 from boto3.docs.action import ActionDocumenter
 from boto3.docs.waiter import WaiterResourceDocumenter
 from boto3.docs.collection import CollectionDocumenter
 from boto3.docs.subresource import SubResourceDocumenter
+from boto3.docs.attr import document_attribute
+from boto3.docs.attr import document_identifier
+from boto3.docs.attr import document_reference
 from boto3.docs.utils import get_identifier_args_for_signature
 from boto3.docs.utils import get_identifier_values_for_example
 from boto3.docs.utils import get_identifier_description
@@ -134,11 +136,11 @@ class ResourceDocumenter(BaseDocumenter):
         for identifier in identifiers:
             identifier_section = section.add_new_section(identifier.name)
             member_list.append(identifier.name)
-            identifier_section.style.start_sphinx_py_attr(identifier.name)
-            description = get_identifier_description(
-                self._resource_name, identifier.name)
-            description = '*(string)* ' + description
-            identifier_section.write(description)
+            document_identifier(
+                section=identifier_section,
+                resource_name=self._resource_name,
+                identifier_model=identifier
+            )
 
     def _add_attributes(self, section):
         service_model = self._resource.meta.client.meta.service_model
@@ -165,10 +167,11 @@ class ResourceDocumenter(BaseDocumenter):
             _, attr_shape = attributes[attr_name]
             attribute_section = section.add_new_section(attr_name)
             attribute_list.append(attr_name)
-            attribute_section.style.start_sphinx_py_attr(attr_name)
-            attr_type = '*(%s)* ' % py_type_name(attr_shape.type_name)
-            attribute_section.write(attr_type)
-            attribute_section.include_doc_string(attr_shape.documentation)
+            document_attribute(
+                section=attribute_section,
+                attr_name=attr_name,
+                attr_model=attr_shape
+            )
 
     def _add_references(self, section):
         section = section.add_new_section('references')
@@ -186,11 +189,9 @@ class ResourceDocumenter(BaseDocumenter):
         for reference in references:
             reference_section = section.add_new_section(reference.name)
             reference_list.append(reference.name)
-            reference_section.style.start_sphinx_py_attr(reference.name)
-            reference_type = '(:py:class:`%s`) ' % reference.resource.type
-            reference_section.write(reference_type)
-            reference_section.include_doc_string(
-                'The related %s if set, otherwise ``None``.' % reference.name
+            document_reference(
+                section=reference_section,
+                reference_model=reference
             )
 
     def _add_actions(self, section):

--- a/boto3/docs/service.py
+++ b/boto3/docs/service.py
@@ -10,25 +10,23 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import botocore.session
 from botocore.exceptions import DataNotFoundError
 from botocore.docs.paginator import PaginatorDocumenter
 from botocore.docs.waiter import WaiterDocumenter
-from botocore.docs.utils import get_official_service_name
 from botocore.docs.bcdoc.restdoc import DocumentStructure
 
-from boto3.session import Session
 from boto3.docs.client import Boto3ClientDocumenter
 from boto3.docs.resource import ResourceDocumenter
 from boto3.docs.resource import ServiceResourceDocumenter
 
 
 class ServiceDocumenter(object):
-    def __init__(self, service_name):
+    def __init__(self, service_name, session):
         self._service_name = service_name
-        self._botocore_session = botocore.session.get_session()
-        self._session = Session(botocore_session=self._botocore_session,
-                                region_name='us-east-1')
+        self._session = session
+        # I know that this is an internal attribute, but the botocore session
+        # is needed to load the paginator and waiter models.
+        self._botocore_session = session._session
         self._client = self._session.client(service_name)
         self._service_resource = None
         if self._service_name in self._session.get_available_resources():

--- a/boto3/docs/subresource.py
+++ b/boto3/docs/subresource.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from botocore import xform_name
+from botocore.utils import get_service_module_name
 
 from boto3.docs.base import BaseDocumenter
 from boto3.docs.utils import get_identifier_args_for_signature
@@ -38,53 +39,74 @@ class SubResourceDocumenter(BaseDocumenter):
         for sub_resource in sub_resources:
             sub_resource_section = section.add_new_section(sub_resource.name)
             sub_resources_list.append(sub_resource.name)
-            self._document_sub_resource(sub_resource_section, sub_resource)
+            document_sub_resource(
+                section=sub_resource_section,
+                resource_name=self._resource_name,
+                sub_resource_model=sub_resource,
+                service_model=self._service_model
+            )
 
-    def _document_sub_resource(self, sub_resource_section, sub_resource):
-        identifiers_needed = []
-        for identifier in sub_resource.resource.identifiers:
-            if identifier.source == 'input':
-                identifiers_needed.append(xform_name(identifier.target))
 
+def document_sub_resource(section, resource_name, sub_resource_model,
+                          service_model, include_signature=True):
+    """Documents a resource action
+
+    :param section: The section to write to
+
+    :param resource_name: The name of the resource
+
+    :param sub_resource_model: The model of the subresource
+
+    :param service_model: The model of the service
+
+    :param include_signature: Whether or not to include the signature.
+        It is useful for generating docstrings.
+    """
+    identifiers_needed = []
+    for identifier in sub_resource_model.resource.identifiers:
+        if identifier.source == 'input':
+            identifiers_needed.append(xform_name(identifier.target))
+
+    if include_signature:
         signature_args = get_identifier_args_for_signature(identifiers_needed)
-        sub_resource_section.style.start_sphinx_py_method(
-            sub_resource.name, signature_args)
+        section.style.start_sphinx_py_method(
+            sub_resource_model.name, signature_args)
 
-        method_intro_section = sub_resource_section.add_new_section(
-            'method-intro')
-        description = 'Creates a %s resource.' % sub_resource.resource.type
-        method_intro_section.include_doc_string(description)
+    method_intro_section = section.add_new_section(
+        'method-intro')
+    description = 'Creates a %s resource.' % sub_resource_model.resource.type
+    method_intro_section.include_doc_string(description)
+    example_section = section.add_new_section('example')
+    example_values = get_identifier_values_for_example(identifiers_needed)
+    example_resource_name = xform_name(resource_name)
+    if service_model.service_name == resource_name:
+        example_resource_name = resource_name
+    example = '%s = %s.%s(%s)' % (
+        xform_name(sub_resource_model.resource.type),
+        example_resource_name,
+        sub_resource_model.name, example_values
+    )
+    example_section.style.start_codeblock()
+    example_section.write(example)
+    example_section.style.end_codeblock()
 
-        example_section = sub_resource_section.add_new_section('example')
-        example_values = get_identifier_values_for_example(identifiers_needed)
-        resource_name = xform_name(self._resource_name)
-        if self.represents_service_resource:
-            resource_name = self._resource_name
-        example = '%s = %s.%s(%s)' % (
-            xform_name(sub_resource.resource.type),
-            resource_name,
-            sub_resource.name, example_values
-        )
-        example_section.style.start_codeblock()
-        example_section.write(example)
-        example_section.style.end_codeblock()
+    param_section = section.add_new_section('params')
+    for identifier in identifiers_needed:
+        description = get_identifier_description(
+            sub_resource_model.name, identifier)
+        param_section.write(':type %s: string' % identifier)
+        param_section.style.new_line()
+        param_section.write(':param %s: %s' % (
+            identifier, description))
+        param_section.style.new_line()
 
-        param_section = sub_resource_section.add_new_section('params')
-        for identifier in identifiers_needed:
-            description = get_identifier_description(
-                sub_resource.name, identifier)
-            param_section.write(':type %s: string' % identifier)
-            param_section.style.new_line()
-            param_section.write(':param %s: %s' % (
-                identifier, description))
-            param_section.style.new_line()
-
-        return_section = sub_resource_section.add_new_section('return')
-        return_section.style.new_line()
-        return_section.write(
-            ':rtype: :py:class:`%s.%s`' % (
-                self._service_docs_name, sub_resource.resource.type))
-        return_section.style.new_line()
-        return_section.write(
-            ':returns: A %s resource' % sub_resource.resource.type)
-        return_section.style.new_line()
+    return_section = section.add_new_section('return')
+    return_section.style.new_line()
+    return_section.write(
+        ':rtype: :py:class:`%s.%s`' % (
+            get_service_module_name(service_model),
+            sub_resource_model.resource.type))
+    return_section.style.new_line()
+    return_section.write(
+        ':returns: A %s resource' % sub_resource_model.resource.type)
+    return_section.style.new_line()

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,11 +13,14 @@
 # serve to show the default.
 
 import os
-import boto3
 
+import boto3
+import boto3.session
 from boto3.docs import generate_docs
 
-generate_docs(os.path.dirname(os.path.abspath(__file__)))
+
+session = boto3.session.Session(region_name='us-east-1')
+generate_docs(os.path.dirname(os.path.abspath(__file__)), session)
 
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/tests/functional/docs/test_dynamodb.py
+++ b/tests/functional/docs/test_dynamodb.py
@@ -12,12 +12,14 @@
 # language governing permissions and limitations under the License.
 from tests.functional.docs import BaseDocsFunctionalTests
 
+from boto3.session import Session
 from boto3.docs.service import ServiceDocumenter
 
 
 class TestDynamoDBCustomizations(BaseDocsFunctionalTests):
     def setUp(self):
-        self.documenter = ServiceDocumenter('dynamodb')
+        self.documenter = ServiceDocumenter(
+            'dynamodb', session=Session(region_name='us-east-1'))
         self.generated_contents = self.documenter.document_service()
         self.generated_contents = self.generated_contents.decode('utf-8')
 

--- a/tests/functional/docs/test_s3.py
+++ b/tests/functional/docs/test_s3.py
@@ -12,12 +12,14 @@
 # language governing permissions and limitations under the License.
 from tests.functional.docs import BaseDocsFunctionalTests
 
+from boto3.session import Session
 from boto3.docs.service import ServiceDocumenter
 
 
 class TestS3Customizations(BaseDocsFunctionalTests):
     def setUp(self):
-        self.documenter = ServiceDocumenter('s3')
+        self.documenter = ServiceDocumenter(
+            's3', session=Session(region_name='us-east-1'))
         self.generated_contents = self.documenter.document_service()
         self.generated_contents = self.generated_contents.decode('utf-8')
 

--- a/tests/functional/docs/test_smoke.py
+++ b/tests/functional/docs/test_smoke.py
@@ -22,9 +22,10 @@ from boto3.docs.service import ServiceDocumenter
 def test_docs_generated():
     """Verify we can generate the appropriate docs for all services"""
     botocore_session = botocore.session.get_session()
-    session = boto3.Session()
+    session = boto3.Session(region_name='us-east-1')
     for service_name in session.get_available_services():
-        generated_docs = ServiceDocumenter(service_name).document_service()
+        generated_docs = ServiceDocumenter(
+            service_name, session=session).document_service()
         generated_docs = generated_docs.decode('utf-8')
         client = boto3.client(service_name, 'us-east-1')
 

--- a/tests/unit/docs/__init__.py
+++ b/tests/unit/docs/__init__.py
@@ -52,7 +52,8 @@ class BaseDocsTest(unittest.TestCase):
         self.loader = Loader(extra_search_paths=[self.root_dir])
         self.botocore_session = botocore.session.get_session()
         self.botocore_session.register_component('data_loader', self.loader)
-        self.session = Session(botocore_session=self.botocore_session)
+        self.session = Session(
+            botocore_session=self.botocore_session, region_name='us-east-1')
         self.client = self.session.client('myservice', 'us-east-1')
         self.resource = self.session.resource('myservice', 'us-east-1')
 

--- a/tests/unit/docs/__init__.py
+++ b/tests/unit/docs/__init__.py
@@ -192,6 +192,17 @@ class BaseDocsTest(unittest.TestCase):
                             }
                         }
                     },
+                    "has": {
+                        "RelatedSample": {
+                            "resource": {
+                                "type": "Sample",
+                                "identifiers": [
+                                    {"target": "Name", "source": "data",
+                                     "path": "Foo"}
+                                ]
+                            }
+                        }
+                    },
                     "waiters": {
                         "Complete": {
                             "waiterName": "SampleOperationComplete",

--- a/tests/unit/docs/test_action.py
+++ b/tests/unit/docs/test_action.py
@@ -51,7 +51,7 @@ class TestActionDocumenter(BaseDocsTest):
         action_documenter.document_actions(self.doc_structure)
         self.assert_contains_lines_in_order([
             '.. py:method:: load()',
-            ('  Calls :py:meth:`myservice.Client.sample_operation` to update '
+            ('  Calls :py:meth:`MyService.Client.sample_operation` to update '
              'the attributes of the Sample resource'),
             '  **Request Syntax** ',
             '  ::',
@@ -79,7 +79,7 @@ class TestActionDocumenter(BaseDocsTest):
             '      - **Foo** *(string) --* Documents Foo',
             '      - **Bar** *(string) --* Documents Bar',
             '.. py:method:: reload()',
-            ('  Calls :py:meth:`myservice.Client.sample_operation` to update '
+            ('  Calls :py:meth:`MyService.Client.sample_operation` to update '
              'the attributes of the Sample resource'),
             '  **Request Syntax** ',
             '  ::',

--- a/tests/unit/docs/test_docstring.py
+++ b/tests/unit/docs/test_docstring.py
@@ -1,0 +1,74 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import mock
+from botocore.compat import six
+
+from tests.unit.docs import BaseDocsTest
+
+
+class TestResourceDocstrings(BaseDocsTest):
+    def test_action_help(self):
+        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+            help(self.resource.sample_operation)
+        action_docstring = mock_stdout.getvalue()
+        self.assert_contains_lines_in_order([
+            '  **Request Syntax**',
+            '  ::',
+            '    response = myservice.sample_operation(',
+            '        Foo=\'string\',',
+            '        Bar=\'string\'',
+            '    )',
+            '  :type Foo: string',
+            '  :param Foo: Documents Foo',
+            '  :type Bar: string',
+            '  :param Bar: Documents Bar',
+            '  :rtype: dict',
+            '  :returns:',
+            '    **Response Syntax**',
+            '    ::',
+            '      {',
+            '          \'Foo\': \'string\',',
+            '          \'Bar\': \'string\'',
+            '      }',
+            '    **Response Structure**',
+            '    - *(dict) --*',
+            '      - **Foo** *(string) --* Documents Foo',
+            '      - **Bar** *(string) --* Documents Bar'
+        ], action_docstring)
+
+    def test_load_help(self):
+        sub_resource = self.resource.Sample('Id')
+        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+            help(sub_resource.load)
+        load_docstring = mock_stdout.getvalue()
+        self.assert_contains_lines_in_order([
+            ('  Calls :py:meth:`MyService.Client.sample_operation` to update '
+             'the attributes of the Sample resource'),
+            '  **Request Syntax** ',
+            '  ::',
+            '    sample.load()',
+            '  :returns: None',
+        ], load_docstring)
+
+    def test_sub_resource_help(self):
+        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+            help(self.resource.Sample)
+        sub_resource_docstring = mock_stdout.getvalue()
+        self.assert_contains_lines_in_order([
+            '  Creates a Sample resource.::',
+            "    sample = myservice.Sample('name')",
+            '  :type name: string',
+            "  :param name: The Sample's name identifier.",
+            '  :rtype: :py:class:`MyService.Sample`',
+            '  :returns: A Sample resource',
+        ], sub_resource_docstring)

--- a/tests/unit/docs/test_docstring.py
+++ b/tests/unit/docs/test_docstring.py
@@ -72,3 +72,29 @@ class TestResourceDocstrings(BaseDocsTest):
             '  :rtype: :py:class:`MyService.Sample`',
             '  :returns: A Sample resource',
         ], sub_resource_docstring)
+
+    def test_attribute_help(self):
+        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+            help(self.resource.Sample('id').__class__.foo)
+        attribute_docstring = mock_stdout.getvalue()
+        self.assert_contains_lines_in_order([
+            '    *(string)* Documents Foo'
+        ], attribute_docstring)
+
+    def test_identifier_help(self):
+        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+            help(self.resource.Sample('id').__class__.name)
+        identifier_docstring = mock_stdout.getvalue()
+        self.assert_contains_lines_in_order([
+            "    *(string)* The Sample's name identifier. This "
+            "**must** be set."
+        ], identifier_docstring)
+
+    def test_reference_help(self):
+        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+            help(self.resource.Sample('id').__class__.name)
+        identifier_docstring = mock_stdout.getvalue()
+        self.assert_contains_lines_in_order([
+            "    *(string)* The Sample's name identifier. This "
+            "**must** be set."
+        ], identifier_docstring)

--- a/tests/unit/docs/test_docstring.py
+++ b/tests/unit/docs/test_docstring.py
@@ -91,10 +91,11 @@ class TestResourceDocstrings(BaseDocsTest):
         ], identifier_docstring)
 
     def test_reference_help(self):
+        sample_resource = self.resource.Sample('id')
         with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
-            help(self.resource.Sample('id').__class__.name)
-        identifier_docstring = mock_stdout.getvalue()
+            help(sample_resource.__class__.related_sample)
+        reference_docstring = mock_stdout.getvalue()
         self.assert_contains_lines_in_order([
-            "    *(string)* The Sample's name identifier. This "
-            "**must** be set."
-        ], identifier_docstring)
+            "    (:py:class:`Sample`) The related related_sample "
+            "if set, otherwise ``None``."
+        ], reference_docstring)

--- a/tests/unit/docs/test_service.py
+++ b/tests/unit/docs/test_service.py
@@ -12,26 +12,13 @@
 # language governing permissions and limitations under the License.
 import os
 
-import mock
-
 from tests.unit.docs import BaseDocsTest
 from boto3.docs.service import ServiceDocumenter
 
 
 class TestServiceDocumenter(BaseDocsTest):
-    def setUp(self):
-        super(TestServiceDocumenter, self).setUp()
-        self.create_loader_patch = mock.patch(
-            'botocore.session.create_loader',
-            return_value=self.loader)
-        self.create_loader_patch.start()
-
-    def tearDown(self):
-        super(TestServiceDocumenter, self).tearDown()
-        self.create_loader_patch.stop()
-
     def test_document_service(self):
-        service_documenter = ServiceDocumenter('myservice')
+        service_documenter = ServiceDocumenter('myservice', self.session)
         contents = service_documenter.document_service().decode('utf-8')
         lines = [
             '*********',
@@ -103,7 +90,7 @@ class TestServiceDocumenter(BaseDocsTest):
 
     def test_document_service_no_resource(self):
         os.remove(self.resource_model_file)
-        service_documenter = ServiceDocumenter('myservice')
+        service_documenter = ServiceDocumenter('myservice', self.session)
         contents = service_documenter.document_service().decode('utf-8')
         self.assertNotIn('Service Resource', contents)
 
@@ -112,7 +99,7 @@ class TestServiceDocumenter(BaseDocsTest):
         # as it may try to look at the paginator model during documentation.
         os.remove(self.resource_model_file)
         os.remove(self.paginator_model_file)
-        service_documenter = ServiceDocumenter('myservice')
+        service_documenter = ServiceDocumenter('myservice', self.session)
         contents = service_documenter.document_service().decode('utf-8')
         self.assertNotIn('Paginators', contents)
 
@@ -121,6 +108,6 @@ class TestServiceDocumenter(BaseDocsTest):
         # as it may try to look at the waiter model during documentation.
         os.remove(self.resource_model_file)
         os.remove(self.waiter_model_file)
-        service_documenter = ServiceDocumenter('myservice')
+        service_documenter = ServiceDocumenter('myservice', self.session)
         contents = service_documenter.document_service().decode('utf-8')
         self.assertNotIn('Waiters', contents)


### PR DESCRIPTION
This adds lazy loaded docstrings to resource actions and sub-resources. Note that I still have yet to add docstrings identifiers, attributes, collections, and resource waiters. I just figured that splitting the work up a bit would be easier to review. There are a lot of moving parts so I figured to break it up to make it easier to follow and track feedback updates. Here are some examples of what you can do now:
```py
import boto3

ec2 = boto3.resource('ec2')
instance = ec2.Instance('Id')

# Sub-resource
help(ec2.Instance)
# Load action
help(instance.load)
# Action         
help(instance.start)
```

Note that the tests won't pass till this PR gets merged: https://github.com/boto/botocore/pull/642

cc @jamesls @mtdowling @rayluo 