### PR TITLE
Fix S3Transfer doc issues

### DIFF
--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -72,7 +72,7 @@ client operation.  Here are a few examples using ``upload_file``::
                          extra_args={'ContentType': "application/json"})
 
 
-The ``S3Transfer`` clas also supports progress callbacks so you can
+The ``S3Transfer`` class also supports progress callbacks so you can
 provide transfer progress to users.  Both the ``upload_file`` and
 ``download_file`` methods take an optional ``callback`` parameter.
 Here's an example of how to print a simple progress percentage
@@ -94,7 +94,7 @@ to the user:
                 self._seen_so_far += bytes_amount
                 percentage = (self._seen_so_far / self._size) * 100
                 sys.stdout.write(
-                    "\r%s  %s / %s  (%.2f%%)" % (self._filename, self._seen_so_far,
+                    "\\r%s  %s / %s  (%.2f%%)" % (self._filename, self._seen_so_far,
                                                  self._size, percentage))
                 sys.stdout.flush()
 
@@ -179,7 +179,7 @@ class ReadFileChunk(object):
                  callback=None, enable_callback=True):
         """
 
-        Given a file object shown below:
+        Given a file object shown below::
 
             |___________________________________________________|
             0          |                 |                 full_file_size


### PR DESCRIPTION
This fixes a couple of issues in the current s3transfer docs. Closes #594 and also closes #391 

# Before #

![creturn](https://cloud.githubusercontent.com/assets/2643092/14573384/9c789a20-0309-11e6-915c-d7ec5af14df8.png)
---
![filechunk](https://cloud.githubusercontent.com/assets/2643092/14573386/9e597774-0309-11e6-841c-1813e1c316d3.png)

# After # 

![creturn2](https://cloud.githubusercontent.com/assets/2643092/14573390/a630a300-0309-11e6-925e-f6ed1de94e2c.png)
---
![filechunk2](https://cloud.githubusercontent.com/assets/2643092/14573394/aa7f25ee-0309-11e6-9f8d-7f419059928e.png)
