### PR TITLE
Update s3.rst: Generating Presigned POSTs

### DIFF
--- a/docs/source/guide/s3.rst
+++ b/docs/source/guide/s3.rst
@@ -176,7 +176,9 @@ conditions when you generate the POST data.::
     # Generate the POST attributes
     post = s3.generate_presigned_post(
         Bucket='bucket-name',
-        Key='key-name'
+        Key='key-name',
+        Fields=fields,
+        Conditions=conditions
     )
 
 Note: if your bucket is new and you require CORS, it is advised that


### PR DESCRIPTION
Corrected example code to pass the fields and conditions values into the generate_presigned_post method.