### PR TITLE
Injecting examples into docs at build-time

### DIFF
--- a/boto3/docs/service.py
+++ b/boto3/docs/service.py
@@ -26,7 +26,7 @@ from boto3.docs.resource import ServiceResourceDocumenter
 
 class ServiceDocumenter(object):
     # The path used to find examples
-    EXAMPLE_PATH = os.sep.join([os.path.dirname(boto3.__file__), 'examples'])
+    EXAMPLE_PATH = os.path.join(os.path.dirname(boto3.__file__), 'examples')
 
     def __init__(self, service_name, session):
         self._service_name = service_name
@@ -131,8 +131,8 @@ class ServiceDocumenter(object):
 
     def _get_example_file(self):
         return os.path.realpath(
-            os.sep.join([self.EXAMPLE_PATH,
-                         self._service_name + '.rst']))
+            os.path.join(self.EXAMPLE_PATH,
+                         self._service_name + '.rst'))
 
     def _document_examples(self, section):
         examples_file = self._get_example_file()

--- a/boto3/docs/service.py
+++ b/boto3/docs/service.py
@@ -10,6 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import os
+
 from botocore.exceptions import DataNotFoundError
 from botocore.docs.paginator import PaginatorDocumenter
 from botocore.docs.waiter import WaiterDocumenter
@@ -22,9 +24,12 @@ from boto3.docs.resource import ServiceResourceDocumenter
 
 
 class ServiceDocumenter(object):
-    def __init__(self, service_name, session):
+    def __init__(self, service_name, session, examples_file=None):
         self._service_name = service_name
         self._session = session
+        if examples_file is None:
+            examples_file = self._get_examples_file()
+        self._examples_file = examples_file
         # I know that this is an internal attribute, but the botocore session
         # is needed to load the paginator and waiter models.
         self._botocore_session = session._session
@@ -39,8 +44,16 @@ class ServiceDocumenter(object):
             'paginators',
             'waiters',
             'service-resource',
-            'resources'
+            'resources',
+            'examples'
         ]
+
+    def _get_examples_file(self):
+        path = os.sep.join([os.path.dirname(__file__), '..', 'examples',
+                            self._service_name + '.rst'])
+        path = os.path.realpath(path)
+        if os.path.isfile(path):
+            return path
 
     def document_service(self):
         """Documents an entire service.
@@ -60,6 +73,7 @@ class ServiceDocumenter(object):
             self._document_service_resource(
                 doc_structure.get_section('service-resource'))
             self._document_resources(doc_structure.get_section('resources'))
+        self._document_examples(doc_structure.get_section('examples'))
         return doc_structure.flush_structure()
 
     def _document_title(self, section):
@@ -120,3 +134,10 @@ class ServiceDocumenter(object):
             ResourceDocumenter(
                 resource, self._botocore_session).document_resource(
                     section.add_new_section(resource.meta.resource_model.name))
+
+    def _document_examples(self, section):
+        if self._examples_file:
+            section.style.h2('Examples')
+            section.style.new_line()
+            with open(self._examples_file, 'r') as f:
+                section.write(f.read())

--- a/boto3/docs/service.py
+++ b/boto3/docs/service.py
@@ -139,5 +139,8 @@ class ServiceDocumenter(object):
         if os.path.isfile(examples_file):
             section.style.h2('Examples')
             section.style.new_line()
+            section.write(".. contents::\n    :local:\n    :depth: 1")
+            section.style.new_line()
+            section.style.new_line()
             with open(examples_file, 'r') as f:
                 section.write(f.read())

--- a/boto3/examples/s3.rst
+++ b/boto3/examples/s3.rst
@@ -1,0 +1,15 @@
+**To list objects in an Amazon S3 bucket**
+
+The following example shows how to use an Amazon S3 bucket resource to list
+the objects in the bucket.
+
+.. code-block:: python
+
+    import boto3
+
+    s3 = boto3.resource('s3')
+    bucket = s3.Bucket('glacier_test')
+    for obj_sum in bucket.objects.all():
+        obj = s3.Object(obj_sum.bucket_name, obj_sum.key)
+        storage_class = obj.storage_class
+        restore = obj.restore

--- a/boto3/examples/s3.rst
+++ b/boto3/examples/s3.rst
@@ -1,4 +1,5 @@
-**To list objects in an Amazon S3 bucket**
+List objects in an Amazon S3 bucket
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The following example shows how to use an Amazon S3 bucket resource to list
 the objects in the bucket.
@@ -8,8 +9,6 @@ the objects in the bucket.
     import boto3
 
     s3 = boto3.resource('s3')
-    bucket = s3.Bucket('glacier_test')
-    for obj_sum in bucket.objects.all():
-        obj = s3.Object(obj_sum.bucket_name, obj_sum.key)
-        storage_class = obj.storage_class
-        restore = obj.restore
+    bucket = s3.Bucket('my-bucket')
+    for obj in bucket.objects.all():
+        print(obj.key)

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     package_data={
         'boto3': [
             'data/aws/resources/*.json',
+            'examples/*.rst'
         ]
     },
     include_package_data=True,

--- a/tests/unit/data/examples/myservice.rst
+++ b/tests/unit/data/examples/myservice.rst
@@ -1,0 +1,3 @@
+** This is an example **
+
+This is the contents!

--- a/tests/unit/data/examples/otherservice.rst
+++ b/tests/unit/data/examples/otherservice.rst
@@ -1,0 +1,3 @@
+**Other example**
+
+This is for another service

--- a/tests/unit/docs/test_service.py
+++ b/tests/unit/docs/test_service.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import os
+import mock
 
 from tests.unit.docs import BaseDocsTest
 from boto3.docs.service import ServiceDocumenter
@@ -111,3 +112,20 @@ class TestServiceDocumenter(BaseDocsTest):
         service_documenter = ServiceDocumenter('myservice', self.session)
         contents = service_documenter.document_service().decode('utf-8')
         self.assertNotIn('Waiters', contents)
+
+    def test_creates_correct_path_to_examples_based_on_service_name(self):
+        path = os.sep.join([os.path.dirname(__file__), '..', '..', '..',
+                            'boto3', 'examples', 'myservice.rst'])
+        path = os.path.realpath(path)
+        with mock.patch('os.path.isfile') as patch:
+            ServiceDocumenter('myservice', self.session)
+            patch.assert_has_call_with(path)
+
+    def test_injects_examples_when_found(self):
+        examples_file = os.sep.join([os.path.dirname(__file__), '..', 'data',
+                                     'examples', 'myservice.rst'])
+        service_documenter = ServiceDocumenter(
+            'myservice', self.session, examples_file)
+        contents = service_documenter.document_service().decode('utf-8')
+        self.assertIn('This is an example', contents)
+        self.assertNotIn('This is for another service', contents)

--- a/tests/unit/docs/test_service.py
+++ b/tests/unit/docs/test_service.py
@@ -13,6 +13,7 @@
 import os
 import mock
 
+import boto3
 from tests.unit.docs import BaseDocsTest
 from boto3.docs.service import ServiceDocumenter
 
@@ -114,18 +115,19 @@ class TestServiceDocumenter(BaseDocsTest):
         self.assertNotIn('Waiters', contents)
 
     def test_creates_correct_path_to_examples_based_on_service_name(self):
-        path = os.sep.join([os.path.dirname(__file__), '..', '..', '..',
-                            'boto3', 'examples', 'myservice.rst'])
+        path = os.sep.join([os.path.dirname(boto3.__file__), 'boto3',
+                            'examples', 'myservice.rst'])
         path = os.path.realpath(path)
         with mock.patch('os.path.isfile') as patch:
             ServiceDocumenter('myservice', self.session)
             patch.assert_has_call_with(path)
 
     def test_injects_examples_when_found(self):
-        examples_file = os.sep.join([os.path.dirname(__file__), '..', 'data',
-                                     'examples', 'myservice.rst'])
+        examples_path = os.sep.join([os.path.dirname(__file__), '..', 'data',
+                                     'examples'])
         service_documenter = ServiceDocumenter(
-            'myservice', self.session, examples_file)
+            'myservice', self.session)
+        service_documenter.EXAMPLE_PATH = examples_path
         contents = service_documenter.document_service().decode('utf-8')
         self.assertIn('This is an example', contents)
         self.assertNotIn('This is for another service', contents)


### PR DESCRIPTION
This PR adds the ability to inject examples into service documentation at doc build-time. Each service can have a file stored under `boto3/examples/<service-name>.rst`. If found, the contents of this file will be injected into each service's documentation output at the bottom in an "Examples" section.

@kyleknap 