### PR TITLE
Provide S3 copy_file() transfer

### DIFF
--- a/boto3/s3/inject.py
+++ b/boto3/s3/inject.py
@@ -19,6 +19,7 @@ from botocore.exceptions import ClientError
 def inject_s3_transfer_methods(class_attributes, **kwargs):
     utils.inject_attribute(class_attributes, 'upload_file', upload_file)
     utils.inject_attribute(class_attributes, 'download_file', download_file)
+    utils.inject_attribute(class_attributes, 'copy_file', copy_file)
 
 
 def inject_bucket_methods(class_attributes, **kwargs):
@@ -26,12 +27,14 @@ def inject_bucket_methods(class_attributes, **kwargs):
     utils.inject_attribute(class_attributes, 'upload_file', bucket_upload_file)
     utils.inject_attribute(
         class_attributes, 'download_file', bucket_download_file)
+    utils.inject_attribute(class_attributes, 'copy_file', bucket_copy_file)
 
 
 def inject_object_methods(class_attributes, **kwargs):
     utils.inject_attribute(class_attributes, 'upload_file', object_upload_file)
     utils.inject_attribute(
         class_attributes, 'download_file', object_download_file)
+    utils.inject_attribute(class_attributes, 'copy_file', object_copy_file)
 
 
 def bucket_load(self, *args, **kwargs):
@@ -91,6 +94,27 @@ def download_file(self, Bucket, Key, Filename, ExtraArgs=None,
         extra_args=ExtraArgs, callback=Callback)
 
 
+def copy_file(self, SrcBucket, SrcKey, DestBucket, DestKey,
+              ExtraArgs=None, Callback=None, Config=None):
+    """Copy one S3 object to another s3 object.
+
+    Usage::
+
+        import boto3
+        s3 = boto3.resource('s3')
+        s3.meta.client.copy_file('bucket1', 'hello.txt', 'bucket2', 'hello.txt')
+
+    Similar behavior as S3Transfer's copy_file() method,
+    except that parameters are capitalized. Detailed examples can be found at
+    :ref:`S3Transfer's Usage <ref_s3transfer_usage>`.
+    """
+    transfer = S3Transfer(self, Config)
+    return transfer.copy_file(
+        src_bucket=SrcBucket, src_key=SrcKey,
+        dest_bucket=DestBucket, dest_key=DestKey,
+        extra_args=ExtraArgs, callback=Callback)
+
+
 def bucket_upload_file(self, Filename, Key,
                        ExtraArgs=None, Callback=None, Config=None):
     """Upload a file to an S3 object.
@@ -129,6 +153,26 @@ def bucket_download_file(self, Key, Filename,
         ExtraArgs=ExtraArgs, Callback=Callback, Config=Config)
 
 
+def bucket_copy_file(self, SrcBucket, SrcKey, DestKey,
+                     ExtraArgs=None, Callback=None, Config=None):
+    """Copy one S3 object to another s3 object.
+
+    Usage::
+
+        import boto3
+        s3 = boto3.resource('s3')
+        s3.Bucket('bucket2').copy_file('bucket1', 'hello.txt', 'hello.txt')
+
+    Similar behavior as S3Transfer's copy_file() method,
+    except that parameters are capitalized. Detailed examples can be found at
+    :ref:`S3Transfer's Usage <ref_s3transfer_usage>`.
+    """
+    return self.meta.client.copy_file(
+        SrcBucket=SrcBucket, SrcKey=SrcKey,
+        DestBucket=self.name, DestKey=DestKey,
+        ExtraArgs=ExtraArgs, Callback=Callback, Config=Config)
+
+
 def object_upload_file(self, Filename,
                        ExtraArgs=None, Callback=None, Config=None):
     """Upload a file to an S3 object.
@@ -164,4 +208,24 @@ def object_download_file(self, Filename,
     """
     return self.meta.client.download_file(
         Bucket=self.bucket_name, Key=self.key, Filename=Filename,
+        ExtraArgs=ExtraArgs, Callback=Callback, Config=Config)
+
+
+def object_copy_file(self, SrcBucket, SrcKey,
+                     ExtraArgs=None, Callback=None, Config=None):
+    """Copy one S3 object to another s3 object.
+
+    Usage::
+
+        import boto3
+        s3 = boto3.resource('s3')
+        s3.Object('bucket2', 'hello.txt').copy_file('bucket1', 'hello.txt')
+
+    Similar behavior as S3Transfer's copy_file() method,
+    except that parameters are capitalized. Detailed examples can be found at
+    :ref:`S3Transfer's Usage <ref_s3transfer_usage>`.
+    """
+    return self.meta.client.copy_file(
+        SrcBucket=SrcBucket, SrcKey=SrcKey,
+        DestBucket=self.bucket_name, DestKey=self.key,
         ExtraArgs=ExtraArgs, Callback=Callback, Config=Config)

--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -13,7 +13,7 @@
 """Abstractions over S3's upload/download operations.
 
 This module provides high level abstractions for efficient
-uploads/downloads.  It handles several things for the user:
+uploads/downloads/copies.  It handles several things for the user:
 
 * Automatically switching to multipart transfers when
   a file is over a specific size threshold
@@ -34,9 +34,6 @@ to configure many aspects of the transfer process including:
 * Socket timeouts
 * Retry amounts
 
-There is no support for s3->s3 multipart copies at this
-time.
-
 
 .. _ref_s3transfer_usage:
 
@@ -55,9 +52,13 @@ The simplest way to use this module is:
     # Download s3://bucket/key to /tmp/myfile
     transfer.download_file('bucket', 'key', '/tmp/myfile')
 
-The ``upload_file`` and ``download_file`` methods also accept
-``**kwargs``, which will be forwarded through to the corresponding
-client operation.  Here are a few examples using ``upload_file``::
+    # Copy s3://bucket1/key to s3://bucket2/key
+    transfer.copy_file('bucket1', 'key', 'bucket2', 'key')
+
+The ``upload_file``, ``download_file`` and ``copy_file`` methods also
+accept ``**kwargs``, which will be forwarded through to the
+corresponding client operation.  Here are a few examples using
+``upload_file``::
 
     # Making the object public
     transfer.upload_file('/tmp/myfile', 'bucket', 'key',
@@ -73,10 +74,10 @@ client operation.  Here are a few examples using ``upload_file``::
 
 
 The ``S3Transfer`` clas also supports progress callbacks so you can
-provide transfer progress to users.  Both the ``upload_file`` and
-``download_file`` methods take an optional ``callback`` parameter.
-Here's an example of how to print a simple progress percentage
-to the user:
+provide transfer progress to users.  All of the ``upload_file``,
+``download_file`` and ``copy_file`` methods take an optional
+``callback`` parameter.  Here's an example of how to print a simple
+progress percentage to the user:
 
 .. code-block:: python
 
@@ -412,6 +413,95 @@ class MultipartUploader(object):
             return {'ETag': etag, 'PartNumber': part_number}
 
 
+class MultipartCopier(object):
+    # These are the extra_args that need to be forwarded onto
+    # subsequent copy_parts.
+    COPY_PART_ARGS = [
+        'CopySourceIfMatch',
+        'CopySourceIfModifiedSince',
+        'CopySourceIfNoneMatch',
+        'CopySourceIfUnmodifiedSince',
+        'CopySourceSSECustomerKey',
+        'CopySourceSSECustomerAlgorithm',
+        'CopySourceSSECustomerKeyMD5',
+        'SSECustomerKey',
+        'SSECustomerAlgorithm',
+        'SSECustomerKeyMD5',
+        'RequestPayer',
+    ]
+
+    def __init__(self, client, config,
+                 executor_cls=futures.ThreadPoolExecutor):
+        self._client = client
+        self._config = config
+        self._executor_cls = executor_cls
+
+    def _extra_copy_part_args(self, extra_args):
+        # Only the args in COPY_PART_ARGS actually need to be passed
+        # onto the upload_part calls.
+        copy_parts_args = {}
+        for key, value in extra_args.items():
+            if key in self.COPY_PART_ARGS:
+                copy_parts_args[key] = value
+        return copy_parts_args
+
+    def copy_file(self, src_bucket, src_key, dest_bucket, dest_key,
+                  object_size, callback, extra_args):
+        response = self._client.create_multipart_upload(Bucket=dest_bucket,
+                                                        Key=dest_key,
+                                                        **extra_args)
+        upload_id = response['UploadId']
+        try:
+            parts = self._copy_parts(upload_id, src_bucket, src_key,
+                                     dest_bucket, dest_key, object_size,
+                                     callback, extra_args)
+        except Exception  as e:
+            logger.debug("Exception raised while copying parts, "
+                         "aborting multipart upload.", exc_info=True)
+            self._client.abort_multipart_upload(
+                Bucket=dest_bucket, Key=dest_key, UploadId=upload_id)
+            raise S3UploadFailedError(
+                "Failed to copy %s to %s: %s" % (
+                    '/'.join([src_bucket, src_key]),
+                    '/'.join([dest_bucket, dest_key]), e))
+        self._client.complete_multipart_upload(
+            Bucket=dest_bucket, Key=dest_key, UploadId=upload_id,
+            MultipartUpload={'Parts': parts})
+
+    def _copy_parts(self, upload_id, src_bucket, src_key,
+                    dest_bucket, dest_key, object_size,
+                    callback, extra_args):
+        copy_parts_extra_args = self._extra_copy_part_args(extra_args)
+        parts = []
+        part_size = self._config.multipart_chunksize
+        num_parts = int(math.ceil(object_size / float(part_size)))
+        max_workers = self._config.max_concurrency
+        with self._executor_cls(max_workers=max_workers) as executor:
+            copy_partial = functools.partial(
+                self._copy_one_part, src_bucket, src_key, dest_bucket,
+                dest_key, upload_id, object_size, part_size,
+                copy_parts_extra_args, callback)
+            for part in executor.map(copy_partial, range(1, num_parts + 1)):
+                parts.append(part)
+        return parts
+
+    def _copy_one_part(self, src_bucket, src_key, dest_bucket, dest_key,
+                       upload_id, object_size, part_size, extra_args,
+                       callback, part_number):
+        start = part_size * (part_number - 1)
+        end = min(start + part_size - 1, object_size - 1)
+        response = self._client.upload_part_copy(
+            Bucket=dest_bucket, Key=dest_key,
+            UploadId=upload_id, PartNumber=part_number,
+            CopySource='/'.join([src_bucket, src_key]),
+            CopySourceRange='bytes=%d-%d' %(start, end),
+            **extra_args)
+        if callback is not None:
+            callback(end - start + 1)
+        etag = response['CopyPartResult']['ETag']
+        return {'ETag': etag, 'PartNumber': part_number}
+
+
 class ShutdownQueue(queue.Queue):
     """A queue implementation that can be shutdown.
 
@@ -597,6 +687,16 @@ class S3Transfer(object):
         'SSEKMSKeyId',
     ]
 
+    ALLOWED_COPY_ARGS = ALLOWED_UPLOAD_ARGS + [
+        'CopySourceIfMatch',
+        'CopySourceIfModifiedSince',
+        'CopySourceIfNoneMatch',
+        'CopySourceIfUnmodifiedSince',
+        'CopySourceSSECustomerAlgorithm',
+        'CopySourceSSECustomerKey',
+        'CopySourceSSECustomerKeyMD5',
+    ]
+
     def __init__(self, client, config=None, osutil=None):
         self._client = client
         if config is None:
@@ -723,3 +823,41 @@ class S3Transfer(object):
     def _multipart_upload(self, filename, bucket, key, callback, extra_args):
         uploader = MultipartUploader(self._client, self._config, self._osutil)
         uploader.upload_file(filename, bucket, key, callback, extra_args)
+
+    def copy_file(self, src_bucket, src_key, dest_bucket, dest_key,
+                    callback=None, extra_args=None):
+        """Copy a file from one S3 object to another.
+
+        Variants have also been injected into S3 client, Bucket and Object.
+        You don't have to use S3Transfer.copy_file() directly.
+        """
+        if extra_args is None:
+            extra_args = {}
+        self._validate_all_known_args(extra_args, self.ALLOWED_COPY_ARGS)
+        # Strip out just download args for getting size
+        size_extra_args = {}
+        for key, value in extra_args.items():
+            if key in self.ALLOWED_DOWNLOAD_ARGS:
+                size_extra_args[key] = value
+        object_size = self._object_size(src_bucket, src_key,
+                                        size_extra_args)
+        if object_size >= self._config.multipart_threshold:
+            self._multipart_copy(src_bucket, src_key, dest_bucket, dest_key,
+                                 object_size, callback, extra_args)
+        else:
+            self._copy_object(src_bucket, src_key, dest_bucket, dest_key,
+                              object_size, callback, extra_args)
+
+    def _multipart_copy(self, src_bucket, src_key, dest_bucket, dest_key,
+                        object_size, callback, extra_args):
+        copier = MultipartCopier(self._client, self._config)
+        copier.copy_file(src_bucket, src_key, dest_bucket, dest_key,
+                         object_size, callback, extra_args)
+
+    def _copy_object(self, src_bucket, src_key, dest_bucket, dest_key,
+                     object_size, callback, extra_args):
+        self._client.copy_object(CopySource='/'.join([src_bucket, src_key]),
+                                 Bucket=dest_bucket, Key=dest_key,
+                                 **extra_args)
+        if callback is not None:
+            callback(object_size)

--- a/tests/functional/docs/test_s3.py
+++ b/tests/functional/docs/test_s3.py
@@ -26,8 +26,10 @@ class TestS3Customizations(BaseDocsFunctionalTests):
     def test_file_transfer_methods_are_documented(self):
         self.assert_contains_lines_in_order([
             '.. py:class:: S3.Client',
+            '  *   :py:meth:`copy_file`',
             '  *   :py:meth:`download_file`',
             '  *   :py:meth:`upload_file`',
+            '  .. py:method:: copy_file(',
             '  .. py:method:: download_file(',
             '  .. py:method:: upload_file('],
             self.generated_contents

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -23,6 +23,8 @@ class TestS3MethodInjection(unittest.TestCase):
                         'upload_file was not injected onto S3 client')
         self.assertTrue(hasattr(client, 'download_file'),
                         'download_file was not injected onto S3 client')
+        self.assertTrue(hasattr(client, 'copy_file'),
+                        'copy_file was not injected onto S3 client')
 
     def test_bucket_resource_has_load_method(self):
         session = boto3.session.Session(region_name='us-west-2')
@@ -36,6 +38,8 @@ class TestS3MethodInjection(unittest.TestCase):
                         'upload_file was not injected onto S3 bucket')
         self.assertTrue(hasattr(bucket, 'download_file'),
                         'download_file was not injected onto S3 bucket')
+        self.assertTrue(hasattr(bucket, 'copy_file'),
+                        'copy_file was not injected onto S3 bucket')
 
     def test_transfer_methods_injected_to_object(self):
         obj = boto3.resource('s3').Object('my_bucket', 'my_key')
@@ -43,3 +47,5 @@ class TestS3MethodInjection(unittest.TestCase):
                         'upload_file was not injected onto S3 object')
         self.assertTrue(hasattr(obj, 'download_file'),
                         'download_file was not injected onto S3 object')
+        self.assertTrue(hasattr(obj, 'copy_file'),
+                        'copy_file was not injected onto S3 object')

--- a/tests/unit/s3/test_transfer.py
+++ b/tests/unit/s3/test_transfer.py
@@ -27,6 +27,7 @@ from boto3.s3.transfer import ReadFileChunk, StreamReaderProgress
 from boto3.s3.transfer import S3Transfer
 from boto3.s3.transfer import OSUtils, TransferConfig
 from boto3.s3.transfer import MultipartDownloader, MultipartUploader
+from boto3.s3.transfer import MultipartCopier
 from boto3.s3.transfer import ShutdownQueue
 from boto3.s3.transfer import QueueShutdownError
 from boto3.s3.transfer import random_file_extension
@@ -480,6 +481,101 @@ class TestMultipartDownloader(unittest.TestCase):
                                      len(response_body), {})
 
 
+class TestMultipartCopier(unittest.TestCase):
+    def test_multipart_copy_uses_correct_client_calls(self):
+        client = mock.Mock()
+        copier = MultipartCopier(
+            client, TransferConfig(),
+            SequentialExecutor)
+        client.create_multipart_upload.return_value = {'UploadId': 'upload_id'}
+        client.upload_part_copy.return_value = {
+            'CopyPartResult': {
+                'ETag': 'first'
+            }
+        }
+
+        copier.copy_file('bucket1', 'key1', 'bucket2', 'key2', 1,
+                         None, {})
+
+        # We need to check both the sequence of calls (create/upload/complete)
+        # as well as the params passed between the calls, including
+        # 1. The upload_id was plumbed through
+        # 2. The collected etags were added to the complete call.
+        client.create_multipart_upload.assert_called_with(
+            Bucket='bucket2', Key='key2')
+        # Should be two parts.
+        client.upload_part_copy.assert_called_with(
+            CopySource='bucket1/key1',
+            Bucket='bucket2', Key='key2',
+            UploadId='upload_id', PartNumber=1,
+            CopySourceRange='bytes=0-0')
+        client.complete_multipart_upload.assert_called_with(
+            MultipartUpload={'Parts': [{'PartNumber': 1, 'ETag': 'first'}]},
+            Bucket='bucket2',
+            UploadId='upload_id',
+            Key='key2')
+
+    def test_multipart_copy_injects_proper_kwargs(self):
+        client = mock.Mock()
+        copier = MultipartCopier(
+            client, TransferConfig(),
+            SequentialExecutor)
+        client.create_multipart_upload.return_value = {'UploadId': 'upload_id'}
+        client.upload_part_copy.return_value = {
+            'CopyPartResult': {
+                'ETag': 'first'
+            }
+        }
+
+        extra_args = {
+            'SSECustomerKey': 'fakekey',
+            'SSECustomerAlgorithm': 'AES256',
+            'StorageClass': 'REDUCED_REDUNDANCY'
+        }
+        copier.copy_file('bucket1', 'key1', 'bucket2', 'key2', 1,
+                         None, extra_args)
+
+        client.create_multipart_upload.assert_called_with(
+            Bucket='bucket2', Key='key2',
+            # The initial call should inject all the storage class params.
+            SSECustomerKey='fakekey',
+            SSECustomerAlgorithm='AES256',
+            StorageClass='REDUCED_REDUNDANCY')
+        client.upload_part_copy.assert_called_with(
+            CopySource='bucket1/key1',
+            Bucket='bucket2', Key='key2',
+            UploadId='upload_id', PartNumber=1,
+            CopySourceRange='bytes=0-0',
+            # We only have to forward certain **extra_args in subsequent
+            # UploadPart calls.
+            SSECustomerKey='fakekey',
+            SSECustomerAlgorithm='AES256',
+        )
+        client.complete_multipart_upload.assert_called_with(
+            MultipartUpload={'Parts': [{'PartNumber': 1, 'ETag': 'first'}]},
+            Bucket='bucket2',
+            UploadId='upload_id',
+            Key='key2')
+
+    def test_multipart_copy_is_aborted_on_error(self):
+        # If the create_multipart_upload succeeds and any upload_part_copy
+        # fails, then abort_multipart_upload will be called.
+        client = mock.Mock()
+        copier = MultipartCopier(
+            client, TransferConfig(),
+            SequentialExecutor)
+        client.create_multipart_upload.return_value = {'UploadId': 'upload_id'}
+        client.upload_part_copy.side_effect = Exception(
+            "Some kind of error occurred.")
+
+        with self.assertRaises(S3UploadFailedError):
+            copier.copy_file('bucket1', 'key1', 'bucket2', 'key2', 1,
+                             None, {})
+
+        client.abort_multipart_upload.assert_called_with(
+            Bucket='bucket2', Key='key2', UploadId='upload_id')
+
+
 class TestS3Transfer(unittest.TestCase):
     def setUp(self):
         self.client = mock.Mock()
@@ -518,6 +614,18 @@ class TestS3Transfer(unittest.TestCase):
             Bucket='bucket', Key='key', Body=mock.ANY
         )
 
+    def test_copy_below_multipart_threshold_uses_copy_object(self):
+        threshold = 1024
+        config = TransferConfig(multipart_threshold=threshold)
+        transfer = S3Transfer(self.client, config=config)
+        self.client.head_object.return_value = {
+            'ContentLength': threshold - 1,
+        }
+        transfer.copy_file('bucket1', 'key1', 'bucket2', 'key2')
+        self.client.copy_object.assert_called_with(
+            CopySource='bucket1/key1', Bucket='bucket2', Key='key2'
+        )
+
     def test_extra_args_on_uploaded_passed_to_api_call(self):
         extra_args = {'ACL': 'public-read'}
         fake_files = {
@@ -529,6 +637,19 @@ class TestS3Transfer(unittest.TestCase):
                              extra_args=extra_args)
         self.client.put_object.assert_called_with(
             Bucket='bucket', Key='key', Body=mock.ANY,
+            ACL='public-read'
+        )
+
+    def test_extra_args_on_copy_passed_to_api_call(self):
+        extra_args = {'ACL': 'public-read'}
+        transfer = S3Transfer(self.client)
+        self.client.head_object.return_value = {
+            'ContentLength': 1,
+        }
+        transfer.copy_file('bucket1', 'key1', 'bucket2', 'key2',
+                           extra_args=extra_args)
+        self.client.copy_object.assert_called_with(
+            CopySource='bucket1/key1', Bucket='bucket2', Key='key2',
             ACL='public-read'
         )
 
@@ -563,6 +684,20 @@ class TestS3Transfer(unittest.TestCase):
                 'bucket', 'key', 'filename.RANDOM', over_multipart_threshold,
                 {}, callback)
 
+    def test_uses_multipart_copy_when_over_threshold(self):
+        with mock.patch('boto3.s3.transfer.MultipartCopier') as copier:
+            threshold = 1024
+            config = TransferConfig(multipart_threshold=threshold)
+            transfer = S3Transfer(self.client, config=config)
+            self.client.head_object.return_value = {
+                'ContentLength': threshold,
+            }
+            transfer.copy_file('bucket1', 'key1', 'bucket2', 'key2')
+
+            copier.return_value.copy_file.assert_called_with(
+                'bucket1', 'key1', 'bucket2', 'key2', threshold,
+                None, {})
+
     def test_download_file_with_invalid_extra_args(self):
         below_threshold = 20
         osutil = InMemoryOSLayer({})
@@ -580,6 +715,13 @@ class TestS3Transfer(unittest.TestCase):
         with self.assertRaises(ValueError):
             transfer.upload_file('bucket', 'key', '/tmp/smallfile',
                                  extra_args=bad_args)
+
+    def test_copy_file_with_invalid_extra_args(self):
+        transfer = S3Transfer(self.client)
+        bad_args = {"WebsiteRedirectLocation": "/foo"}
+        with self.assertRaises(ValueError):
+            transfer.copy_file('bucket1', 'key1', 'bucket2', 'key2',
+                               extra_args=bad_args)
 
     def test_download_file_fowards_extra_args(self):
         extra_args = {


### PR DESCRIPTION
Like the `upload_file()` and `download_file()` methods provided by S3Transfer, this provides `copy_file()` methods for copying from one S3 object to another. This handles parallel multipart uploads like `upload_file()` for fast copies of large files.

#348