### PR TITLE
dynamodb: add request auto de-duplication  for batch_writer

### DIFF
--- a/.changes/next-release/feature-DynamoDB.json
+++ b/.changes/next-release/feature-DynamoDB.json
@@ -1,0 +1,5 @@
+{
+  "category": "DynamoDB", 
+  "type": "feature", 
+  "description": "Add request auto de-duplication based on specified primary keys for batch_writer. (``#605 <https://github.com/boto/boto3/issues/605>`__ <https"
+}

--- a/docs/source/guide/dynamodb.rst
+++ b/docs/source/guide/dynamodb.rst
@@ -274,6 +274,24 @@ table.
                 }
             )
 
+The batch writer can help to de-duplicate request by specifying ``auto_dedup=True``
+if you want to bypass no duplication limitation of single batch write request. The error looks like
+``botocore.exceptions.ClientError: An error occurred (ValidationException) when calling the BatchWriteItem operation: Provided list of item keys contains duplicates``.
+It will just write out a single request since all requests are the same in below example.
+
+::
+
+    with table.batch_writer(auto_dedup=True) as batch:
+        for _ in range(50):
+            batch.put_item(
+                Item={
+                    'account_type': 'anonymous',
+                    'username': 'user',
+                    'first_name': 'unknown',
+                    'last_name': 'unknown'
+                }
+            )
+
 
 Querying and Scanning
 ---------------------

--- a/tests/functional/docs/test_dynamodb.py
+++ b/tests/functional/docs/test_dynamodb.py
@@ -27,7 +27,7 @@ class TestDynamoDBCustomizations(BaseDocsFunctionalTests):
         self.assert_contains_lines_in_order([
             '.. py:class:: DynamoDB.Table(name)',
             '  *   :py:meth:`batch_writer()`',
-            '  .. py:method:: batch_writer()'],
+            '  .. py:method:: batch_writer(auto_dedup=False)'],
             self.generated_contents
         )
 

--- a/tests/functional/docs/test_dynamodb.py
+++ b/tests/functional/docs/test_dynamodb.py
@@ -27,7 +27,7 @@ class TestDynamoDBCustomizations(BaseDocsFunctionalTests):
         self.assert_contains_lines_in_order([
             '.. py:class:: DynamoDB.Table(name)',
             '  *   :py:meth:`batch_writer()`',
-            '  .. py:method:: batch_writer(auto_dedup=False)'],
+            '  .. py:method:: batch_writer(overwrite_by_pkeys=None)'],
             self.generated_contents
         )
 


### PR DESCRIPTION
# Motivation #
For scenarios like parsing some values from several sources like server log, user upload data which might contain value duplication, and write them to dynamoDB as unique values.

You want to bypass no duplication limitation of single batch write request within `boto3` rather than adding another layer to deal with value duplication.

The no duplication error looks like
`botocore.exceptions.ClientError: An error occurred (ValidationException) when calling the BatchWriteItem operation: Provided list of item keys contains duplicates`.




# Solution #
To de-duplicate request by specifying ``auto_dedup=True``
It will just write out a single request since all requests are the same in below example.

```python
    with table.batch_writer(auto_dedup=True) as batch:
        for _ in range(50):
            batch.put_item(
                Item={
                    'account_type': 'anonymous',
                    'username': 'user',
                    'first_name': 'unknown',
                    'last_name': 'unknown'
                }
            )