### PR TITLE
Update iam resource model

### DIFF
--- a/boto3/data/iam/2010-05-08/resources-1.json
+++ b/boto3/data/iam/2010-05-08/resources-1.json
@@ -858,7 +858,7 @@
       "identifiers": [
         {
           "name": "Arn",
-          "memberName": "PolicyArn"
+          "memberName": "Arn"
         }
       ],
       "shape": "Policy",

--- a/boto3/data/iam/2010-05-08/resources-1.json
+++ b/boto3/data/iam/2010-05-08/resources-1.json
@@ -968,8 +968,7 @@
             "type": "Group",
             "identifiers": [
               { "target": "Name", "source": "response", "path": "PolicyGroups[].GroupName" }
-            ],
-            "path": "PolicyGroups[]"
+            ]
           }
         },
         "AttachedRoles": {
@@ -984,8 +983,7 @@
             "type": "Role",
             "identifiers": [
               { "target": "Name", "source": "response", "path": "PolicyRoles[].RoleName" }
-            ],
-            "path": "PolicyRoles[]"
+            ]
           }
         },
         "AttachedUsers": {
@@ -1000,8 +998,7 @@
             "type": "User",
             "identifiers": [
               { "target": "Name", "source": "response", "path": "PolicyUsers[].UserName" }
-            ],
-            "path": "PolicyRoles[]"
+            ]
           }
         },
         "Versions": {


### PR DESCRIPTION
Collection resources for the Policy resource were getting preloaded due to the existance of a path. These resources need to be fully loaded through their load method not the ListEntitiesForPolicy method because it returns a partial subset of the resource's attributes.

Fixes https://github.com/boto/boto3/issues/273

cc @jamesls @mtdowling @rayluo @JordonPhillips 