### PR TITLE
Ensure batch writer never sends more than flush_amount

### DIFF
--- a/boto3/dynamodb/table.py
+++ b/boto3/dynamodb/table.py
@@ -98,14 +98,16 @@ class BatchWriter(object):
             self._flush()
 
     def _flush(self):
+        items_to_send = self._items_buffer[:self._flush_amount]
+        self._items_buffer = self._items_buffer[self._flush_amount:]
         response = self._client.batch_write_item(
-            RequestItems={self._table_name: self._items_buffer})
+            RequestItems={self._table_name: items_to_send})
         unprocessed_items = response['UnprocessedItems']
 
         if unprocessed_items and unprocessed_items[self._table_name]:
             # Any unprocessed_items are immediately added to the
             # next batch we send.
-            self._items_buffer = unprocessed_items[self._table_name]
+            self._items_buffer.extend(unprocessed_items[self._table_name])
         else:
             self._items_buffer = []
         logger.debug("Batch write sent %s, unprocessed: %s",


### PR DESCRIPTION
In the case where no items are processed and we received
all the items back as unprocessed key, the next put_item
request will have flush_amount + 1, which will trigger
an error.

To fix this, the input_buffer is always sliced to
flush_amount before the batch_write_item() call.

Fixes #483.

cc @kyleknap @JordonPhillips 