### PR TITLE
Update tox to include futures dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,13 +5,10 @@ envlist = py26,py27,py33,py34
 # This is helpful to test installation but takes extra time
 skipsdist = True
 
-[testenv:py26]
-# Python 2.6 requires two extra test dependencies
-deps =
-    unittest2
-    -rrequirements.txt
-
 [testenv]
-deps = -rrequirements.txt
+deps =
+    py26: -rrequirements26.txt
+    py26,py27: futures==2.2.0
+    -rrequirements.txt
 commands =
     nosetests {posargs:tests/unit}

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,6 @@ envlist = py26,py27,py33,py34
 skipsdist = True
 
 [testenv]
-deps =
-    py26: -rrequirements26.txt
-    py26,py27: futures==2.2.0
-    -rrequirements.txt
 commands =
-    nosetests {posargs:tests/unit}
+    {toxinidir}/scripts/ci/install
+    {toxinidir}/scripts/ci/run-tests


### PR DESCRIPTION
Fixes https://github.com/boto/boto3/issues/351

I would also be fine with bringing back the requirement2.txt file that we used to have instead of directly writing ``futures`` into the tox.ini file. I picked this because we really do not use tox to often in our testing and seemed kind of awkward to have a requirements2.txt lying around that was only used for tox.

cc @jamesls @mtdowling @rayluo @JordonPhillips  