### PR TITLE
Sync futures req spec in setup.py and setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,4 @@ universal = 1
 requires-dist =
 	botocore>=1.3.0,<1.4.0
 	jmespath>=0.7.1,<1.0.0
-	futures==2.2.0; python_version=="2.6" or python_version=="2.7"
+	futures>=2.2.0,<4.0.0; python_version=="2.6" or python_version=="2.7"


### PR DESCRIPTION
The 1.2.2 wheel on PyPI is a bit busted because of a discrepancy between the futures requirement spec in setup.py and setup.cfg. See https://bitbucket.org/pypa/wheel/src/90957a3a0a0dd1cb00343938c4f5721d9e3d81a1/CHANGES.txt?at=default&fileviewer=file-view-default#CHANGES.txt-152:

> requires-dist from setup.cfg overwrites any requirements from setup.py
> Care must be taken that the requirements are the same in both cases,
> or just always install from wheel.