### PR TITLE
S3 restore additions

### DIFF
--- a/boto3/data/s3/2006-03-01/resources-1.json
+++ b/boto3/data/s3/2006-03-01/resources-1.json
@@ -846,6 +846,15 @@
               { "target": "Key", "source": "identifier", "name": "Key" }
             ]
           }
+        },
+        "StartRestore": {
+          "request": {
+            "operation": "RestoreObject",
+            "params": [
+              { "target": "Bucket", "source": "identifier", "name": "BucketName" },
+              { "target": "Key", "source": "identifier", "name": "Key" }
+            ]
+          }
         }
       },
       "batchActions": {
@@ -1008,6 +1017,15 @@
         "Put": {
           "request": {
             "operation": "PutObject",
+            "params": [
+              { "target": "Bucket", "source": "identifier", "name": "BucketName" },
+              { "target": "Key", "source": "identifier", "name": "Key" }
+            ]
+          }
+        },
+        "StartRestore": {
+          "request": {
+            "operation": "RestoreObject",
             "params": [
               { "target": "Bucket", "source": "identifier", "name": "BucketName" },
               { "target": "Key", "source": "identifier", "name": "Key" }

--- a/boto3/data/s3/2006-03-01/resources-1.json
+++ b/boto3/data/s3/2006-03-01/resources-1.json
@@ -847,7 +847,7 @@
             ]
           }
         },
-        "StartRestore": {
+        "RestoreObject": {
           "request": {
             "operation": "RestoreObject",
             "params": [
@@ -1023,7 +1023,7 @@
             ]
           }
         },
-        "StartRestore": {
+        "RestoreObject": {
           "request": {
             "operation": "RestoreObject",
             "params": [

--- a/boto3/examples/s3.rst
+++ b/boto3/examples/s3.rst
@@ -35,7 +35,7 @@ restoration is finished.
             # request.
             if obj.restore is None:
                 print('Submitting restoration request: %s' % obj.key)
-                obj.start_restore()
+                obj.restore_object()
             # Print out objects whose restoration is on-going
             elif 'ongoing-request="true"' in obj.restore:
                 print('Restoration in-progress: %s' % obj.key)

--- a/boto3/examples/s3.rst
+++ b/boto3/examples/s3.rst
@@ -12,3 +12,33 @@ the objects in the bucket.
     bucket = s3.Bucket('my-bucket')
     for obj in bucket.objects.all():
         print(obj.key)
+
+
+Restore Glacier objects in an Amazon S3 bucket
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following example shows how to initiate restoration of glacier objects in
+an Amazon S3 bucket, determine if a restoration is on-going, and determine if a
+restoration is finished.
+
+.. code-block:: python
+
+    import boto3
+
+    s3 = boto3.resource('s3')
+    bucket = s3.Bucket('glacier-bucket')
+    for obj_sum in bucket.objects.all():
+        obj = s3.Object(obj_sum.bucket_name, obj_sum.key)
+        if obj.storage_class == 'GLACIER':
+            # Try to restore the object if the storage class is glacier and
+            # the object does not have a completed or ongoing restoration
+            # request.
+            if obj.restore is None:
+                print('Submitting restoration request: %s' % obj.key)
+                obj.start_restore()
+            # Print out objects whose restoration is on-going
+            elif 'ongoing-request="true"' in obj.restore:
+                print('Restoration in-progress: %s' % obj.key)
+            # Print out objects whose restoration is complete
+            elif 'ongoing-request="false"' in obj.restore:
+                print('Restoration complete: %s' % obj.key)


### PR DESCRIPTION
Fixes https://github.com/boto/boto3/issues/380

It adds a ``start_restore()`` on ``Object`` and ``ObjectSummary`` resources. Note that the method is not called ``restore()`` because the ``Object`` resource already has a ``restore`` attribute.

cc @jamesls @mtdowling @rayluo @JordonPhillips 