### PR TITLE
Update botocore dependency

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+Next Release - (TBD)
+--------------------
+* feature:``EC2``: Add delete_tags() action to Instance resource.
+  (`issue 459 <https://github.com/boto/boto3/pull/459>`__)
+* feature:``Session``: Add ``region_name`` property on session.
+  (`issue 414 <https://github.com/boto/boto3/pull/414>`__)
+* bugfix:``S3``: Fix issue with hanging downloads.
+  (`issue 471 <https://github.com/boto/boto3/pull/471>`__)
+
+
 1.2.3 - (2015-12-17)
 --------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,6 @@ universal = 1
 
 [metadata]
 requires-dist =
-	botocore>=1.3.0,<1.4.0
+	botocore>=1.3.24,<1.4.0
 	jmespath>=0.7.1,<1.0.0
 	futures>=2.2.0,<4.0.0; python_version=="2.6" or python_version=="2.7"

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ VERSION_RE = re.compile(r'''__version__ = ['"]([0-9.]+)['"]''')
 
 
 requires = [
-    'botocore>=1.3.0,<1.4.0',
+    'botocore>=1.3.24,<1.4.0',
     'jmespath>=0.7.1,<1.0.0',
 ]
 


### PR DESCRIPTION
Also noticed we have not been updating the ``CHANGELOG`` so I updated that as
well. This specifically ensures you pick up this merged functionality: https://github.com/boto/botocore/pull/779

cc @jamesls @mtdowling @rayluo @JordonPhillips 