### PR TITLE
Session.__repr__ improvements

### DIFF
--- a/.changes/next-release/bugfix-Session-18701.json
+++ b/.changes/next-release/bugfix-Session-18701.json
@@ -1,0 +1,5 @@
+{
+  "category": "Session",
+  "type": "bugfix",
+  "description": "Fixed Session.__repr__ region argument name."
+}

--- a/boto3/session.py
+++ b/boto3/session.py
@@ -81,7 +81,8 @@ class Session(object):
         self._register_default_handlers()
 
     def __repr__(self):
-        return 'Session(region_name={0})'.format(
+        return '{0}(region_name={1})'.format(
+            self.__class__.__name__,
             repr(self._session.get_config_variable('region')))
 
     @property

--- a/boto3/session.py
+++ b/boto3/session.py
@@ -81,7 +81,7 @@ class Session(object):
         self._register_default_handlers()
 
     def __repr__(self):
-        return 'Session(region={0})'.format(
+        return 'Session(region_name={0})'.format(
             repr(self._session.get_config_variable('region')))
 
     @property

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -29,7 +29,7 @@ class TestSession(BaseTestCase):
 
         session = Session('abc123', region_name='us-west-2')
 
-        self.assertEqual(repr(session), 'Session(region=\'us-west-2\')')
+        self.assertEqual(repr(session), 'Session(region_name=\'us-west-2\')')
 
     def test_can_access_region_name(self):
         bc_session = self.bc_session_cls.return_value

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -31,6 +31,18 @@ class TestSession(BaseTestCase):
 
         self.assertEqual(repr(session), 'Session(region_name=\'us-west-2\')')
 
+    def test_repr_on_subclasses(self):
+        bc_session = self.bc_session_cls.return_value
+        bc_session.get_credentials.return_value.access_key = 'abc123'
+        bc_session.get_config_variable.return_value = 'us-west-2'
+
+        class MySession(Session):
+            pass
+
+        session = MySession('abc123', region_name='us-west-2')
+
+        self.assertEqual(repr(session), 'MySession(region_name=\'us-west-2\')')
+
     def test_can_access_region_name(self):
         bc_session = self.bc_session_cls.return_value
         bc_session.get_config_variable.return_value = 'us-west-2'


### PR DESCRIPTION
This PR adds two small improvements to `Session.__repr__`.

1. Use the proper argument name to set the session region, e.g. `region_name`.
1. Use the class name so subclasses get a proper repr string.

 