### PR TITLE
Add Instance.delete_tags()

### DIFF
--- a/boto3/docs/action.py
+++ b/boto3/docs/action.py
@@ -40,6 +40,7 @@ class ActionDocumenter(BaseDocumenter):
                 'automatically handle the passing in of arguments set '
                 'from identifiers and some attributes.'),
             intro_link='actions_intro')
+
         for action_name in sorted(resource_actions):
             action_section = section.add_new_section(action_name)
             if action_name in ['load', 'reload'] and self._resource_model.load:
@@ -61,7 +62,7 @@ class ActionDocumenter(BaseDocumenter):
                 )
             else:
                 document_custom_method(
-                    section, action_name, resource_actions[action_name])
+                    action_section, action_name, resource_actions[action_name])
 
 
 def document_action(section, resource_name, event_emitter, action_model,

--- a/boto3/ec2/deletetags.py
+++ b/boto3/ec2/deletetags.py
@@ -13,7 +13,7 @@
 from boto3.resources.action import CustomModeledAction
 
 
-def create_delete_tags_action(event_emitter):
+def inject_delete_tags(event_emitter, **kwargs):
     action_model = {
         'request': {
             'operation': 'DeleteTags',
@@ -24,7 +24,9 @@ def create_delete_tags_action(event_emitter):
             }]
         }
     }
-    return CustomModeledAction('delete_tags', action_model, delete_tags, event_emitter)
+    action = CustomModeledAction(
+        'delete_tags', action_model, delete_tags, event_emitter)
+    action.inject(**kwargs)
 
 
 def delete_tags(self, **kwargs):

--- a/boto3/ec2/deletetags.py
+++ b/boto3/ec2/deletetags.py
@@ -10,12 +10,10 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from boto3.utils import inject_attribute
-from boto3.resources.model import Action
-from boto3.docs.docstring import ActionDocstring
+from boto3.resources.action import CustomModeledAction
 
 
-def inject_delete_tags(class_attributes, service_context, emitter, **kwargs):
+def create_delete_tags_action(event_emitter):
     action_model = {
         'request': {
             'operation': 'DeleteTags',
@@ -26,18 +24,7 @@ def inject_delete_tags(class_attributes, service_context, emitter, **kwargs):
             }]
         }
     }
-    action = Action('delete_tags', action_model, {})
-
-    delete_tags_action = delete_tags
-    delete_tags_action.__doc__ = ActionDocstring(
-        resource_name='Instance',
-        event_emitter=emitter,
-        action_model=action,
-        service_model=service_context.service_model,
-        include_signature=False
-    )
-
-    inject_attribute(class_attributes, 'delete_tags', delete_tags_action)
+    return CustomModeledAction('delete_tags', action_model, delete_tags, event_emitter)
 
 
 def delete_tags(self, **kwargs):

--- a/boto3/ec2/deletetags.py
+++ b/boto3/ec2/deletetags.py
@@ -1,0 +1,45 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from boto3.utils import inject_attribute
+from boto3.resources.model import Action
+from boto3.docs.docstring import ActionDocstring
+
+
+def inject_delete_tags(class_attributes, service_context, emitter, **kwargs):
+    action_model = {
+        'request': {
+            'operation': 'DeleteTags',
+            'params': [{
+                'target': 'Resources[0]',
+                'source': 'identifier',
+                'name': 'Id'
+            }]
+        }
+    }
+    action = Action('delete_tags', action_model, {})
+
+    delete_tags_action = delete_tags
+    delete_tags_action.__doc__ = ActionDocstring(
+        resource_name='Instance',
+        event_emitter=emitter,
+        action_model=action,
+        service_model=service_context.service_model,
+        include_signature=False
+    )
+
+    inject_attribute(class_attributes, 'delete_tags', delete_tags_action)
+
+
+def delete_tags(self, **kwargs):
+    kwargs['Resources'] = [self.id]
+    return self.meta.client.delete_tags(**kwargs)

--- a/boto3/resources/action.py
+++ b/boto3/resources/action.py
@@ -17,6 +17,10 @@ from botocore import xform_name
 
 from .params import create_request_parameters
 from .response import RawHandler, ResourceHandler
+from .model import Action
+
+from boto3.docs.docstring import ActionDocstring
+from boto3.utils import inject_attribute
 
 
 logger = logging.getLogger(__name__)
@@ -197,3 +201,42 @@ class WaiterAction(object):
         response = waiter.wait(**params)
 
         logger.debug('Response: %r', response)
+
+
+class CustomModeledAction(object):
+    """A custom, modeled action to inject into a resource."""
+    def __init__(self, action_name, action_model,
+                 function, event_emitter):
+        """
+        :type action_name: str
+        :param action_name: The name of the action to inject, e.g. 'delete_tags'
+
+        :type action_model: dict
+        :param action_model: A JSON definition of the action, as if it were
+            part of the resource model.
+
+        :type function: function
+        :param function: The function to perform when the action is called.
+            The first argument should be 'self', which will be the resource
+            the function is to be called on.
+
+        :type event_emitter: :py:class:`botocore.hooks.BaseEventHooks`
+        :param event_emitter: The session event emitter.
+        """
+        self.name = action_name
+        self.model = action_model
+        self.function = function
+        self.emitter = event_emitter
+
+    def inject(self, class_attributes, service_context,
+               resource_name, **kwargs):
+        action = Action(self.name, self.model, {})
+        self.function.__name__ = self.name
+        self.function.__doc__ = ActionDocstring(
+            resource_name=resource_name,
+            event_emitter=self.emitter,
+            action_model=action,
+            service_model=service_context.service_model,
+            include_signature=False
+        )
+        inject_attribute(class_attributes, self.name, self.function)

--- a/boto3/resources/action.py
+++ b/boto3/resources/action.py
@@ -228,8 +228,8 @@ class CustomModeledAction(object):
         self.function = function
         self.emitter = event_emitter
 
-    def inject(self, class_attributes, service_context,
-               resource_name, **kwargs):
+    def inject(self, class_attributes, service_context, event_name, **kwargs):
+        resource_name = event_name.rsplit(".")[-1]
         action = Action(self.name, self.model, {})
         self.function.__name__ = self.name
         self.function.__doc__ = ActionDocstring(

--- a/boto3/resources/factory.py
+++ b/boto3/resources/factory.py
@@ -136,7 +136,7 @@ class ResourceFactory(object):
             self._emitter.emit(
                 'creating-resource-class.%s' % cls_name,
                 class_attributes=attrs, base_classes=base_classes,
-                service_context=service_context, emitter=self._emitter)
+                service_context=service_context, resource_name=resource_name)
         return type(str(cls_name), tuple(base_classes), attrs)
 
     def _load_identifiers(self, attrs, meta, resource_model, resource_name):

--- a/boto3/resources/factory.py
+++ b/boto3/resources/factory.py
@@ -133,9 +133,10 @@ class ResourceFactory(object):
 
         base_classes = [ServiceResource]
         if self._emitter is not None:
-            self._emitter.emit('creating-resource-class.%s' % cls_name,
-                               class_attributes=attrs,
-                               base_classes=base_classes)
+            self._emitter.emit(
+                'creating-resource-class.%s' % cls_name,
+                class_attributes=attrs, base_classes=base_classes,
+                service_context=service_context, emitter=self._emitter)
         return type(str(cls_name), tuple(base_classes), attrs)
 
     def _load_identifiers(self, attrs, meta, resource_model, resource_name):

--- a/boto3/resources/factory.py
+++ b/boto3/resources/factory.py
@@ -136,7 +136,7 @@ class ResourceFactory(object):
             self._emitter.emit(
                 'creating-resource-class.%s' % cls_name,
                 class_attributes=attrs, base_classes=base_classes,
-                service_context=service_context, resource_name=resource_name)
+                service_context=service_context)
         return type(str(cls_name), tuple(base_classes), attrs)
 
     def _load_identifiers(self, attrs, meta, resource_model, resource_name):

--- a/boto3/session.py
+++ b/boto3/session.py
@@ -350,3 +350,7 @@ class Session(object):
             'creating-resource-class.ec2.ServiceResource',
             boto3.utils.lazy_call(
                 'boto3.ec2.createtags.inject_create_tags'))
+        self._session.register(
+            'creating-resource-class.ec2.Instance',
+            boto3.utils.lazy_call(
+                'boto3.ec2.deletetags.inject_delete_tags'))

--- a/boto3/session.py
+++ b/boto3/session.py
@@ -19,6 +19,7 @@ from botocore.client import Config
 
 import boto3
 import boto3.utils
+from boto3.ec2.deletetags import create_delete_tags_action
 
 from .resources.factory import ResourceFactory
 
@@ -350,7 +351,7 @@ class Session(object):
             'creating-resource-class.ec2.ServiceResource',
             boto3.utils.lazy_call(
                 'boto3.ec2.createtags.inject_create_tags'))
+
+        delete_tags = create_delete_tags_action(self.events)
         self._session.register(
-            'creating-resource-class.ec2.Instance',
-            boto3.utils.lazy_call(
-                'boto3.ec2.deletetags.inject_delete_tags'))
+            'creating-resource-class.ec2.Instance', delete_tags.inject)

--- a/boto3/session.py
+++ b/boto3/session.py
@@ -19,7 +19,6 @@ from botocore.client import Config
 
 import boto3
 import boto3.utils
-from boto3.ec2.deletetags import create_delete_tags_action
 
 from .resources.factory import ResourceFactory
 
@@ -352,6 +351,8 @@ class Session(object):
             boto3.utils.lazy_call(
                 'boto3.ec2.createtags.inject_create_tags'))
 
-        delete_tags = create_delete_tags_action(self.events)
         self._session.register(
-            'creating-resource-class.ec2.Instance', delete_tags.inject)
+            'creating-resource-class.ec2.Instance',
+            boto3.utils.lazy_call(
+                'boto3.ec2.deletetags.inject_delete_tags',
+                event_emitter=self.events))

--- a/boto3/utils.py
+++ b/boto3/utils.py
@@ -53,11 +53,15 @@ def import_module(name):
     return sys.modules[name]
 
 
-def lazy_call(full_name):
+def lazy_call(full_name, **kwargs):
+    parent_kwargs = kwargs
+
     def _handler(**kwargs):
         module, function_name = full_name.rsplit('.', 1)
         module = import_module(module)
+        kwargs.update(parent_kwargs)
         return getattr(module, function_name)(**kwargs)
+
     return _handler
 
 

--- a/tests/functional/docs/__init__.py
+++ b/tests/functional/docs/__init__.py
@@ -59,21 +59,21 @@ class BaseDocsFunctionalTests(unittest.TestCase):
         return contents[:end_index]
 
     def get_request_parameter_document_block(self, param_name, contents):
-        start_param_document = '    :type %s:' % param_name
+        start_param_document = ':type %s:' % param_name
         start_index = contents.find(start_param_document)
         self.assertNotEqual(start_index, -1, 'Param is not found in contents')
         contents = contents[start_index:]
-        end_index = contents.find('    :type', len(start_param_document))
+        end_index = contents.find(':type', len(start_param_document))
         return contents[:end_index]
 
     def get_response_parameter_document_block(self, param_name, contents):
-        start_param_document = '        **Response Structure**'
+        start_param_document = '**Response Structure**'
         start_index = contents.find(start_param_document)
         self.assertNotEqual(start_index, -1, 'There is no response structure')
 
-        start_param_document = '          - **%s**' % param_name
+        start_param_document = '- **%s**' % param_name
         start_index = contents.find(start_param_document)
         self.assertNotEqual(start_index, -1, 'Param is not found in contents')
         contents = contents[start_index:]
-        end_index = contents.find('          - **', len(start_param_document))
+        end_index = contents.find('- **', len(start_param_document))
         return contents[:end_index]

--- a/tests/functional/docs/test_dynamodb.py
+++ b/tests/functional/docs/test_dynamodb.py
@@ -42,19 +42,19 @@ class TestDynamoDBCustomizations(BaseDocsFunctionalTests):
         request_syntax_contents = self.get_request_syntax_document_block(
             method_contents)
         self.assert_contains_lines_in_order([
-            '        response = table.put_item(',
-            '            Item={',
-            ('                \'string\': \'string\'|123|Binary(b\'bytes\')'
+            'response = table.put_item(',
+            'Item={',
+            ('\'string\': \'string\'|123|Binary(b\'bytes\')'
              '|True|None|set([\'string\'])|set([123])|'
              'set([Binary(b\'bytes\')])|[]|{}'),
-            '            },',
-            '            Expected={',
-            '                \'string\': {',
-            ('                    \'Value\': \'string\'|123'
+            '},',
+            'Expected={',
+            '\'string\': {',
+            ('\'Value\': \'string\'|123'
              '|Binary(b\'bytes\')|True|None|set([\'string\'])'
              '|set([123])|set([Binary(b\'bytes\')])|[]|{},'),
-            '                    \'AttributeValueList\': [',
-            ('                        \'string\'|123|Binary(b\'bytes\')'
+            '\'AttributeValueList\': [',
+            ('\'string\'|123|Binary(b\'bytes\')'
              '|True|None|set([\'string\'])|set([123])|'
              'set([Binary(b\'bytes\')])|[]|{},')],
             request_syntax_contents)
@@ -63,22 +63,22 @@ class TestDynamoDBCustomizations(BaseDocsFunctionalTests):
         response_syntax_contents = self.get_response_syntax_document_block(
             method_contents)
         self.assert_contains_lines_in_order([
-            '          {',
-            '              \'Attributes\': {',
-            ('                  \'string\': \'string\'|123|'
+            '{',
+            '\'Attributes\': {',
+            ('\'string\': \'string\'|123|'
              'Binary(b\'bytes\')|True|None|set([\'string\'])|'
              'set([123])|set([Binary(b\'bytes\')])|[]|{}'),
-            '              },'],
+            '},'],
             response_syntax_contents)
 
         # Make sure the request parameter is documented correctly.
         request_param_contents = self.get_request_parameter_document_block(
             'Item', method_contents)
         self.assert_contains_lines_in_order([
-            '    :type Item: dict',
-            '    :param Item: **[REQUIRED]**',
-            '        - *(string) --*',
-            ('          - *(valid DynamoDB type) --* - The value of the '
+            ':type Item: dict',
+            ':param Item: **[REQUIRED]**',
+            '- *(string) --*',
+            ('- *(valid DynamoDB type) --* - The value of the '
              'attribute. The valid value types are listed in the '
              ':ref:`DynamoDB Reference Guide<ref_valid_dynamodb_types>`.')],
             request_param_contents
@@ -88,9 +88,9 @@ class TestDynamoDBCustomizations(BaseDocsFunctionalTests):
         response_param_contents = self.get_response_parameter_document_block(
             'Attributes', method_contents)
         self.assert_contains_lines_in_order([
-            '          - **Attributes** *(dict) --*',
-            '            - *(string) --*',
-            ('              - *(valid DynamoDB type) --* - The value of '
+            '- **Attributes** *(dict) --*',
+            '- *(string) --*',
+            ('- *(valid DynamoDB type) --* - The value of '
              'the attribute. The valid value types are listed in the '
              ':ref:`DynamoDB Reference Guide<ref_valid_dynamodb_types>`.')],
             response_param_contents)
@@ -106,23 +106,23 @@ class TestDynamoDBCustomizations(BaseDocsFunctionalTests):
         request_syntax_contents = self.get_request_syntax_document_block(
             method_contents)
         self.assert_contains_lines_in_order([
-            '        response = table.query(',
-            ('            FilterExpression=Attr(\'myattribute\').'
+            'response = table.query(',
+            ('FilterExpression=Attr(\'myattribute\').'
              'eq(\'myvalue\'),'),
-            ('            KeyConditionExpression=Key(\'mykey\')'
+            ('KeyConditionExpression=Key(\'mykey\')'
              '.eq(\'myvalue\'),')],
             request_syntax_contents)
 
         # Make sure the request parameter is documented correctly.
         self.assert_contains_lines_in_order([
-            ('      :type FilterExpression: condition from '
+            (':type FilterExpression: condition from '
              ':py:class:`boto3.dynamodb.conditions.Attr` method'),
-            ('      :param FilterExpression: The condition(s) an '
+            (':param FilterExpression: The condition(s) an '
              'attribute(s) must meet. Valid conditions are listed in '
              'the :ref:`DynamoDB Reference Guide<ref_dynamodb_conditions>`.'),
-            ('      :type KeyConditionExpression: condition from '
+            (':type KeyConditionExpression: condition from '
              ':py:class:`boto3.dynamodb.conditions.Key` method'),
-            ('      :param KeyConditionExpression: The condition(s) a '
+            (':param KeyConditionExpression: The condition(s) a '
              'key(s) must meet. Valid conditions are listed in the '
              ':ref:`DynamoDB Reference Guide<ref_dynamodb_conditions>`.')],
             method_contents)

--- a/tests/functional/docs/test_ec2.py
+++ b/tests/functional/docs/test_ec2.py
@@ -1,0 +1,35 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests.functional.docs import BaseDocsFunctionalTests
+
+from boto3.session import Session
+from boto3.docs.service import ServiceDocumenter
+
+
+class TestInstanceDeleteTags(BaseDocsFunctionalTests):
+    def setUp(self):
+        self.documenter = ServiceDocumenter(
+            'ec2', session=Session(region_name='us-east-1'))
+        self.generated_contents = self.documenter.document_service()
+        self.generated_contents = self.generated_contents.decode('utf-8')
+
+    def test_delete_tags_method_is_documented(self):
+        contents = self.get_class_document_block(
+                'EC2.Instance', self.generated_contents)
+        method_contents = self.get_method_document_block(
+                'delete_tags', contents)
+        self.assert_contains_lines_in_order([
+            'response = instance.delete_tags(',
+            'DryRun=True|False,',
+            'Tags=[',
+        ], method_contents)

--- a/tests/functional/test_ec2.py
+++ b/tests/functional/test_ec2.py
@@ -1,0 +1,36 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import unittest
+
+import boto3.session
+from botocore.stub import Stubber
+
+
+class TestInstanceDeleteTags(unittest.TestCase):
+    def setUp(self):
+        self.session = boto3.session.Session(region_name='us-west-2')
+        self.service_resource = self.session.resource('ec2')
+        self.instance_resource = self.service_resource.Instance('i-abc123')
+
+    def test_delete_tags_injected(self):
+        self.assertTrue(hasattr(self.instance_resource, 'delete_tags'),
+                        'delete_tags was not injected onto Instance resource.')
+
+    def test_delete_tags(self):
+        stubber = Stubber(self.instance_resource.meta.client)
+        stubber.add_response('delete_tags', {})
+        stubber.activate()
+        response = self.instance_resource.delete_tags(Tags=[{'Key': 'foo'}])
+        stubber.assert_no_pending_responses()
+        self.assertEqual(response, {})
+        stubber.deactivate()

--- a/tests/unit/ec2/test_deletetags.py
+++ b/tests/unit/ec2/test_deletetags.py
@@ -1,0 +1,40 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the 'license' file accompanying this file. This file is
+# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import unittest
+import mock
+
+from boto3.ec2.deletetags import delete_tags
+
+
+class TestDeleteTags(unittest.TestCase):
+    def setUp(self):
+        self.client = mock.Mock()
+        self.resource = mock.Mock()
+        self.resource.meta.client = self.client
+        self.instance_id = 'instance_id'
+        self.resource.id = self.instance_id
+
+    def test_delete_tags(self):
+        tags = {
+            'Tags': [
+                {'Key': 'key1', 'Value': 'value1'},
+                {'Key': 'key2', 'Value': 'value2'},
+                {'Key': 'key3', 'Value': 'value3'}
+            ]
+        }
+
+        delete_tags(self.resource, **tags)
+
+        kwargs = tags
+        kwargs['Resources'] = [self.instance_id]
+        self.client.delete_tags.assert_called_with(**kwargs)


### PR DESCRIPTION
The Tag resource was incorrectly modeled such that it is not a collection on an Instance. As a result, there is no way to batch delete tags from an Instance resource. This adds that functionality in, in a way that won't break on future EC2 resource changes.

In the long term there are plans to codify SDK specific customizations while maintaining a canonically correct resource model, but that will sometime in the future as part of a different story.

Fixes #381

cc @kyleknap @jamesls @mtdowling @rayluo 