### PR TITLE
Use consistent reads in integ tests

### DIFF
--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -57,7 +57,8 @@ class TestDynamoDBTypes(BaseDynamoDBTest):
     def test_put_get_item(self):
         self.table.put_item(Item=self.item_data)
         self.addCleanup(self.table.delete_item, Key={'MyHashKey': 'mykey'})
-        response = self.table.get_item(Key={'MyHashKey': 'mykey'})
+        response = self.table.get_item(Key={'MyHashKey': 'mykey'},
+                                       ConsistentRead=True)
         self.assertEqual(response['Item'], self.item_data)
 
 


### PR DESCRIPTION
Fixes the occasional test failure.

cc @kyleknap @mtdowling @rayluo 