### PR TITLE
Fix string compatibility issue in scripts/new-change

### DIFF
--- a/scripts/new-change
+++ b/scripts/new-change
@@ -47,7 +47,7 @@ import subprocess
 import argparse
 
 
-VALID_CHARS = set(string.letters + string.digits)
+VALID_CHARS = set(string.ascii_letters + string.digits)
 CHANGES_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
     '.changes'


### PR DESCRIPTION
Python 3 does not have `string.letters` due to the ambiguous nature of
the word 'letters' when locales are taken into consideration. To get the
same effect, you can use `string.ascii_letters`, which is available on
all versions we support.

cc @kyleknap @jamesls