### PR TITLE
Add get_available_subresources to Resources

### DIFF
--- a/boto3/resources/factory.py
+++ b/boto3/resources/factory.py
@@ -248,6 +248,26 @@ class ResourceFactory(object):
                 service_context=service_context
             )
 
+        self._create_available_subresources_command(
+            attrs, resource_model.subresources)
+
+    def _create_available_subresources_command(self, attrs, subresources):
+        _subresources = [subresource.name for subresource in subresources]
+        _subresources = sorted(_subresources)
+
+        def get_available_subresources(factory_self):
+            """
+            Returns a list of all the available sub-resources for this
+            Resource.
+
+            :returns: A list containing the name of each sub-resource for this
+                resource
+            :rtype: list of str
+            """
+            return _subresources
+
+        attrs['get_available_subresources'] = get_available_subresources
+
     def _load_waiters(self, attrs, resource_name, resource_model,
                       service_context):
         """

--- a/tests/functional/test_resource.py
+++ b/tests/functional/test_resource.py
@@ -39,7 +39,6 @@ class TestResourceCustomization(unittest.TestCase):
         self.assertEqual(resource.my_method('anything'), 'anything')
 
 
-
 class TestSessionErrorMessages(unittest.TestCase):
     def test_has_good_error_message_when_no_resource(self):
         bad_resource_name = 'doesnotexist'
@@ -48,3 +47,9 @@ class TestSessionErrorMessages(unittest.TestCase):
         )
         with self.assertRaisesRegexp(ResourceNotExistsError, err_regex):
             boto3.resource(bad_resource_name)
+
+
+class TestGetAvailableSubresources(unittest.TestCase):
+    def test_s3_available_subresources_exists(self):
+        s3 = boto3.resource('s3')
+        self.assertTrue(hasattr(s3, 'get_available_subresources'))

--- a/tests/unit/resources/test_factory.py
+++ b/tests/unit/resources/test_factory.py
@@ -856,6 +856,13 @@ class TestServiceResourceSubresources(BaseTestResourceFactory):
         self.assertIn('PriorityQueue', dir(resource))
         self.assertIn('Message', dir(resource))
 
+    def test_get_available_subresources(self):
+        resource = self.load('test', self.model, self.defs)()
+        self.assertTrue(hasattr(resource, 'get_available_subresources'))
+        subresources = sorted(resource.get_available_subresources())
+        expected = sorted(['PriorityQueue', 'Message', 'QueueObject'])
+        self.assertEqual(subresources, expected)
+
     def test_subresource_missing_all_subresources(self):
         resource = self.load('test', self.model, self.defs)()
         message = resource.Message('url', 'handle')
@@ -875,8 +882,9 @@ class TestServiceResourceSubresources(BaseTestResourceFactory):
 
         # Verify we send out the class attributes dict.
         actual_class_attrs = sorted(call_args[1]['class_attributes'])
-        self.assertEqual(actual_class_attrs,
-                         ['Message', 'PriorityQueue', 'QueueObject', 'meta'])
+        self.assertEqual(actual_class_attrs, [
+            'Message', 'PriorityQueue', 'QueueObject',
+            'get_available_subresources', 'meta'])
 
         base_classes = sorted(call_args[1]['base_classes'])
         self.assertEqual(base_classes, [ServiceResource])


### PR DESCRIPTION
We currently have the ability to inspect what resources are available to a session, but not what subresources are available to a resource. This adds a method to do that on each resource class.

Resolves #113

This wasn't super high priority, but it was a very simple change.

![screen shot 2016-03-18 at 4 06 16 pm](https://cloud.githubusercontent.com/assets/2643092/13894283/5f8d6ac4-ed23-11e5-8f4f-c9411dd5e1ad.png)


cc @jamesls @kyleknap 