### PR TITLE
Bump mock dep to 1.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -e git://github.com/boto/botocore.git@develop#egg=botocore
 -e git://github.com/boto/jmespath.git@develop#egg=jmespath
 nose==1.3.3
-mock==1.0.1
+mock==1.3.0
 wheel==0.24.0

--- a/tests/unit/docs/test_service.py
+++ b/tests/unit/docs/test_service.py
@@ -115,12 +115,16 @@ class TestServiceDocumenter(BaseDocsTest):
         self.assertNotIn('Waiters', contents)
 
     def test_creates_correct_path_to_examples_based_on_service_name(self):
-        path = os.sep.join([os.path.dirname(boto3.__file__), 'boto3',
+        path = os.sep.join([os.path.dirname(boto3.__file__),
                             'examples', 'myservice.rst'])
         path = os.path.realpath(path)
-        with mock.patch('os.path.isfile') as patch:
-            ServiceDocumenter('myservice', self.session)
-            patch.assert_has_call_with(path)
+        with mock.patch('os.path.isfile') as isfile:
+            isfile.return_value = False
+            s = ServiceDocumenter('myservice', self.session)
+            s.document_service()
+            self.assertEqual(
+                isfile.call_args_list[-1],
+                mock.call(path))
 
     def test_injects_examples_when_found(self):
         examples_path = os.sep.join([os.path.dirname(__file__), '..', 'data',


### PR DESCRIPTION
Upgrading to mock=1.3.0 with the erroneous assertion method checking also caught another test bug in one of our doc unit tests.  This PR includes both the version bump to mock as well as the corrected unit test.

Closes #405.

cc @kyleknap @mtdowling @rayluo @JordonPhillips 