### PR TITLE
Make resource identifiers immutable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Next Release - (TBD)
+--------------------
+
+* bugfix:Identifier: Make resource identifiers immutable.
+  (`issue 246 <https://github.com/boto/boto3/pull/246>`__)
+
+
 1.1.3 - 2015-09-03
 ------------------
 

--- a/boto3/resources/base.py
+++ b/boto3/resources/base.py
@@ -99,7 +99,7 @@ class ServiceResource(object):
         # Allow setting identifiers as positional arguments in the order
         # in which they were defined in the ResourceJSON.
         for i, value in enumerate(args):
-            setattr(self, self.meta.identifiers[i], value)
+            setattr(self, '_' + self.meta.identifiers[i], value)
 
         # Allow setting identifiers via keyword arguments. Here we need
         # extra logic to ignore other keyword arguments like ``client``.
@@ -110,7 +110,7 @@ class ServiceResource(object):
             if name not in self.meta.identifiers:
                 raise ValueError('Unknown keyword argument: {0}'.format(name))
 
-            setattr(self, name, value)
+            setattr(self, '_' + name, value)
 
         # Validate that all identifiers have been set.
         for identifier in self.meta.identifiers:

--- a/boto3/resources/factory.py
+++ b/boto3/resources/factory.py
@@ -199,6 +199,12 @@ class ResourceFactory(object):
         Creates a read-only property for identifier attributes.
         """
         def identifier(self):
+            # The default value is set to ``None`` instead of
+            # raising an AttributeError because when resources are
+            # instantiated a check is made such that none of the
+            # identifiers have a value ``None``. If any are ``None``,
+            # a more informative user error than a generic AttributeError
+            # is raised.
             return getattr(self, '_' + name, None)
 
         identifier.__name__ = str(name)

--- a/boto3/resources/factory.py
+++ b/boto3/resources/factory.py
@@ -112,7 +112,7 @@ class ResourceFactory(object):
         """
         for identifier in model.identifiers:
             meta.identifiers.append(identifier.name)
-            attrs[identifier.name] = None
+            attrs[identifier.name] = self._create_identifier(identifier.name)
 
     def _load_actions(self, attrs, model, resource_defs, service_model):
         """
@@ -193,6 +193,17 @@ class ResourceFactory(object):
         """
         for waiter in model.waiters:
             attrs[waiter.name] = self._create_waiter(waiter)
+
+    def _create_identifier(factory_self, name):
+        """
+        Creates a read-only property for identifier attributes.
+        """
+        def identifier(self):
+            return getattr(self, '_' + name, None)
+
+        identifier.__name__ = str(name)
+        identifier.__doc__ = 'TODO'
+        return property(identifier)
 
     def _create_autoload_property(factory_self, name, snake_cased):
         """

--- a/tests/unit/resources/test_factory.py
+++ b/tests/unit/resources/test_factory.py
@@ -648,6 +648,13 @@ class TestResourceFactoryDanglingResource(BaseTestResourceFactory):
         with self.assertRaises(ValueError):
             resource.Queue(url='foo', bar='baz')
 
+    def test_dangling_resource_identifier_is_immutable(self):
+        resource = self.load('test', 'test', self.model, self.defs, None)()
+        queue = resource.Queue('url')
+        # We should not be able to change the identifier's value
+        with self.assertRaises(AttributeError):
+            queue.url = 'foo'
+
     def test_dangling_resource_equality(self):
         resource = self.load('test', 'test', self.model, self.defs, None)()
 


### PR DESCRIPTION
Before you could switch out the identifiers on a resource, which can have unintended affects if you switch the identifier and then make subsequent calls with the resource. Now identifiers are read-only, much like how attributes are read-only:
```py
In [1]: import boto3

In [2]: s3 = boto3.resource('s3')

In [3]: bucket = s3.Bucket('mybucketfoo')

In [4]: bucket.name = 'foo'
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-4-5d85c15550cd> in <module>()
----> 1 bucket.name = 'foo'

AttributeError: can't set attribute

```

cc @jamesls @mtdowling @rayluo 