### PR TITLE
Change readthedocs.org to readthedocs.io

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,5 +1,5 @@
 For more information, please see the official docs at
-http://boto3.readthedocs.org/
+http://boto3.readthedocs.io/
 
 Contributing Code
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -12,12 +12,12 @@ services that are supported.
 
 
 .. _boto: https://docs.pythonboto.org/
-.. _`Read the Docs`: https://boto3.readthedocs.org/en/latest/
+.. _`Read the Docs`: https://boto3.readthedocs.io/en/latest/
 .. |Build Status| image:: http://img.shields.io/travis/boto/boto3/develop.svg?style=flat
     :target: https://travis-ci.org/boto/boto3
     :alt: Build Status
-.. |Docs| image:: https://readthedocs.org/projects/boto3/badge/?version=latest&style=flat
-    :target: https://boto3.readthedocs.org/en/latest/
+.. |Docs| image:: https://readthedocs.io/projects/boto3/badge/?version=latest&style=flat
+    :target: https://boto3.readthedocs.io/en/latest/
     :alt: Read the docs
 .. |Downloads| image:: http://img.shields.io/pypi/dm/boto3.svg?style=flat
     :target: https://pypi.python.org/pypi/boto3/

--- a/boto3/session.py
+++ b/boto3/session.py
@@ -241,7 +241,7 @@ class Session(object):
             over environment variables and configuration values, but not over
             a region_name value passed explicitly to the method. See
             `botocore config documentation
-            <http://botocore.readthedocs.org/en/latest/reference/config.html>`_
+            <http://botocore.readthedocs.io/en/latest/reference/config.html>`_
             for more details.
 
         :return: Service client instance
@@ -323,7 +323,7 @@ class Session(object):
             user_agent_extra is specified in the client config, it overrides
             the default user_agent_extra provided by the resource API. See
             `botocore config documentation
-            <http://botocore.readthedocs.org/en/latest/reference/config.html>`_
+            <http://botocore.readthedocs.io/en/latest/reference/config.html>`_
             for more details.
 
         :return: Subclass of :py:class:`~boto3.resources.base.ServiceResource`

--- a/docs/source/guide/migration.rst
+++ b/docs/source/guide/migration.rst
@@ -50,7 +50,7 @@ Once configured, you may begin using Boto 3::
     for bucket in boto3.resource('s3').buckets.all():
         print(bucket.name)
 
-See the :ref:`tutorial_list` and `Boto 3 Documentation <http://boto3.readthedocs.org/>`__ for more information.
+See the :ref:`tutorial_list` and `Boto 3 Documentation <http://boto3.readthedocs.io/>`__ for more information.
 
 The rest of this document will describe specific common usage scenarios of Boto 2 code and how to accomplish the same tasks with Boto 3.
 

--- a/docs/source/guide/s3.rst
+++ b/docs/source/guide/s3.rst
@@ -182,5 +182,5 @@ conditions when you generate the POST data.::
 Note: if your bucket is new and you require CORS, it is advised that
 you use path style addressing (which is set by default in signature version 4).
 
-.. _s3 transfer manager: http://boto3.readthedocs.org/en/latest/reference/customizations/s3.html#module-boto3.s3.transfer
+.. _s3 transfer manager: http://boto3.readthedocs.io/en/latest/reference/customizations/s3.html#module-boto3.s3.transfer
 .. _virtual host addressing: http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html


### PR DESCRIPTION
Readthedocs is changing their project domains over to .io for
some security concerns. This replaces all occurences of
`readthedocs.org` with `readthedocs.io`.

cc @kyleknap @jamesls