### PR TITLE
Add config argument to boto3 resource (closes #168)

### DIFF
--- a/boto3/session.py
+++ b/boto3/session.py
@@ -277,7 +277,7 @@ class Session(object):
         # and service model, the resource version and resource JSON data.
         # We pass these to the factory and get back a class, which is
         # instantiated on top of the low-level client.
-        if config:
+        if config is not None:
             if config.user_agent_extra is None:
                 config = copy.deepcopy(config)
                 config.user_agent_extra = 'Resource'

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -176,6 +176,51 @@ class TestSession(BaseTestCase):
             config=mock.ANY)
         client_config = session.client.call_args[1]['config']
         self.assertEqual(client_config.user_agent_extra, 'Resource')
+        self.assertEqual(client_config.signature_version, None)
+
+    def test_create_resource_with_config(self):
+        mock_bc_session = mock.Mock()
+        loader = mock.Mock(spec=loaders.Loader)
+        loader.determine_latest_version.return_value = '2014-11-02'
+        loader.load_service_model.return_value = {'resources': [], 'service': []}
+        mock_bc_session.get_component.return_value = loader
+        session = Session(botocore_session=mock_bc_session)
+        session.resource_factory.load_from_definition = mock.Mock()
+        session.client = mock.Mock()
+        config = Config(signature_version='v4')
+
+        session.resource('sqs', config=config)
+
+        session.client.assert_called_with(
+            'sqs', aws_secret_access_key=None, aws_access_key_id=None,
+            endpoint_url=None, use_ssl=True, aws_session_token=None,
+            verify=None, region_name=None, api_version='2014-11-02',
+            config=mock.ANY)
+        client_config = session.client.call_args[1]['config']
+        self.assertEqual(client_config.user_agent_extra, 'Resource')
+        self.assertEqual(client_config.signature_version, 'v4')
+
+    def test_create_resource_with_config_override_user_agent_extra(self):
+        mock_bc_session = mock.Mock()
+        loader = mock.Mock(spec=loaders.Loader)
+        loader.determine_latest_version.return_value = '2014-11-02'
+        loader.load_service_model.return_value = {'resources': [], 'service': []}
+        mock_bc_session.get_component.return_value = loader
+        session = Session(botocore_session=mock_bc_session)
+        session.resource_factory.load_from_definition = mock.Mock()
+        session.client = mock.Mock()
+        config = Config(signature_version='v4', user_agent_extra='foo')
+
+        session.resource('sqs', config=config)
+
+        session.client.assert_called_with(
+            'sqs', aws_secret_access_key=None, aws_access_key_id=None,
+            endpoint_url=None, use_ssl=True, aws_session_token=None,
+            verify=None, region_name=None, api_version='2014-11-02',
+            config=mock.ANY)
+        client_config = session.client.call_args[1]['config']
+        self.assertEqual(client_config.user_agent_extra, 'foo')
+        self.assertEqual(client_config.signature_version, 'v4')
 
     def test_create_resource_latest_version(self):
         mock_bc_session = mock.Mock()


### PR DESCRIPTION
This pull request adds a config argument to the `boto3.resource()`/`boto3.session.resource()` function. This allows passing in a custom config to programatically set a signature version, an s3 addressing style, or any other argument from the botocore client config.

It was done this way over passing a client argument in (as suggested in #168) because it prevents the user from passing in a client of the wrong service type, as illustrated in this hypothetical set of calls.

```
client = boto3.client('sqs', config=Config())
resource = boto3.resource('ec2', client=client)
```

(You could make it so that resource ignores the `service_name` argument passed into it if `client` is specified, but that's really confusing since `service_name` is a required argument of `boto3.resource()`.)

The only other non-straightforward thing in this pull request that would be nice to have feedback on is the `copy.deepcopy` performed if the config has not passed in `user_agent_extra`. This was done so that the incoming argument is not modified, but another possible semantic is that we use `user_agent_extra` untouched if a config is passed in, not attempting to override with a default value. Any preference, or okay as is?