### PR TITLE
Add dependencies to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,8 @@
 [wheel]
 universal = 1
+
+[metadata]
+requires-dist =
+	botocore>=1.2.0,<1.3.0
+	jmespath>=0.7.1,<1.0.0
+	futures==2.2.0; python_version=="2.6" or python_version=="2.7"


### PR DESCRIPTION
This overrides the values from setup.py.
If fixes an issue where python3 was unnecessarily
pulling in a dependency on futures.

Fixes #163.

Two additional things:

1. Pretty sure we'll need to apply similar changes to botocore and aws/aws-cli as they both have conditional dependencies.
2. Futures has a new major version.  I'll look at upgrading that dependency as a separate PR.

cc @kyleknap @mtdowling @rayluo @JordonPhillips 