### PR TITLE
Removed unused reference for coveralls.io.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Boto 3 - The AWS SDK for Python
 ===============================
 
-|Build Status| |Coverage| |Docs| |Version|
+|Build Status| |Docs| |Version|
 
 Boto3 is the Amazon Web Services (AWS) Software Development Kit (SDK) for
 Python, which allows Python developers to write software that makes use


### PR DESCRIPTION
In [this commit](https://github.com/boto/boto3/commit/872f68b057d2f79df1cca38ce908b8c5bd65fdcb), the definition of `|Coverage|` was removed, but the reference remained in `README.rst`.