### PR TITLE
Fix test failure when unit tests running after other tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -66,5 +66,12 @@ class BaseTestCase(unittest.TestCase):
         loader.data_path = ''
         self.loader = loader
 
+        # We also need to patch the global default session.
+        # Otherwise it could be a cached real session came from previous
+        # "functional" or "integration" tests.
+        _patch_global_session = mock.patch('boto3.DEFAULT_SESSION')
+        _patch_global_session.start()
+        self.addCleanup(_patch_global_session.stop)
+
     def tearDown(self):
         self.bc_session_patch.stop()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -69,9 +69,9 @@ class BaseTestCase(unittest.TestCase):
         # We also need to patch the global default session.
         # Otherwise it could be a cached real session came from previous
         # "functional" or "integration" tests.
-        _patch_global_session = mock.patch('boto3.DEFAULT_SESSION')
-        _patch_global_session.start()
-        self.addCleanup(_patch_global_session.stop)
+        patch_global_session = mock.patch('boto3.DEFAULT_SESSION')
+        patch_global_session.start()
+        self.addCleanup(patch_global_session.stop)
 
     def tearDown(self):
         self.bc_session_patch.stop()


### PR DESCRIPTION
There were 27 test cases failures when running "nosetests tests". By default the test sequence is in alphabetical order, so it is equivalent to "nosetests tests/functional tests/integration tests/unit". You can also observe it when running "nosetests tests/functional tests/unit".

Because [our travis-ci script happens to run "unit" before "functional"](https://github.com/boto/boto3/blob/develop/scripts/ci/run-tests#L20) (which is conceptually correct), so it won't catch this error.

This fix ensures unit tests uses a mocked session object.

I've manually tested the fix.

Before: "nosetests tests/functional tests/unit" ends up with 27 errors.
After: "nosetests tests/functional tests/unit" passes.
And the original "nosetests tests/unit tests/functional" still passes.