### PR TITLE
Improve error message when creating a resource that does not exist

### DIFF
--- a/boto3/exceptions.py
+++ b/boto3/exceptions.py
@@ -19,6 +19,32 @@ class NoVersionFound(Exception):
     pass
 
 
+class UnknownAPIVersionError(Exception):
+    def __init__(self, service_name, bad_api_version,
+                 available_api_versions):
+        msg = (
+            "The '%s' resource does not an API version of: %s\n"
+            "Valid API versions are: %s"
+            % (service_name, bad_api_version, available_api_versions)
+        )
+        super(UnknownAPIVersionError, self).__init__(msg)
+
+
+class ResourceNotExistsError(Exception):
+    """Raised when you attempt to create a resource that does not exist."""
+    def __init__(self, service_name, available_services, has_low_level_client):
+        msg = (
+            "The '%s' resource does not exist.\n"
+            "The available resources are:\n"
+            "   - %s\n" % (service_name, '\n   - '.join(available_services))
+        )
+        if has_low_level_client:
+            msg += (
+                "\nConsider using a boto3.client('%s') instead "
+                "of a resource for '%s'" % (service_name, service_name))
+        super(ResourceNotExistsError, self).__init__(msg)
+
+
 class RetriesExceededError(Exception):
     def __init__(self, last_exception, msg='Max Retries Exceeded'):
         super(RetriesExceededError, self).__init__(msg)

--- a/boto3/exceptions.py
+++ b/boto3/exceptions.py
@@ -11,15 +11,32 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-class ResourceLoadException(Exception):
+# All exceptions in this class should subclass from Boto3Error.
+import botocore.exceptions
+
+
+# All exceptions should subclass from Boto3Error in this module.
+class Boto3Error(Exception):
+    """Base class for all Boto3 errors."""
+
+
+class ResourceLoadException(Boto3Error):
     pass
 
 
-class NoVersionFound(Exception):
+# NOTE: This doesn't appear to be used anywhere.
+# It's probably safe to remove this.
+class NoVersionFound(Boto3Error):
     pass
 
 
-class UnknownAPIVersionError(Exception):
+# We're subclassing from botocore.exceptions.DataNotFoundError
+# to keep backwards compatibility with anyone that was catching
+# this low level Botocore error before this exception was
+# introduced in boto3.
+# Same thing for ResourceNotExistsError below.
+class UnknownAPIVersionError(Boto3Error,
+                             botocore.exceptions.DataNotFoundError):
     def __init__(self, service_name, bad_api_version,
                  available_api_versions):
         msg = (
@@ -27,10 +44,13 @@ class UnknownAPIVersionError(Exception):
             "Valid API versions are: %s"
             % (service_name, bad_api_version, available_api_versions)
         )
-        super(UnknownAPIVersionError, self).__init__(msg)
+        # Not using super because we don't want the DataNotFoundError
+        # to be called, it has a different __init__ signature.
+        Boto3Error.__init__(self, msg)
 
 
-class ResourceNotExistsError(Exception):
+class ResourceNotExistsError(Boto3Error,
+                             botocore.exceptions.DataNotFoundError):
     """Raised when you attempt to create a resource that does not exist."""
     def __init__(self, service_name, available_services, has_low_level_client):
         msg = (
@@ -42,24 +62,26 @@ class ResourceNotExistsError(Exception):
             msg += (
                 "\nConsider using a boto3.client('%s') instead "
                 "of a resource for '%s'" % (service_name, service_name))
-        super(ResourceNotExistsError, self).__init__(msg)
+        # Not using super because we don't want the DataNotFoundError
+        # to be called, it has a different __init__ signature.
+        Boto3Error.__init__(self, msg)
 
 
-class RetriesExceededError(Exception):
+class RetriesExceededError(Boto3Error):
     def __init__(self, last_exception, msg='Max Retries Exceeded'):
         super(RetriesExceededError, self).__init__(msg)
         self.last_exception = last_exception
 
 
-class S3TransferFailedError(Exception):
+class S3TransferFailedError(Boto3Error):
     pass
 
 
-class S3UploadFailedError(Exception):
+class S3UploadFailedError(Boto3Error):
     pass
 
 
-class DynamoDBOperationNotSupportedError(Exception):
+class DynamoDBOperationNotSupportedError(Boto3Error):
     """Raised for operantions that are not supported for an operand"""
     def __init__(self, operation, value):
         msg = (
@@ -72,7 +94,7 @@ class DynamoDBOperationNotSupportedError(Exception):
 # FIXME: Backward compatibility
 DynanmoDBOperationNotSupportedError = DynamoDBOperationNotSupportedError
 
-class DynamoDBNeedsConditionError(Exception):
+class DynamoDBNeedsConditionError(Boto3Error):
     """Raised when input is not a condition"""
     def __init__(self, value):
         msg = (
@@ -82,5 +104,5 @@ class DynamoDBNeedsConditionError(Exception):
         Exception.__init__(self, msg)
 
 
-class DynamoDBNeedsKeyConditionError(Exception):
+class DynamoDBNeedsKeyConditionError(Boto3Error):
     pass

--- a/tests/functional/test_resource.py
+++ b/tests/functional/test_resource.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import boto3
+from boto3.exceptions import ResourceNotExistsError
 
 import botocore.session
 from tests import unittest
@@ -36,3 +37,14 @@ class TestResourceCustomization(unittest.TestCase):
         resource = session.resource('s3')
         self.assertTrue(hasattr(resource, 'my_method'))
         self.assertEqual(resource.my_method('anything'), 'anything')
+
+
+
+class TestSessionErrorMessages(unittest.TestCase):
+    def test_has_good_error_message_when_no_resource(self):
+        bad_resource_name = 'doesnotexist'
+        err_regex = (
+            '%s.*resource does not exist.' % bad_resource_name
+        )
+        with self.assertRaisesRegexp(ResourceNotExistsError, err_regex):
+            boto3.resource(bad_resource_name)

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -12,11 +12,11 @@
 # language governing permissions and limitations under the License.
 
 from botocore import loaders
-from botocore.exceptions import DataNotFoundError
+from botocore.exceptions import DataNotFoundError, UnknownServiceError
 from botocore.client import Config
 
 from boto3 import __version__
-from boto3.exceptions import NoVersionFound
+from boto3.exceptions import NoVersionFound, ResourceNotExistsError
 from boto3.session import Session
 from tests import mock, BaseTestCase
 
@@ -263,18 +263,47 @@ class TestSession(BaseTestCase):
         session.resource('sqs')
 
         loader.load_service_model.assert_called_with(
-            'sqs', 'resources-1', '2014-11-02')
+            'sqs', 'resources-1', None)
 
     def test_bad_resource_name(self):
         mock_bc_session = mock.Mock()
         loader = mock.Mock(spec=loaders.Loader)
-        loader.determine_latest_version.side_effect = DataNotFoundError(
-            data_path='foo')
+        loader.load_service_model.side_effect = UnknownServiceError(
+            service_name='foo', known_service_names='asdf'
+        )
         mock_bc_session.get_component.return_value = loader
+        loader.list_available_services.return_value = ['good-resource']
+        mock_bc_session.get_available_services.return_value = ['sqs']
 
         session = Session(botocore_session=mock_bc_session)
-        with self.assertRaises(DataNotFoundError):
+        with self.assertRaises(ResourceNotExistsError) as e:
             session.resource('sqs')
+        err_msg = str(e.exception)
+        # 1. should say the resource doesn't exist.
+        self.assertIn('resource does not exist', err_msg)
+        self.assertIn('sqs', err_msg)
+        # 2. Should list available resources you can choose.
+        self.assertIn('good-resource', err_msg)
+        # 3. Should list client if available.
+        self.assertIn('client', err_msg)
+
+    def test_bad_resource_name_with_no_client_has_simple_err_msg(self):
+        mock_bc_session = mock.Mock()
+        loader = mock.Mock(spec=loaders.Loader)
+        loader.load_service_model.side_effect = UnknownServiceError(
+            service_name='foo', known_service_names='asdf'
+        )
+        mock_bc_session.get_component.return_value = loader
+        loader.list_available_services.return_value = ['good-resource']
+        mock_bc_session.get_available_services.return_value = ['good-client']
+
+        session = Session(botocore_session=mock_bc_session)
+        with self.assertRaises(ResourceNotExistsError) as e:
+            session.resource('bad-client')
+        err_msg = str(e.exception)
+        # Shouldn't mention anything about clients because
+        # 'bad-client' it not a valid boto3.client(...)
+        self.assertNotIn('boto3.client', err_msg)
 
     def test_can_reach_events(self):
         mock_bc_session = self.bc_session_cls()


### PR DESCRIPTION
This handles 3 cases:

* They've provided an invalid service_name
* They've provided a service name that has a client but no resource
* They've provided a valid service name but an invalid API version


As an example, this script:

```python
import boto3
print "\ncase1: boto3.resource('bad-resource-name')  # Bad name with no client:\n"
try:
    r = boto3.resource('bad-resource-name')
except Exception as e:
    print str(e)

print "\ncase2: boto3.resource('firehose')    #  No resource but has client:\n"
try:
    r = boto3.resource('firehose')
except Exception as e:
    print str(e)

print "\ncase3: boto3.resource('ec2', api_version='bad-version')  # Has resource/client but bad API version.\n"
try:
    r = boto3.resource('ec2', api_version='bad-version')
except Exception as e:
    print str(e)

```

produces this output:

```
$ python t.py

case1: boto3.resource('bad-resource-name')  # Bad name with no client:

The 'bad-resource-name' resource does not exist.
The available resources are:
   - cloudformation
   - cloudwatch
   - dynamodb
   - ec2
   - glacier
   - iam
   - opsworks
   - s3
   - sns
   - sqs


case2: boto3.resource('firehose')    #  No resource but has client:

The 'firehose' resource does not exist.
The available resources are:
   - cloudformation
   - cloudwatch
   - dynamodb
   - ec2
   - glacier
   - iam
   - opsworks
   - s3
   - sns
   - sqs

Consider using a boto3.client('firehose') instead of a resource for 'firehose'

case3: boto3.resource('ec2', api_version='bad-version')  # Has resource/client but bad API version.

The 'ec2' resource does not an API version of: bad-version
Valid API versions are: 2014-10-01, 2015-03-01, 2015-04-15, 2015-10-01
```

Fixes #506 

cc @kyleknap @JordonPhillips 