### PR TITLE
Fix an SQS sample code typo

### DIFF
--- a/docs/source/guide/sqs.rst
+++ b/docs/source/guide/sqs.rst
@@ -89,7 +89,7 @@ You can also create messages with custom attributes::
     queue.send_message(MessageBody='boto3', MessageAttributes={
         'Author': {
             'StringValue': 'Daniel',
-            'DataType': 'string'
+            'DataType': 'String'
         }
     })
 
@@ -107,7 +107,7 @@ described above in a single request would look like the following::
             'MessageAttributes': {
                 'Author': {
                     'StringValue': 'Daniel',
-                    'DataType': 'string'
+                    'DataType': 'String'
                 }
             }
         }


### PR DESCRIPTION
Fixes #360 

Error message is `(InvalidParameterValue) when calling the SendMessage operation: The message attribute 'Author' has an invalid message attribute type, the set of supported type prefixes is Binary, Number, and String.`

As the message says, correct spelling is `String` not `string` .