### PR TITLE
log the exact amount of items sent to dynamo in batch

### DIFF
--- a/boto3/dynamodb/table.py
+++ b/boto3/dynamodb/table.py
@@ -111,7 +111,7 @@ class BatchWriter(object):
         else:
             self._items_buffer = []
         logger.debug("Batch write sent %s, unprocessed: %s",
-                     self._flush_amount, len(self._items_buffer))
+                     len(items_to_send), len(self._items_buffer))
 
     def __enter__(self):
         return self


### PR DESCRIPTION
Let logging show the real amount of sent items. Small, but quite useful detail to log during testing stages. 