### PR TITLE
Fixed documentation generation bug.

### DIFF
--- a/boto3/docs/method.py
+++ b/boto3/docs/method.py
@@ -32,7 +32,7 @@ def document_model_driven_resource_method(
         document_output=document_output
     )
 
-    # If this action returns a reource modify the return example to
+    # If this action returns a resource modify the return example to
     # appropriately reflect that.
     if resource_action_model.resource:
         if 'return' in section.available_sections:
@@ -47,7 +47,7 @@ def document_model_driven_resource_method(
         return_type = ':py:class:`%s`' % return_resource_type
         return_description = '%s resource' % (resource_type)
 
-        if resource_action_model.path and '[]' in resource_action_model.path:
+        if _method_returns_resource_list(resource_action_model.resource):
             return_type = 'list(%s)' % return_type
             return_description = 'A list of %s resources' % (
                 resource_type)
@@ -59,3 +59,11 @@ def document_model_driven_resource_method(
         new_return_section.write(
             ':returns: %s' % return_description)
         new_return_section.style.new_line()
+
+
+def _method_returns_resource_list(resource):
+    for identifier in resource.identifiers:
+        if identifier.path and '[]' in identifier.path:
+            return True
+
+    return False

--- a/tests/unit/docs/__init__.py
+++ b/tests/unit/docs/__init__.py
@@ -127,11 +127,22 @@ class BaseDocsTest(unittest.TestCase):
 
         self.resource_json_model = {
             "service": {
-                "actions": {
-                    "SampleOperation": {
+                "actions": OrderedDict([
+                    ("SampleOperation", {
                         "request": {"operation": "SampleOperation"}
-                    }
-                },
+                    }),
+                    ("SampleListReturnOperation", {
+                        "request": {"operation": "SampleOperation"},
+                        "resource": {
+                            "type": "Sample",
+                            "identifiers": [
+                                {"target": "Name", "source": "response",
+                                "path": "Samples[].Name"}
+                            ],
+                            "path": "Samples[]"
+                        }
+                    })
+                ]),
                 "has": {
                     "Sample": {
                         "resource": {

--- a/tests/unit/docs/test_collection.py
+++ b/tests/unit/docs/test_collection.py
@@ -27,8 +27,8 @@ class TestCollectionDocumenter(BaseDocsTest):
             '    **Request Syntax** ',
             '    ::',
             '      sample_iterator = myservice.samples.all()',
-            '    :rtype: :py:class:`myservice.Sample`',
-            '    :returns: Sample resource',
+            '    :rtype: list(:py:class:`myservice.Sample`)',
+            '    :returns: A list of Sample resources',
             '  .. py:method:: filter(**kwargs)',
             ('    Creates an iterable of all Sample resources in '
              'the collection filtered by kwargs passed to method.'),
@@ -42,8 +42,8 @@ class TestCollectionDocumenter(BaseDocsTest):
             '    :param Foo: Documents Foo',
             '    :type Bar: string',
             '    :param Bar: Documents Bar',
-            '    :rtype: :py:class:`myservice.Sample`',
-            '    :returns: Sample resource',
+            '    :rtype: list(:py:class:`myservice.Sample`)',
+            '    :returns: A list of Sample resources',
             '  .. py:method:: limit(**kwargs)',
             ('    Creates an iterable up to a specified amount of '
              'Sample resources in the collection.'),
@@ -55,8 +55,8 @@ class TestCollectionDocumenter(BaseDocsTest):
             '    :type count: integer',
             ('    :param count: The limit to the number of resources '
              'in the iterable.'),
-            '    :rtype: :py:class:`myservice.Sample`',
-            '    :returns: Sample resource',
+            '    :rtype: list(:py:class:`myservice.Sample`)',
+            '    :returns: A list of Sample resources',
             '  .. py:method:: page_size(**kwargs)',
             ('    Creates an iterable of all Sample resources in the '
              'collection, but limits the number of items returned by '
@@ -70,7 +70,7 @@ class TestCollectionDocumenter(BaseDocsTest):
             '    :type count: integer',
             ('    :param count: The number of items returned by '
              'each service call'),
-            '    :rtype: :py:class:`myservice.Sample`',
-            '    :returns: Sample resource',
+            '    :rtype: list(:py:class:`myservice.Sample`)',
+            '    :returns: A list of Sample resources',
             '    '
         ])

--- a/tests/unit/docs/test_method.py
+++ b/tests/unit/docs/test_method.py
@@ -97,16 +97,7 @@ class TestDocumentModelDrivenResourceMethod(BaseDocsTest):
         ])
 
     def test_returns_list_of_resource(self):
-        resource_action = self.service_resource_model.actions[0]
-        # Override the return type of the action to be a resource
-        # instead of the regular dictionary.
-        resource_action.resource = ResponseResource(
-            {'type': 'Sample',
-             'identifiers': [{
-                 'target': 'Name', 'source': 'requestParameter',
-                 'path': '[].Foo'}]},
-            self.resource_json_model)
-        resource_action.path = '[]'
+        resource_action = self.service_resource_model.actions[1]
         document_model_driven_resource_method(
             self.doc_structure, 'foo', self.operation_model,
             event_emitter=self.event_emitter,


### PR DESCRIPTION
This is a fix for #195. When attempting to detect lists, the path for the method was being examined instead of the path for the resource.