### PR TITLE
Lock jmespath to 0.7.1-1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ VERSION_RE = re.compile(r'''__version__ = ['"]([0-9.]+)['"]''')
 
 requires = [
     'botocore>=1.2.0,<1.3.0',
-    'jmespath>=0.6.2,<1.0.0',
+    'jmespath>=0.7.1,<1.0.0',
 ]
 
 


### PR DESCRIPTION
This isn't strictly needed, but we should match
the same version range that botocore uses.

Related: https://github.com/boto/botocore/issues/656

Fixes #270.
cc @kyleknap @mtdowling @rayluo 