### PR TITLE
Port s3transfer to S3Transfer

### DIFF
--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -128,26 +128,12 @@ from s3transfer.exceptions import RetriesExceededError as \
 from s3transfer.manager import TransferConfig as S3TransferConfig
 from s3transfer.manager import TransferManager
 from s3transfer.subscribers import BaseSubscriber
-from s3transfer.utils import OSUtils as S3TransferOSUtils
+from s3transfer.utils import OSUtils
 
 from boto3.exceptions import RetriesExceededError, S3UploadFailedError
 
 
 MB = 1024 * 1024
-
-
-class OSUtils(S3TransferOSUtils):
-    def open_file_chunk_reader(self, filename, start_byte, size, callback):
-        callbacks = None
-        if callback:
-            # We need to wrap the callback in the ProgressCallbackInvoker
-            # because the read callbacks will always be invoked with
-            # the keyword argument ``bytes_transferred`` which would break
-            # if the callback relied on a positional argument of a different
-            # name, which most likely did.
-            callbacks = [ProgressCallbackInvoker(callback).on_progress]
-        return super(OSUtils, self).open_file_chunk_reader(
-            filename, start_byte, size, callbacks)
 
 
 class TransferConfig(S3TransferConfig):

--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -122,499 +122,85 @@ transfer.  For example:
 
 
 """
-import os
-import math
-import functools
-import logging
-import socket
-import threading
-import random
-import string
-import boto3
-from concurrent import futures
+from botocore.exceptions import ClientError
+from s3transfer.exceptions import RetriesExceededError as \
+    S3TransferRetriesExceededError
+from s3transfer.manager import TransferConfig as S3TransferConfig
+from s3transfer.manager import TransferManager
+from s3transfer.subscribers import BaseSubscriber
+from s3transfer.utils import OSUtils as S3TransferOSUtils
 
-from botocore.compat import six
-from botocore.vendored.requests.packages.urllib3.exceptions import \
-    ReadTimeoutError
-from botocore.exceptions import IncompleteReadError
-
-import boto3.compat
 from boto3.exceptions import RetriesExceededError, S3UploadFailedError
 
 
-logger = logging.getLogger(__name__)
-queue = six.moves.queue
-
 MB = 1024 * 1024
-SHUTDOWN_SENTINEL = object()
-S3_RETRYABLE_ERRORS = (
-    socket.timeout, boto3.compat.SOCKET_ERROR,
-    ReadTimeoutError, IncompleteReadError
-)
 
 
-def random_file_extension(num_digits=8):
-    return ''.join(random.choice(string.hexdigits) for _ in range(num_digits))
-
-
-def disable_upload_callbacks(request, operation_name, **kwargs):
-    if operation_name in ['PutObject', 'UploadPart'] and \
-            hasattr(request.body, 'disable_callback'):
-        request.body.disable_callback()
-
-
-def enable_upload_callbacks(request, operation_name, **kwargs):
-    if operation_name in ['PutObject', 'UploadPart'] and \
-            hasattr(request.body, 'enable_callback'):
-        request.body.enable_callback()
-
-
-class QueueShutdownError(Exception):
-    pass
-
-
-class ReadFileChunk(object):
-    def __init__(self, fileobj, start_byte, chunk_size, full_file_size,
-                 callback=None, enable_callback=True):
-        """
-
-        Given a file object shown below::
-
-            |___________________________________________________|
-            0          |                 |                 full_file_size
-                       |----chunk_size---|
-                 start_byte
-
-        :type fileobj: file
-        :param fileobj: File like object
-
-        :type start_byte: int
-        :param start_byte: The first byte from which to start reading.
-
-        :type chunk_size: int
-        :param chunk_size: The max chunk size to read.  Trying to read
-            pass the end of the chunk size will behave like you've
-            reached the end of the file.
-
-        :type full_file_size: int
-        :param full_file_size: The entire content length associated
-            with ``fileobj``.
-
-        :type callback: function(amount_read)
-        :param callback: Called whenever data is read from this object.
-
-        """
-        self._fileobj = fileobj
-        self._start_byte = start_byte
-        self._size = self._calculate_file_size(
-            self._fileobj, requested_size=chunk_size,
-            start_byte=start_byte, actual_file_size=full_file_size)
-        self._fileobj.seek(self._start_byte)
-        self._amount_read = 0
-        self._callback = callback
-        self._callback_enabled = enable_callback
-
-    @classmethod
-    def from_filename(cls, filename, start_byte, chunk_size, callback=None,
-                      enable_callback=True):
-        """Convenience factory function to create from a filename.
-
-        :type start_byte: int
-        :param start_byte: The first byte from which to start reading.
-
-        :type chunk_size: int
-        :param chunk_size: The max chunk size to read.  Trying to read
-            pass the end of the chunk size will behave like you've
-            reached the end of the file.
-
-        :type full_file_size: int
-        :param full_file_size: The entire content length associated
-            with ``fileobj``.
-
-        :type callback: function(amount_read)
-        :param callback: Called whenever data is read from this object.
-
-        :type enable_callback: bool
-        :param enable_callback: Indicate whether to invoke callback
-            during read() calls.
-
-        :rtype: ``ReadFileChunk``
-        :return: A new instance of ``ReadFileChunk``
-
-        """
-        f = open(filename, 'rb')
-        file_size = os.fstat(f.fileno()).st_size
-        return cls(f, start_byte, chunk_size, file_size, callback,
-                   enable_callback)
-
-    def _calculate_file_size(self, fileobj, requested_size, start_byte,
-                             actual_file_size):
-        max_chunk_size = actual_file_size - start_byte
-        return min(max_chunk_size, requested_size)
-
-    def read(self, amount=None):
-        if amount is None:
-            amount_to_read = self._size - self._amount_read
-        else:
-            amount_to_read = min(self._size - self._amount_read, amount)
-        data = self._fileobj.read(amount_to_read)
-        self._amount_read += len(data)
-        if self._callback is not None and self._callback_enabled:
-            self._callback(len(data))
-        return data
-
-    def enable_callback(self):
-        self._callback_enabled = True
-
-    def disable_callback(self):
-        self._callback_enabled = False
-
-    def seek(self, where):
-        self._fileobj.seek(self._start_byte + where)
-        if self._callback is not None and self._callback_enabled:
-            # To also rewind the callback() for an accurate progress report
-            self._callback(where - self._amount_read)
-        self._amount_read = where
-
-    def close(self):
-        self._fileobj.close()
-
-    def tell(self):
-        return self._amount_read
-
-    def __len__(self):
-        # __len__ is defined because requests will try to determine the length
-        # of the stream to set a content length.  In the normal case
-        # of the file it will just stat the file, but we need to change that
-        # behavior.  By providing a __len__, requests will use that instead
-        # of stat'ing the file.
-        return self._size
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args, **kwargs):
-        self.close()
-
-    def __iter__(self):
-        # This is a workaround for http://bugs.python.org/issue17575
-        # Basically httplib will try to iterate over the contents, even
-        # if its a file like object.  This wasn't noticed because we've
-        # already exhausted the stream so iterating over the file immediately
-        # stops, which is what we're simulating here.
-        return iter([])
-
-
-class StreamReaderProgress(object):
-    """Wrapper for a read only stream that adds progress callbacks."""
-    def __init__(self, stream, callback=None):
-        self._stream = stream
-        self._callback = callback
-
-    def read(self, *args, **kwargs):
-        value = self._stream.read(*args, **kwargs)
-        if self._callback is not None:
-            self._callback(len(value))
-        return value
-
-
-class OSUtils(object):
-    def get_file_size(self, filename):
-        return os.path.getsize(filename)
-
+class OSUtils(S3TransferOSUtils):
     def open_file_chunk_reader(self, filename, start_byte, size, callback):
-        return ReadFileChunk.from_filename(filename, start_byte,
-                                           size, callback,
-                                           enable_callback=False)
-
-    def open(self, filename, mode):
-        return open(filename, mode)
-
-    def remove_file(self, filename):
-        """Remove a file, noop if file does not exist."""
-        # Unlike os.remove, if the file does not exist,
-        # then this method does nothing.
-        try:
-            os.remove(filename)
-        except OSError:
-            pass
-
-    def rename_file(self, current_filename, new_filename):
-        boto3.compat.rename_file(current_filename, new_filename)
+        callbacks = None
+        if callback:
+            # We need to wrap the callback in the ProgressCallbackInvoker
+            # because the read callbacks will always be invoked with
+            # the keyword argument ``bytes_transferred`` which would break
+            # if the callback relied on a positional argument of a different
+            # name, which most likely did.
+            callbacks = [ProgressCallbackInvoker(callback).on_progress]
+        return super(OSUtils, self).open_file_chunk_reader(
+            filename, start_byte, size, callbacks)
 
 
-class MultipartUploader(object):
-    # These are the extra_args that need to be forwarded onto
-    # subsequent upload_parts.
-    UPLOAD_PART_ARGS = [
-        'SSECustomerKey',
-        'SSECustomerAlgorithm',
-        'SSECustomerKeyMD5',
-        'RequestPayer',
-    ]
+class TransferConfig(S3TransferConfig):
+    ALIAS = {
+        'max_concurrency': 'max_request_concurrency',
+        'max_io_queue': 'max_io_queue_size'
+    }
 
-    def __init__(self, client, config, osutil,
-                 executor_cls=futures.ThreadPoolExecutor):
-        self._client = client
-        self._config = config
-        self._os = osutil
-        self._executor_cls = executor_cls
-
-    def _extra_upload_part_args(self, extra_args):
-        # Only the args in UPLOAD_PART_ARGS actually need to be passed
-        # onto the upload_part calls.
-        upload_parts_args = {}
-        for key, value in extra_args.items():
-            if key in self.UPLOAD_PART_ARGS:
-                upload_parts_args[key] = value
-        return upload_parts_args
-
-    def upload_file(self, filename, bucket, key, callback, extra_args):
-        response = self._client.create_multipart_upload(Bucket=bucket,
-                                                        Key=key, **extra_args)
-        upload_id = response['UploadId']
-        try:
-            parts = self._upload_parts(upload_id, filename, bucket, key,
-                                       callback, extra_args)
-        except Exception as e:
-            logger.debug("Exception raised while uploading parts, "
-                         "aborting multipart upload.", exc_info=True)
-            self._client.abort_multipart_upload(
-                Bucket=bucket, Key=key, UploadId=upload_id)
-            raise S3UploadFailedError(
-                "Failed to upload %s to %s: %s" % (
-                    filename, '/'.join([bucket, key]), e))
-        self._client.complete_multipart_upload(
-            Bucket=bucket, Key=key, UploadId=upload_id,
-            MultipartUpload={'Parts': parts})
-
-    def _upload_parts(self, upload_id, filename, bucket, key, callback,
-                      extra_args):
-        upload_parts_extra_args = self._extra_upload_part_args(extra_args)
-        parts = []
-        part_size = self._config.multipart_chunksize
-        num_parts = int(
-            math.ceil(self._os.get_file_size(filename) / float(part_size)))
-        max_workers = self._config.max_concurrency
-        with self._executor_cls(max_workers=max_workers) as executor:
-            upload_partial = functools.partial(
-                self._upload_one_part, filename, bucket, key, upload_id,
-                part_size, upload_parts_extra_args, callback)
-            for part in executor.map(upload_partial, range(1, num_parts + 1)):
-                parts.append(part)
-        return parts
-
-    def _upload_one_part(self, filename, bucket, key,
-                         upload_id, part_size, extra_args,
-                         callback, part_number):
-        open_chunk_reader = self._os.open_file_chunk_reader
-        with open_chunk_reader(filename, part_size * (part_number - 1),
-                               part_size, callback) as body:
-            response = self._client.upload_part(
-                Bucket=bucket, Key=key,
-                UploadId=upload_id, PartNumber=part_number, Body=body,
-                **extra_args)
-            etag = response['ETag']
-            return {'ETag': etag, 'PartNumber': part_number}
-
-
-class ShutdownQueue(queue.Queue):
-    """A queue implementation that can be shutdown.
-
-    Shutting down a queue means that this class adds a
-    trigger_shutdown method that will trigger all subsequent
-    calls to put() to fail with a ``QueueShutdownError``.
-
-    It purposefully deviates from queue.Queue, and is *not* meant
-    to be a drop in replacement for ``queue.Queue``.
-
-    """
-    def _init(self, maxsize):
-        self._shutdown = False
-        self._shutdown_lock = threading.Lock()
-        # queue.Queue is an old style class so we don't use super().
-        return queue.Queue._init(self, maxsize)
-
-    def trigger_shutdown(self):
-        with self._shutdown_lock:
-            self._shutdown = True
-            logger.debug("The IO queue is now shutdown.")
-
-    def put(self, item):
-        # Note: this is not sufficient, it's still possible to deadlock!
-        # Need to hook into the condition vars used by this class.
-        with self._shutdown_lock:
-            if self._shutdown:
-                raise QueueShutdownError("Cannot put item to queue when "
-                                         "queue has been shutdown.")
-        return queue.Queue.put(self, item)
-
-
-class MultipartDownloader(object):
-    def __init__(self, client, config, osutil,
-                 executor_cls=futures.ThreadPoolExecutor):
-        self._client = client
-        self._config = config
-        self._os = osutil
-        self._executor_cls = executor_cls
-        self._ioqueue = ShutdownQueue(self._config.max_io_queue)
-
-    def download_file(self, bucket, key, filename, object_size,
-                      extra_args, callback=None):
-        with self._executor_cls(max_workers=2) as controller:
-            # 1 thread for the future that manages the uploading of files
-            # 1 thread for the future that manages IO writes.
-            download_parts_handler = functools.partial(
-                self._download_file_as_future,
-                bucket, key, filename, object_size, extra_args, callback)
-            parts_future = controller.submit(download_parts_handler)
-
-            io_writes_handler = functools.partial(
-                self._perform_io_writes, filename)
-            io_future = controller.submit(io_writes_handler)
-            results = futures.wait([parts_future, io_future],
-                                   return_when=futures.FIRST_EXCEPTION)
-            self._process_future_results(results)
-
-    def _process_future_results(self, futures):
-        finished, unfinished = futures
-        for future in finished:
-            future.result()
-
-    def _download_file_as_future(self, bucket, key, filename, object_size,
-                                 extra_args, callback):
-        part_size = self._config.multipart_chunksize
-        num_parts = int(math.ceil(object_size / float(part_size)))
-        max_workers = self._config.max_concurrency
-        download_partial = functools.partial(
-            self._download_range, bucket, key, filename,
-            part_size, num_parts, extra_args, callback)
-        try:
-            with self._executor_cls(max_workers=max_workers) as executor:
-                list(executor.map(download_partial, range(num_parts)))
-        finally:
-            self._ioqueue.put(SHUTDOWN_SENTINEL)
-
-    def _calculate_range_param(self, part_size, part_index, num_parts):
-        start_range = part_index * part_size
-        if part_index == num_parts - 1:
-            end_range = ''
-        else:
-            end_range = start_range + part_size - 1
-        range_param = 'bytes=%s-%s' % (start_range, end_range)
-        return range_param
-
-    def _download_range(self, bucket, key, filename,
-                        part_size, num_parts,
-                        extra_args, callback, part_index):
-        try:
-            range_param = self._calculate_range_param(
-                part_size, part_index, num_parts)
-
-            max_attempts = self._config.num_download_attempts
-            last_exception = None
-            for i in range(max_attempts):
-                try:
-                    logger.debug("Making get_object call.")
-                    response = self._client.get_object(
-                        Bucket=bucket, Key=key, Range=range_param,
-                        **extra_args)
-                    streaming_body = StreamReaderProgress(
-                        response['Body'], callback)
-                    buffer_size = 1024 * 16
-                    current_index = part_size * part_index
-                    for chunk in iter(lambda: streaming_body.read(buffer_size),
-                                      b''):
-                        self._ioqueue.put((current_index, chunk))
-                        current_index += len(chunk)
-                    return
-                except S3_RETRYABLE_ERRORS as e:
-                    logger.debug("Retrying exception caught (%s), "
-                                 "retrying request, (attempt %s / %s)", e, i,
-                                 max_attempts, exc_info=True)
-                    last_exception = e
-                    continue
-            raise RetriesExceededError(last_exception)
-        finally:
-            logger.debug("EXITING _download_range for part: %s", part_index)
-
-    def _perform_io_writes(self, filename):
-        try:
-            self._loop_on_io_writes(filename)
-        except Exception as e:
-            logger.debug("Caught exception in IO thread: %s",
-                         e, exc_info=True)
-            self._ioqueue.trigger_shutdown()
-            raise
-
-    def _loop_on_io_writes(self, filename):
-        with self._os.open(filename, 'wb') as f:
-            while True:
-                task = self._ioqueue.get()
-                if task is SHUTDOWN_SENTINEL:
-                    logger.debug("Shutdown sentinel received in IO handler, "
-                                 "shutting down IO handler.")
-                    return
-                else:
-                    offset, data = task
-                    f.seek(offset)
-                    f.write(data)
-
-
-class TransferConfig(object):
     def __init__(self,
                  multipart_threshold=8 * MB,
                  max_concurrency=10,
                  multipart_chunksize=8 * MB,
                  num_download_attempts=5,
                  max_io_queue=100):
-        self.multipart_threshold = multipart_threshold
-        self.max_concurrency = max_concurrency
-        self.multipart_chunksize = multipart_chunksize
-        self.num_download_attempts = num_download_attempts
-        self.max_io_queue = max_io_queue
+        super(TransferConfig, self).__init__(
+            multipart_threshold=multipart_threshold,
+            max_request_concurrency=max_concurrency,
+            multipart_chunksize=multipart_chunksize,
+            num_download_attempts=num_download_attempts,
+            max_io_queue_size=max_io_queue
+        )
+        # Some of the argument names are not the same as the inherited
+        # S3TransferConfig so we add aliases so you can still access the
+        # old version of the names.
+        for alias in self.ALIAS:
+            setattr(self, alias, getattr(self, self.ALIAS[alias]))
+
+    def __setattr__(self, name, value):
+        # If the alias name is used, make sure we set the name that it points
+        # to as that is what actually is used in governing the TransferManager.
+        if name in self.ALIAS:
+            super(TransferConfig, self).__setattr__(self.ALIAS[name], value)
+        # Always set the value of the actual name provided.
+        super(TransferConfig, self).__setattr__(name, value)
 
 
 class S3Transfer(object):
-
-    ALLOWED_DOWNLOAD_ARGS = [
-        'VersionId',
-        'SSECustomerAlgorithm',
-        'SSECustomerKey',
-        'SSECustomerKeyMD5',
-        'RequestPayer',
-    ]
-
-    ALLOWED_UPLOAD_ARGS = [
-        'ACL',
-        'CacheControl',
-        'ContentDisposition',
-        'ContentEncoding',
-        'ContentLanguage',
-        'ContentType',
-        'Expires',
-        'GrantFullControl',
-        'GrantRead',
-        'GrantReadACP',
-        'GrantWriteACL',
-        'Metadata',
-        'RequestPayer',
-        'ServerSideEncryption',
-        'StorageClass',
-        'SSECustomerAlgorithm',
-        'SSECustomerKey',
-        'SSECustomerKeyMD5',
-        'SSEKMSKeyId',
-    ]
+    ALLOWED_DOWNLOAD_ARGS = TransferManager.ALLOWED_DOWNLOAD_ARGS
+    ALLOWED_UPLOAD_ARGS = TransferManager.ALLOWED_UPLOAD_ARGS
 
     def __init__(self, client, config=None, osutil=None):
-        self._client = client
         if config is None:
             config = TransferConfig()
-        self._config = config
         if osutil is None:
             osutil = OSUtils()
-        self._osutil = osutil
+        self._manager = TransferManager(client, config, osutil)
+
+    @classmethod
+    def from_transfer_manager(cls, transfer_manager):
+        """Instantiate S3Transfer from s3transfer.TransferManager instance"""
+        cls_instance = super(S3Transfer, cls).__new__(cls)
+        cls_instance._manager = transfer_manager
+        return cls_instance
 
     def upload_file(self, filename, bucket, key,
                     callback=None, extra_args=None):
@@ -623,31 +209,19 @@ class S3Transfer(object):
         Variants have also been injected into S3 client, Bucket and Object.
         You don't have to use S3Transfer.upload_file() directly.
         """
-        if extra_args is None:
-            extra_args = {}
-        self._validate_all_known_args(extra_args, self.ALLOWED_UPLOAD_ARGS)
-        events = self._client.meta.events
-        events.register_first('request-created.s3',
-                              disable_upload_callbacks,
-                              unique_id='s3upload-callback-disable')
-        events.register_last('request-created.s3',
-                             enable_upload_callbacks,
-                             unique_id='s3upload-callback-enable')
-        if self._osutil.get_file_size(filename) >= \
-                self._config.multipart_threshold:
-            self._multipart_upload(filename, bucket, key, callback, extra_args)
-        else:
-            self._put_object(filename, bucket, key, callback, extra_args)
-
-    def _put_object(self, filename, bucket, key, callback, extra_args):
-        # We're using open_file_chunk_reader so we can take advantage of the
-        # progress callback functionality.
-        open_chunk_reader = self._osutil.open_file_chunk_reader
-        with open_chunk_reader(filename, 0,
-                               self._osutil.get_file_size(filename),
-                               callback=callback) as body:
-            self._client.put_object(Bucket=bucket, Key=key, Body=body,
-                                    **extra_args)
+        subscribers = self._get_subscribers(callback)
+        future = self._manager.upload(
+            filename, bucket, key, extra_args, subscribers)
+        try:
+            future.result()
+        # If a client error was raised, add the backwards compatibility layer
+        # that raises a S3UploadFailedError. These specific errors were only
+        # ever thrown for upload_parts but now can be thrown for any related
+        # client error.
+        except ClientError as e:
+            raise S3UploadFailedError(
+                "Failed to upload %s to %s: %s" % (
+                    filename, '/'.join([bucket, key]), e))
 
     def download_file(self, bucket, key, filename, extra_args=None,
                       callback=None):
@@ -656,77 +230,33 @@ class S3Transfer(object):
         Variants have also been injected into S3 client, Bucket and Object.
         You don't have to use S3Transfer.download_file() directly.
         """
-        # This method will issue a ``head_object`` request to determine
-        # the size of the S3 object.  This is used to determine if the
-        # object is downloaded in parallel.
-        if extra_args is None:
-            extra_args = {}
-        self._validate_all_known_args(extra_args, self.ALLOWED_DOWNLOAD_ARGS)
-        object_size = self._object_size(bucket, key, extra_args)
-        temp_filename = filename + os.extsep + random_file_extension()
+        subscribers = self._get_subscribers(callback)
+        future = self._manager.download(
+            bucket, key, filename, extra_args, subscribers)
         try:
-            self._download_file(bucket, key, temp_filename, object_size,
-                                extra_args, callback)
-        except Exception:
-            logger.debug("Exception caught in download_file, removing partial "
-                         "file: %s", temp_filename, exc_info=True)
-            self._osutil.remove_file(temp_filename)
-            raise
-        else:
-            self._osutil.rename_file(temp_filename, filename)
+            future.result()
+        # This is for backwards compatibility where when retries are
+        # exceeded we need to throw the same error from boto3 instead of
+        # s3transfer's built in RetriesExceededError as current users are
+        # catching the boto3 one instead of the s3transfer exception to do
+        # their own retries.
+        except S3TransferRetriesExceededError as e:
+            raise RetriesExceededError(e.last_exception)
 
-    def _download_file(self, bucket, key, filename, object_size,
-                       extra_args, callback):
-        if object_size >= self._config.multipart_threshold:
-            self._ranged_download(bucket, key, filename, object_size,
-                                  extra_args, callback)
-        else:
-            self._get_object(bucket, key, filename, extra_args, callback)
+    def _get_subscribers(self, callback):
+        if not callback:
+            return None
+        return [ProgressCallbackInvoker(callback)]
 
-    def _validate_all_known_args(self, actual, allowed):
-        for kwarg in actual:
-            if kwarg not in allowed:
-                raise ValueError(
-                    "Invalid extra_args key '%s', "
-                    "must be one of: %s" % (
-                        kwarg, ', '.join(allowed)))
 
-    def _ranged_download(self, bucket, key, filename, object_size,
-                         extra_args, callback):
-        downloader = MultipartDownloader(self._client, self._config,
-                                         self._osutil)
-        downloader.download_file(bucket, key, filename, object_size,
-                                 extra_args, callback)
+class ProgressCallbackInvoker(BaseSubscriber):
+    """A back-compat wrapper to invoke a provided callback via a subscriber
 
-    def _get_object(self, bucket, key, filename, extra_args, callback):
-        # precondition: num_download_attempts > 0
-        max_attempts = self._config.num_download_attempts
-        last_exception = None
-        for i in range(max_attempts):
-            try:
-                return self._do_get_object(bucket, key, filename,
-                                           extra_args, callback)
-            except S3_RETRYABLE_ERRORS as e:
-                logger.debug("Retrying exception caught (%s), "
-                             "retrying request, (attempt %s / %s)", e, i,
-                             max_attempts, exc_info=True)
-                last_exception = e
-                continue
-        raise RetriesExceededError(last_exception)
+    :param callback: A callable that takes a single positional argument for
+        how many bytes were transferred.
+    """
+    def __init__(self, callback):
+        self._callback = callback
 
-    def _do_get_object(self, bucket, key, filename, extra_args, callback):
-        response = self._client.get_object(Bucket=bucket, Key=key,
-                                           **extra_args)
-        streaming_body = StreamReaderProgress(
-            response['Body'], callback)
-        with self._osutil.open(filename, 'wb') as f:
-            for chunk in iter(lambda: streaming_body.read(8192), b''):
-                f.write(chunk)
-
-    def _object_size(self, bucket, key, extra_args):
-        return self._client.head_object(
-            Bucket=bucket, Key=key, **extra_args)['ContentLength']
-
-    def _multipart_upload(self, filename, bucket, key, callback, extra_args):
-        uploader = MultipartUploader(self._client, self._config, self._osutil)
-        uploader.upload_file(filename, bucket, key, callback, extra_args)
+    def on_progress(self, bytes_transferred, **kwargs):
+        self._callback(bytes_transferred)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 -e git://github.com/boto/botocore.git@develop#egg=botocore
 -e git://github.com/boto/jmespath.git@develop#egg=jmespath
+-e git://github.com/boto/s3transfer.git@develop#egg=s3transfer
 nose==1.3.3
 mock==1.3.0
 wheel==0.24.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,4 @@ universal = 1
 requires-dist =
 	botocore>=1.4.1,<1.5.0
 	jmespath>=0.7.1,<1.0.0
-	futures>=2.2.0,<4.0.0; python_version=="2.6" or python_version=="2.7"
+        s3transfer==0.0.1

--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,8 @@ VERSION_RE = re.compile(r'''__version__ = ['"]([0-9.]+)['"]''')
 requires = [
     'botocore>=1.4.1,<1.5.0',
     'jmespath>=0.7.1,<1.0.0',
+    's3transfer==0.0.1'
 ]
-
-
-if sys.version_info[0] == 2:
-    # concurrent.futures is only in python3, so for
-    # python2 we need to install the backport.
-    requires.append('futures>=2.2.0,<4.0.0')
 
 
 def get_version():
@@ -48,10 +43,6 @@ setup(
     },
     include_package_data=True,
     install_requires=requires,
-    extras_require={
-        ':python_version=="2.6" or python_version=="2.7"': [
-            'futures>=2.2.0,<4.0.0']
-    },
     license="Apache License 2.0",
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/tests/unit/s3/test_transfer.py
+++ b/tests/unit/s3/test_transfer.py
@@ -10,9 +10,6 @@
 # distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import os
-import tempfile
-import shutil
 from tests import unittest
 
 import mock
@@ -23,32 +20,6 @@ from boto3.exceptions import S3UploadFailedError
 from boto3.s3.transfer import S3Transfer
 from boto3.s3.transfer import OSUtils, TransferConfig, ProgressCallbackInvoker
 from boto3.s3.transfer import ClientError, S3TransferRetriesExceededError
-
-
-class TestOSUtils(unittest.TestCase):
-    def setUp(self):
-        self.tempdir = tempfile.mkdtemp()
-        self.filename = os.path.join(self.tempdir, 'myfile')
-        self.contents = b'my contents'
-        with open(self.filename, 'wb') as f:
-            f.write(self.contents)
-        self.osutil = OSUtils()
-
-    def tearDown(self):
-        shutil.rmtree(self.tempdir)
-
-    def test_open_file_chunk_reader(self):
-        read_chunk = self.osutil.open_file_chunk_reader(
-            self.filename, 0, len(self.contents), None)
-        self.assertEqual(read_chunk.read(), self.contents)
-
-    def test_open_file_chunk_reader_with_callback(self):
-        callback = mock.Mock()
-        read_chunk = self.osutil.open_file_chunk_reader(
-            self.filename, 0, len(self.contents), callback)
-        read_chunk.enable_callback()
-        self.assertEqual(read_chunk.read(), self.contents)
-        callback.assert_called_with(len(self.contents))
 
 
 class TestTransferConfig(unittest.TestCase):

--- a/tests/unit/s3/test_transfer.py
+++ b/tests/unit/s3/test_transfer.py
@@ -72,7 +72,7 @@ class TestS3Transfer(unittest.TestCase):
     def setUp(self):
         self.client = mock.Mock()
         self.manager = mock.Mock(TransferManager(self.client))
-        self.transfer = S3Transfer.from_transfer_manager(self.manager)
+        self.transfer = S3Transfer(manager=self.manager)
         self.callback = mock.Mock()
 
     def assert_callback_wrapped_in_subscriber(self, call_args):
@@ -138,3 +138,19 @@ class TestS3Transfer(unittest.TestCase):
         transfer = S3Transfer(
             client=mock.Mock(), config=TransferConfig(), osutil=OSUtils())
         self.assertIsInstance(transfer, S3Transfer)
+
+    def test_client_or_manager_is_required(self):
+        with self.assertRaises(ValueError):
+            S3Transfer()
+
+    def test_client_and_manager_are_mutually_exclusive(self):
+        with self.assertRaises(ValueError):
+            S3Transfer(self.client, manager=self.manager)
+
+    def test_config_and_manager_are_mutually_exclusive(self):
+        with self.assertRaises(ValueError):
+            S3Transfer(config=mock.Mock(), manager=self.manager)
+
+    def test_osutil_and_manager_are_mutually_exclusive(self):
+        with self.assertRaises(ValueError):
+            S3Transfer(osutil=mock.Mock(), manager=self.manager)

--- a/tests/unit/s3/test_transfer.py
+++ b/tests/unit/s3/test_transfer.py
@@ -13,754 +13,157 @@
 import os
 import tempfile
 import shutil
-import socket
 from tests import unittest
-from contextlib import closing
 
 import mock
-from botocore.stub import Stubber
-from botocore.session import Session
-from botocore.vendored import six
-from concurrent import futures
+from s3transfer.manager import TransferManager
 
 from boto3.exceptions import RetriesExceededError
 from boto3.exceptions import S3UploadFailedError
-from boto3.s3.transfer import ReadFileChunk, StreamReaderProgress
 from boto3.s3.transfer import S3Transfer
-from boto3.s3.transfer import OSUtils, TransferConfig
-from boto3.s3.transfer import MultipartDownloader, MultipartUploader
-from boto3.s3.transfer import ShutdownQueue
-from boto3.s3.transfer import QueueShutdownError
-from boto3.s3.transfer import random_file_extension
-from boto3.s3.transfer import disable_upload_callbacks, enable_upload_callbacks
-
-
-class InMemoryOSLayer(OSUtils):
-    def __init__(self, filemap):
-        self.filemap = filemap
-
-    def get_file_size(self, filename):
-        return len(self.filemap[filename])
-
-    def open_file_chunk_reader(self, filename, start_byte, size, callback):
-        return closing(six.BytesIO(self.filemap[filename]))
-
-    def open(self, filename, mode):
-        if 'wb' in mode:
-            fileobj = six.BytesIO()
-            self.filemap[filename] = fileobj
-            return closing(fileobj)
-        else:
-            return closing(self.filemap[filename])
-
-    def remove_file(self, filename):
-        if filename in self.filemap:
-            del self.filemap[filename]
-
-    def rename_file(self, current_filename, new_filename):
-        if current_filename in self.filemap:
-            self.filemap[new_filename] = self.filemap.pop(
-                current_filename)
-
-
-class SequentialExecutor(object):
-    def __init__(self, max_workers):
-        pass
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args, **kwargs):
-        pass
-
-    # The real map() interface actually takes *args, but we specifically do
-    # _not_ use this interface.
-    def map(self, function, args):
-        results = []
-        for arg in args:
-            results.append(function(arg))
-        return results
-
-    def submit(self, function):
-        future = futures.Future()
-        future.set_result(function())
-        return future
+from boto3.s3.transfer import OSUtils, TransferConfig, ProgressCallbackInvoker
+from boto3.s3.transfer import ClientError, S3TransferRetriesExceededError
 
 
 class TestOSUtils(unittest.TestCase):
     def setUp(self):
         self.tempdir = tempfile.mkdtemp()
+        self.filename = os.path.join(self.tempdir, 'myfile')
+        self.contents = b'my contents'
+        with open(self.filename, 'wb') as f:
+            f.write(self.contents)
+        self.osutil = OSUtils()
 
     def tearDown(self):
         shutil.rmtree(self.tempdir)
-
-    def test_get_file_size(self):
-        with mock.patch('os.path.getsize') as m:
-            OSUtils().get_file_size('myfile')
-            m.assert_called_with('myfile')
 
     def test_open_file_chunk_reader(self):
-        with mock.patch('boto3.s3.transfer.ReadFileChunk') as m:
-            OSUtils().open_file_chunk_reader('myfile', 0, 100, None)
-            m.from_filename.assert_called_with('myfile', 0, 100,
-                                               None, enable_callback=False)
+        read_chunk = self.osutil.open_file_chunk_reader(
+            self.filename, 0, len(self.contents), None)
+        self.assertEqual(read_chunk.read(), self.contents)
 
-    def test_open_file(self):
-        fileobj = OSUtils().open(os.path.join(self.tempdir, 'foo'), 'w')
-        self.assertTrue(hasattr(fileobj, 'write'))
-
-    def test_remove_file_ignores_errors(self):
-        with mock.patch('os.remove') as remove:
-            remove.side_effect = OSError('fake error')
-            OSUtils().remove_file('foo')
-        remove.assert_called_with('foo')
-
-    def test_remove_file_proxies_remove_file(self):
-        with mock.patch('os.remove') as remove:
-            OSUtils().remove_file('foo')
-            remove.assert_called_with('foo')
-
-    def test_rename_file(self):
-        with mock.patch('boto3.compat.rename_file') as rename_file:
-            OSUtils().rename_file('foo', 'newfoo')
-            rename_file.assert_called_with('foo', 'newfoo')
+    def test_open_file_chunk_reader_with_callback(self):
+        callback = mock.Mock()
+        read_chunk = self.osutil.open_file_chunk_reader(
+            self.filename, 0, len(self.contents), callback)
+        read_chunk.enable_callback()
+        self.assertEqual(read_chunk.read(), self.contents)
+        callback.assert_called_with(len(self.contents))
 
 
-class TestReadFileChunk(unittest.TestCase):
-    def setUp(self):
-        self.tempdir = tempfile.mkdtemp()
+class TestTransferConfig(unittest.TestCase):
+    def assert_value_of_actual_and_alias(self, config, actual, alias,
+                                         ref_value):
+        # Ensure that the name set in the underlying TransferConfig (i.e.
+        # the actual) is the correct value.
+        self.assertEqual(getattr(config, actual), ref_value)
+        # Ensure that backcompat name (i.e. the alias) is the correct value.
+        self.assertEqual(getattr(config, alias), ref_value)
 
-    def tearDown(self):
-        shutil.rmtree(self.tempdir)
+    def test_alias_max_concurreny(self):
+        ref_value = 10
+        config = TransferConfig(max_concurrency=ref_value)
+        self.assert_value_of_actual_and_alias(
+            config, 'max_request_concurrency', 'max_concurrency', ref_value)
 
-    def test_read_entire_chunk(self):
-        filename = os.path.join(self.tempdir, 'foo')
-        with open(filename, 'wb') as f:
-            f.write(b'onetwothreefourfivesixseveneightnineten')
-        chunk = ReadFileChunk.from_filename(
-            filename, start_byte=0, chunk_size=3)
-        self.assertEqual(chunk.read(), b'one')
-        self.assertEqual(chunk.read(), b'')
+        # Set a new value using the alias
+        new_value = 15
+        config.max_concurrency = new_value
+        # Make sure it sets the value for both the alias and the actual
+        # value that will be used in the TransferManager
+        self.assert_value_of_actual_and_alias(
+            config, 'max_request_concurrency', 'max_concurrency', new_value)
 
-    def test_read_with_amount_size(self):
-        filename = os.path.join(self.tempdir, 'foo')
-        with open(filename, 'wb') as f:
-            f.write(b'onetwothreefourfivesixseveneightnineten')
-        chunk = ReadFileChunk.from_filename(
-            filename, start_byte=11, chunk_size=4)
-        self.assertEqual(chunk.read(1), b'f')
-        self.assertEqual(chunk.read(1), b'o')
-        self.assertEqual(chunk.read(1), b'u')
-        self.assertEqual(chunk.read(1), b'r')
-        self.assertEqual(chunk.read(1), b'')
+    def test_alias_max_io_queue(self):
+        ref_value = 10
+        config = TransferConfig(max_io_queue=ref_value)
+        self.assert_value_of_actual_and_alias(
+            config, 'max_io_queue_size', 'max_io_queue', ref_value)
 
-    def test_reset_stream_emulation(self):
-        filename = os.path.join(self.tempdir, 'foo')
-        with open(filename, 'wb') as f:
-            f.write(b'onetwothreefourfivesixseveneightnineten')
-        chunk = ReadFileChunk.from_filename(
-            filename, start_byte=11, chunk_size=4)
-        self.assertEqual(chunk.read(), b'four')
-        chunk.seek(0)
-        self.assertEqual(chunk.read(), b'four')
-
-    def test_read_past_end_of_file(self):
-        filename = os.path.join(self.tempdir, 'foo')
-        with open(filename, 'wb') as f:
-            f.write(b'onetwothreefourfivesixseveneightnineten')
-        chunk = ReadFileChunk.from_filename(
-            filename, start_byte=36, chunk_size=100000)
-        self.assertEqual(chunk.read(), b'ten')
-        self.assertEqual(chunk.read(), b'')
-        self.assertEqual(len(chunk), 3)
-
-    def test_tell_and_seek(self):
-        filename = os.path.join(self.tempdir, 'foo')
-        with open(filename, 'wb') as f:
-            f.write(b'onetwothreefourfivesixseveneightnineten')
-        chunk = ReadFileChunk.from_filename(
-            filename, start_byte=36, chunk_size=100000)
-        self.assertEqual(chunk.tell(), 0)
-        self.assertEqual(chunk.read(), b'ten')
-        self.assertEqual(chunk.tell(), 3)
-        chunk.seek(0)
-        self.assertEqual(chunk.tell(), 0)
-
-    def test_file_chunk_supports_context_manager(self):
-        filename = os.path.join(self.tempdir, 'foo')
-        with open(filename, 'wb') as f:
-            f.write(b'abc')
-        with ReadFileChunk.from_filename(filename,
-                                         start_byte=0,
-                                         chunk_size=2) as chunk:
-            val = chunk.read()
-            self.assertEqual(val, b'ab')
-
-    def test_iter_is_always_empty(self):
-        # This tests the workaround for the httplib bug (see
-        # the source for more info).
-        filename = os.path.join(self.tempdir, 'foo')
-        open(filename, 'wb').close()
-        chunk = ReadFileChunk.from_filename(
-            filename, start_byte=0, chunk_size=10)
-        self.assertEqual(list(chunk), [])
+        # Set a new value using the alias
+        new_value = 15
+        config.max_io_queue = new_value
+        # Make sure it sets the value for both the alias and the actual
+        # value that will be used in the TransferManager
+        self.assert_value_of_actual_and_alias(
+            config, 'max_io_queue_size', 'max_io_queue', new_value)
 
 
-class TestReadFileChunkWithCallback(TestReadFileChunk):
-    def setUp(self):
-        super(TestReadFileChunkWithCallback, self).setUp()
-        self.filename = os.path.join(self.tempdir, 'foo')
-        with open(self.filename, 'wb') as f:
-            f.write(b'abc')
-        self.amounts_seen = []
-
-    def callback(self, amount):
-        self.amounts_seen.append(amount)
-
-    def test_callback_is_invoked_on_read(self):
-        chunk = ReadFileChunk.from_filename(
-            self.filename, start_byte=0, chunk_size=3, callback=self.callback)
-        chunk.read(1)
-        chunk.read(1)
-        chunk.read(1)
-        self.assertEqual(self.amounts_seen, [1, 1, 1])
-
-    def test_callback_can_be_disabled(self):
-        chunk = ReadFileChunk.from_filename(
-            self.filename, start_byte=0, chunk_size=3, callback=self.callback)
-        chunk.disable_callback()
-        # Now reading from the ReadFileChunk should not invoke
-        # the callback.
-        chunk.read()
-        self.assertEqual(self.amounts_seen, [])
-
-    def test_callback_will_also_be_triggered_by_seek(self):
-        chunk = ReadFileChunk.from_filename(
-            self.filename, start_byte=0, chunk_size=3, callback=self.callback)
-        chunk.read(2)
-        chunk.seek(0)
-        chunk.read(2)
-        chunk.seek(1)
-        chunk.read(2)
-        self.assertEqual(self.amounts_seen, [2, -2, 2, -1, 2])
-
-
-class TestStreamReaderProgress(unittest.TestCase):
-
-    def test_proxies_to_wrapped_stream(self):
-        original_stream = six.StringIO('foobarbaz')
-        wrapped = StreamReaderProgress(original_stream)
-        self.assertEqual(wrapped.read(), 'foobarbaz')
-
-    def test_callback_invoked(self):
-        amounts_seen = []
-
-        def callback(amount):
-            amounts_seen.append(amount)
-
-        original_stream = six.StringIO('foobarbaz')
-        wrapped = StreamReaderProgress(original_stream, callback)
-        self.assertEqual(wrapped.read(), 'foobarbaz')
-        self.assertEqual(amounts_seen, [9])
-
-
-class TestMultipartUploader(unittest.TestCase):
-    def test_multipart_upload_uses_correct_client_calls(self):
-        client = mock.Mock()
-        uploader = MultipartUploader(
-            client, TransferConfig(),
-            InMemoryOSLayer({'filename': b'foobar'}), SequentialExecutor)
-        client.create_multipart_upload.return_value = {'UploadId': 'upload_id'}
-        client.upload_part.return_value = {'ETag': 'first'}
-
-        uploader.upload_file('filename', 'bucket', 'key', None, {})
-
-        # We need to check both the sequence of calls (create/upload/complete)
-        # as well as the params passed between the calls, including
-        # 1. The upload_id was plumbed through
-        # 2. The collected etags were added to the complete call.
-        client.create_multipart_upload.assert_called_with(
-            Bucket='bucket', Key='key')
-        # Should be two parts.
-        client.upload_part.assert_called_with(
-            Body=mock.ANY, Bucket='bucket',
-            UploadId='upload_id', Key='key', PartNumber=1)
-        client.complete_multipart_upload.assert_called_with(
-            MultipartUpload={'Parts': [{'PartNumber': 1, 'ETag': 'first'}]},
-            Bucket='bucket',
-            UploadId='upload_id',
-            Key='key')
-
-    def test_multipart_upload_injects_proper_kwargs(self):
-        client = mock.Mock()
-        uploader = MultipartUploader(
-            client, TransferConfig(),
-            InMemoryOSLayer({'filename': b'foobar'}), SequentialExecutor)
-        client.create_multipart_upload.return_value = {'UploadId': 'upload_id'}
-        client.upload_part.return_value = {'ETag': 'first'}
-
-        extra_args = {
-            'SSECustomerKey': 'fakekey',
-            'SSECustomerAlgorithm': 'AES256',
-            'StorageClass': 'REDUCED_REDUNDANCY'
-        }
-        uploader.upload_file('filename', 'bucket', 'key', None, extra_args)
-
-        client.create_multipart_upload.assert_called_with(
-            Bucket='bucket', Key='key',
-            # The initial call should inject all the storage class params.
-            SSECustomerKey='fakekey',
-            SSECustomerAlgorithm='AES256',
-            StorageClass='REDUCED_REDUNDANCY')
-        client.upload_part.assert_called_with(
-            Body=mock.ANY, Bucket='bucket',
-            UploadId='upload_id', Key='key', PartNumber=1,
-            # We only have to forward certain **extra_args in subsequent
-            # UploadPart calls.
-            SSECustomerKey='fakekey',
-            SSECustomerAlgorithm='AES256',
-        )
-        client.complete_multipart_upload.assert_called_with(
-            MultipartUpload={'Parts': [{'PartNumber': 1, 'ETag': 'first'}]},
-            Bucket='bucket',
-            UploadId='upload_id',
-            Key='key')
-
-    def test_multipart_upload_is_aborted_on_error(self):
-        # If the create_multipart_upload succeeds and any upload_part
-        # fails, then abort_multipart_upload will be called.
-        client = mock.Mock()
-        uploader = MultipartUploader(
-            client, TransferConfig(),
-            InMemoryOSLayer({'filename': b'foobar'}), SequentialExecutor)
-        client.create_multipart_upload.return_value = {'UploadId': 'upload_id'}
-        client.upload_part.side_effect = Exception(
-            "Some kind of error occurred.")
-
-        with self.assertRaises(S3UploadFailedError):
-            uploader.upload_file('filename', 'bucket', 'key', None, {})
-
-        client.abort_multipart_upload.assert_called_with(
-            Bucket='bucket', Key='key', UploadId='upload_id')
-
-
-class TestMultipartDownloader(unittest.TestCase):
-
-    maxDiff = None
-
-    def test_multipart_download_uses_correct_client_calls(self):
-        client = mock.Mock()
-        response_body = b'foobarbaz'
-        client.get_object.return_value = {'Body': six.BytesIO(response_body)}
-
-        downloader = MultipartDownloader(client, TransferConfig(),
-                                         InMemoryOSLayer({}),
-                                         SequentialExecutor)
-        downloader.download_file('bucket', 'key', 'filename',
-                                 len(response_body), {})
-
-        client.get_object.assert_called_with(
-            Range='bytes=0-',
-            Bucket='bucket',
-            Key='key'
-        )
-
-    def test_multipart_download_with_multiple_parts(self):
-        client = mock.Mock()
-        response_body = b'foobarbaz'
-        client.get_object.return_value = {'Body': six.BytesIO(response_body)}
-        # For testing purposes, we're testing with a multipart threshold
-        # of 4 bytes and a chunksize of 4 bytes.  Given b'foobarbaz',
-        # this should result in 3 calls.  In python slices this would be:
-        # r[0:4], r[4:8], r[8:9].  But the Range param will be slightly
-        # different because they use inclusive ranges.
-        config = TransferConfig(multipart_threshold=4,
-                                multipart_chunksize=4)
-
-        downloader = MultipartDownloader(client, config,
-                                         InMemoryOSLayer({}),
-                                         SequentialExecutor)
-        downloader.download_file('bucket', 'key', 'filename',
-                                 len(response_body), {})
-
-        # We're storing these in **extra because the assertEqual
-        # below is really about verifying we have the correct value
-        # for the Range param.
-        extra = {'Bucket': 'bucket', 'Key': 'key'}
-        self.assertEqual(client.get_object.call_args_list,
-                         # Note these are inclusive ranges.
-                         [mock.call(Range='bytes=0-3', **extra),
-                          mock.call(Range='bytes=4-7', **extra),
-                          mock.call(Range='bytes=8-', **extra)])
-
-    def test_multipart_download_with_multiple_parts_and_extra_args(self):
-        client = Session().create_client('s3')
-        stubber = Stubber(client)
-        response_body = b'foobarbaz'
-        response = {'Body': six.BytesIO(response_body)}
-        expected_params = {
-            'Range': mock.ANY, 'Bucket': mock.ANY, 'Key': mock.ANY,
-            'RequestPayer': 'requester'}
-        stubber.add_response('get_object', response, expected_params)
-        stubber.activate()
-        downloader = MultipartDownloader(
-            client, TransferConfig(), InMemoryOSLayer({}), SequentialExecutor)
-        downloader.download_file(
-            'bucket', 'key', 'filename', len(response_body),
-            {'RequestPayer': 'requester'})
-        stubber.assert_no_pending_responses()
-
-    def test_retry_on_failures_from_stream_reads(self):
-        # If we get an exception during a call to the response body's .read()
-        # method, we should retry the request.
-        client = mock.Mock()
-        response_body = b'foobarbaz'
-        stream_with_errors = mock.Mock()
-        stream_with_errors.read.side_effect = [
-            socket.timeout("fake error"),
-            response_body
-        ]
-        client.get_object.return_value = {'Body': stream_with_errors}
-        config = TransferConfig(multipart_threshold=4,
-                                multipart_chunksize=4)
-
-        downloader = MultipartDownloader(client, config,
-                                         InMemoryOSLayer({}),
-                                         SequentialExecutor)
-        downloader.download_file('bucket', 'key', 'filename',
-                                 len(response_body), {})
-
-        # We're storing these in **extra because the assertEqual
-        # below is really about verifying we have the correct value
-        # for the Range param.
-        extra = {'Bucket': 'bucket', 'Key': 'key'}
-        self.assertEqual(client.get_object.call_args_list,
-                         # The first call to range=0-3 fails because of the
-                         # side_effect above where we make the .read() raise a
-                         # socket.error.
-                         # The second call to range=0-3 then succeeds.
-                         [mock.call(Range='bytes=0-3', **extra),
-                          mock.call(Range='bytes=0-3', **extra),
-                          mock.call(Range='bytes=4-7', **extra),
-                          mock.call(Range='bytes=8-', **extra)])
-
-    def test_exception_raised_on_exceeded_retries(self):
-        client = mock.Mock()
-        response_body = b'foobarbaz'
-        stream_with_errors = mock.Mock()
-        stream_with_errors.read.side_effect = socket.timeout("fake error")
-        client.get_object.return_value = {'Body': stream_with_errors}
-        config = TransferConfig(multipart_threshold=4,
-                                multipart_chunksize=4)
-
-        downloader = MultipartDownloader(client, config,
-                                         InMemoryOSLayer({}),
-                                         SequentialExecutor)
-        with self.assertRaises(RetriesExceededError):
-            downloader.download_file('bucket', 'key', 'filename',
-                                     len(response_body), {})
-
-    def test_io_thread_failure_triggers_shutdown(self):
-        client = mock.Mock()
-        response_body = b'foobarbaz'
-        client.get_object.return_value = {'Body': six.BytesIO(response_body)}
-        os_layer = mock.Mock()
-        mock_fileobj = mock.MagicMock()
-        mock_fileobj.__enter__.return_value = mock_fileobj
-        mock_fileobj.write.side_effect = Exception("fake IO error")
-        os_layer.open.return_value = mock_fileobj
-
-        downloader = MultipartDownloader(client, TransferConfig(),
-                                         os_layer, SequentialExecutor)
-        # We're verifying that the exception raised from the IO future
-        # propogates back up via download_file().
-        with self.assertRaisesRegexp(Exception, "fake IO error"):
-            downloader.download_file('bucket', 'key', 'filename',
-                                     len(response_body), {})
-
-    def test_io_thread_fails_to_open_triggers_shutdown_error(self):
-        client = mock.Mock()
-        client.get_object.return_value = {
-            'Body': six.BytesIO(b'asdf')
-        }
-        os_layer = mock.Mock(spec=OSUtils)
-        os_layer.open.side_effect = IOError("Can't open file")
-        downloader = MultipartDownloader(
-            client, TransferConfig(),
-            os_layer, SequentialExecutor)
-        # We're verifying that the exception raised from the IO future
-        # propogates back up via download_file().
-        with self.assertRaisesRegexp(IOError, "Can't open file"):
-            downloader.download_file('bucket', 'key', 'filename',
-                                     len(b'asdf'), {})
-
-    def test_download_futures_fail_triggers_shutdown(self):
-        class FailedDownloadParts(SequentialExecutor):
-            def __init__(self, max_workers):
-                self.is_first = True
-
-            def submit(self, function):
-                future = super(FailedDownloadParts, self).submit(function)
-                if self.is_first:
-                    # This is the download_parts_thread.
-                    future.set_exception(
-                        Exception("fake download parts error"))
-                    self.is_first = False
-                return future
-
-        client = mock.Mock()
-        response_body = b'foobarbaz'
-        client.get_object.return_value = {'Body': six.BytesIO(response_body)}
-
-        downloader = MultipartDownloader(client, TransferConfig(),
-                                         InMemoryOSLayer({}),
-                                         FailedDownloadParts)
-        with self.assertRaisesRegexp(Exception, "fake download parts error"):
-            downloader.download_file('bucket', 'key', 'filename',
-                                     len(response_body), {})
+class TestProgressCallbackInvoker(unittest.TestCase):
+    def test_on_progress(self):
+        callback = mock.Mock()
+        subscriber = ProgressCallbackInvoker(callback)
+        subscriber.on_progress(bytes_transferred=1)
+        callback.assert_called_with(1)
 
 
 class TestS3Transfer(unittest.TestCase):
     def setUp(self):
         self.client = mock.Mock()
-        self.random_file_patch = mock.patch(
-            'boto3.s3.transfer.random_file_extension')
-        self.random_file = self.random_file_patch.start()
-        self.random_file.return_value = 'RANDOM'
+        self.manager = mock.Mock(TransferManager(self.client))
+        self.transfer = S3Transfer.from_transfer_manager(self.manager)
+        self.callback = mock.Mock()
 
-    def tearDown(self):
-        self.random_file_patch.stop()
+    def assert_callback_wrapped_in_subscriber(self, call_args):
+        subscribers = call_args[0][4]
+        # Make sure only one subscriber was passed in.
+        self.assertEqual(len(subscribers), 1)
+        subscriber = subscribers[0]
+        # Make sure that the subscriber is of the correct type
+        self.assertIsInstance(subscriber, ProgressCallbackInvoker)
+        # Make sure that the on_progress method() calls out to the wrapped
+        # callback by actually invoking it.
+        subscriber.on_progress(bytes_transferred=1)
+        self.callback.assert_called_with(1)
 
-    def test_callback_handlers_register_on_put_item(self):
-        osutil = InMemoryOSLayer({'smallfile': b'foobar'})
-        transfer = S3Transfer(self.client, osutil=osutil)
-        transfer.upload_file('smallfile', 'bucket', 'key')
-        events = self.client.meta.events
-        events.register_first.assert_called_with(
-            'request-created.s3',
-            disable_upload_callbacks,
-            unique_id='s3upload-callback-disable',
-        )
-        events.register_last.assert_called_with(
-            'request-created.s3',
-            enable_upload_callbacks,
-            unique_id='s3upload-callback-enable',
-        )
-
-    def test_upload_below_multipart_threshold_uses_put_object(self):
-        fake_files = {
-            'smallfile': b'foobar',
-        }
-        osutil = InMemoryOSLayer(fake_files)
-        transfer = S3Transfer(self.client, osutil=osutil)
-        transfer.upload_file('smallfile', 'bucket', 'key')
-        self.client.put_object.assert_called_with(
-            Bucket='bucket', Key='key', Body=mock.ANY
-        )
-
-    def test_extra_args_on_uploaded_passed_to_api_call(self):
+    def test_upload_file(self):
         extra_args = {'ACL': 'public-read'}
-        fake_files = {
-            'smallfile': b'hello world'
-        }
-        osutil = InMemoryOSLayer(fake_files)
-        transfer = S3Transfer(self.client, osutil=osutil)
-        transfer.upload_file('smallfile', 'bucket', 'key',
-                             extra_args=extra_args)
-        self.client.put_object.assert_called_with(
-            Bucket='bucket', Key='key', Body=mock.ANY,
-            ACL='public-read'
-        )
+        self.transfer.upload_file('smallfile', 'bucket', 'key',
+                                  extra_args=extra_args)
+        self.manager.upload.assert_called_with(
+            'smallfile', 'bucket', 'key', extra_args, None)
 
-    def test_uses_multipart_upload_when_over_threshold(self):
-        with mock.patch('boto3.s3.transfer.MultipartUploader') as uploader:
-            fake_files = {
-                'smallfile': b'foobar',
-            }
-            osutil = InMemoryOSLayer(fake_files)
-            config = TransferConfig(multipart_threshold=2,
-                                    multipart_chunksize=2)
-            transfer = S3Transfer(self.client, osutil=osutil, config=config)
-            transfer.upload_file('smallfile', 'bucket', 'key')
-
-            uploader.return_value.upload_file.assert_called_with(
-                'smallfile', 'bucket', 'key', None, {})
-
-    def test_uses_multipart_download_when_over_threshold(self):
-        with mock.patch('boto3.s3.transfer.MultipartDownloader') as downloader:
-            osutil = InMemoryOSLayer({})
-            over_multipart_threshold = 100 * 1024 * 1024
-            transfer = S3Transfer(self.client, osutil=osutil)
-            callback = mock.sentinel.CALLBACK
-            self.client.head_object.return_value = {
-                'ContentLength': over_multipart_threshold,
-            }
-            transfer.download_file('bucket', 'key', 'filename',
-                                   callback=callback)
-
-            downloader.return_value.download_file.assert_called_with(
-                # Note how we're downloading to a temorary random file.
-                'bucket', 'key', 'filename.RANDOM', over_multipart_threshold,
-                {}, callback)
-
-    def test_download_file_with_invalid_extra_args(self):
-        below_threshold = 20
-        osutil = InMemoryOSLayer({})
-        transfer = S3Transfer(self.client, osutil=osutil)
-        self.client.head_object.return_value = {
-            'ContentLength': below_threshold}
-        with self.assertRaises(ValueError):
-            transfer.download_file('bucket', 'key', '/tmp/smallfile',
-                                   extra_args={'BadValue': 'foo'})
-
-    def test_upload_file_with_invalid_extra_args(self):
-        osutil = InMemoryOSLayer({})
-        transfer = S3Transfer(self.client, osutil=osutil)
-        bad_args = {"WebsiteRedirectLocation": "/foo"}
-        with self.assertRaises(ValueError):
-            transfer.upload_file('bucket', 'key', '/tmp/smallfile',
-                                 extra_args=bad_args)
-
-    def test_download_file_fowards_extra_args(self):
+    def test_download_file(self):
         extra_args = {
             'SSECustomerKey': 'foo',
             'SSECustomerAlgorithm': 'AES256',
         }
-        below_threshold = 20
-        osutil = InMemoryOSLayer({'smallfile': b'hello world'})
-        transfer = S3Transfer(self.client, osutil=osutil)
-        self.client.head_object.return_value = {
-            'ContentLength': below_threshold}
-        self.client.get_object.return_value = {
-            'Body': six.BytesIO(b'foobar')
-        }
-        transfer.download_file('bucket', 'key', '/tmp/smallfile',
-                               extra_args=extra_args)
+        self.transfer.download_file('bucket', 'key', '/tmp/smallfile',
+                                    extra_args=extra_args)
+        self.manager.download.assert_called_with(
+            'bucket', 'key', '/tmp/smallfile', extra_args, None)
 
-        # Note that we need to invoke the HeadObject call
-        # and the PutObject call with the extra_args.
-        # This is necessary.  Trying to HeadObject an SSE object
-        # will return a 400 if you don't provide the required
-        # params.
-        self.client.get_object.assert_called_with(
-            Bucket='bucket', Key='key', SSECustomerAlgorithm='AES256',
-            SSECustomerKey='foo')
+    def test_upload_wraps_callback(self):
+        self.transfer.upload_file(
+            'smallfile', 'bucket', 'key', callback=self.callback)
+        self.assert_callback_wrapped_in_subscriber(
+            self.manager.upload.call_args)
 
-    def test_get_object_stream_is_retried_and_succeeds(self):
-        below_threshold = 20
-        osutil = InMemoryOSLayer({'smallfile': b'hello world'})
-        transfer = S3Transfer(self.client, osutil=osutil)
-        self.client.head_object.return_value = {
-            'ContentLength': below_threshold}
-        self.client.get_object.side_effect = [
-            # First request fails.
-            socket.timeout("fake error"),
-            # Second succeeds.
-            {'Body': six.BytesIO(b'foobar')}
-        ]
-        transfer.download_file('bucket', 'key', '/tmp/smallfile')
+    def test_download_wraps_callback(self):
+        self.transfer.download_file(
+            'bucket', 'key', '/tmp/smallfile', callback=self.callback)
+        self.assert_callback_wrapped_in_subscriber(
+            self.manager.download.call_args)
 
-        self.assertEqual(self.client.get_object.call_count, 2)
-
-    def test_get_object_stream_uses_all_retries_and_errors_out(self):
-        below_threshold = 20
-        osutil = InMemoryOSLayer({})
-        transfer = S3Transfer(self.client, osutil=osutil)
-        self.client.head_object.return_value = {
-            'ContentLength': below_threshold}
-        # Here we're raising an exception every single time, which
-        # will exhaust our retry count and propogate a
-        # RetriesExceededError.
-        self.client.get_object.side_effect = socket.timeout("fake error")
+    def test_propogation_of_retry_error(self):
+        future = mock.Mock()
+        future.result.side_effect = S3TransferRetriesExceededError(Exception())
+        self.manager.download.return_value = future
         with self.assertRaises(RetriesExceededError):
-            transfer.download_file('bucket', 'key', 'smallfile')
+            self.transfer.download_file('bucket', 'key', '/tmp/smallfile')
 
-        self.assertEqual(self.client.get_object.call_count, 5)
-        # We should have also cleaned up the in progress file
-        # we were downloading to.
-        self.assertEqual(osutil.filemap, {})
-
-    def test_download_below_multipart_threshold(self):
-        below_threshold = 20
-        osutil = InMemoryOSLayer({'smallfile': b'hello world'})
-        transfer = S3Transfer(self.client, osutil=osutil)
-        self.client.head_object.return_value = {
-            'ContentLength': below_threshold}
-        self.client.get_object.return_value = {
-            'Body': six.BytesIO(b'foobar')
-        }
-        transfer.download_file('bucket', 'key', 'smallfile')
-
-        self.client.get_object.assert_called_with(Bucket='bucket', Key='key')
+    def test_propogation_s3_upload_failed_error(self):
+        future = mock.Mock()
+        future.result.side_effect = ClientError({'Error': {}}, 'op_name')
+        self.manager.upload.return_value = future
+        with self.assertRaises(S3UploadFailedError):
+            self.transfer.upload_file('smallfile', 'bucket', 'key')
 
     def test_can_create_with_just_client(self):
         transfer = S3Transfer(client=mock.Mock())
         self.assertIsInstance(transfer, S3Transfer)
 
-
-class TestShutdownQueue(unittest.TestCase):
-    def test_handles_normal_put_get_requests(self):
-        q = ShutdownQueue()
-        q.put('foo')
-        self.assertEqual(q.get(), 'foo')
-
-    def test_put_raises_error_on_shutdown(self):
-        q = ShutdownQueue()
-        q.trigger_shutdown()
-        with self.assertRaises(QueueShutdownError):
-            q.put('foo')
-
-
-class TestRandomFileExtension(unittest.TestCase):
-    def test_has_proper_length(self):
-        self.assertEqual(
-            len(random_file_extension(num_digits=4)), 4)
-
-
-class TestCallbackHandlers(unittest.TestCase):
-    def setUp(self):
-        self.request = mock.Mock()
-
-    def test_disable_request_on_put_object(self):
-        disable_upload_callbacks(self.request,
-                                 'PutObject')
-        self.request.body.disable_callback.assert_called_with()
-
-    def test_disable_request_on_upload_part(self):
-        disable_upload_callbacks(self.request,
-                                 'UploadPart')
-        self.request.body.disable_callback.assert_called_with()
-
-    def test_enable_object_on_put_object(self):
-        enable_upload_callbacks(self.request,
-                                 'PutObject')
-        self.request.body.enable_callback.assert_called_with()
-
-    def test_enable_object_on_upload_part(self):
-        enable_upload_callbacks(self.request,
-                                 'UploadPart')
-        self.request.body.enable_callback.assert_called_with()
-
-    def test_dont_disable_if_missing_interface(self):
-        del self.request.body.disable_callback
-        disable_upload_callbacks(self.request,
-                                 'PutObject')
-        self.assertEqual(self.request.body.method_calls, [])
-
-    def test_dont_enable_if_missing_interface(self):
-        del self.request.body.enable_callback
-        enable_upload_callbacks(self.request,
-                                'PutObject')
-        self.assertEqual(self.request.body.method_calls, [])
-
-    def test_dont_disable_if_wrong_operation(self):
-        disable_upload_callbacks(self.request,
-                                 'OtherOperation')
-        self.assertFalse(
-            self.request.body.disable_callback.called)
-
-    def test_dont_enable_if_wrong_operation(self):
-        enable_upload_callbacks(self.request,
-                                'OtherOperation')
-        self.assertFalse(
-            self.request.body.enable_callback.called)
+    def test_can_create_with_extra_configurations(self):
+        transfer = S3Transfer(
+            client=mock.Mock(), config=TransferConfig(), osutil=OSUtils())
+        self.assertIsInstance(transfer, S3Transfer)


### PR DESCRIPTION
I decided to send this PR to a separate ``port-s3transfer`` branch so we can make all the progress we want and then merge all of the related changes in all at once, without worrying that some changes get staggered between releases as ideally all the changes will be a part of a minor version bump.

For this specific PR, I ripped out all of the underlying logic in ``S3Transfer`` and replaced it with the ``s3transfer.TransferManager`` class.

In porting it over, the main ``S3Transfer`` interface should be completely backwards compatible (i.e. there should not be any runtime breaking errors and core functionality remains in-tact for that class and classes that are used to instantiate that class). However, there may be some backwards incompatibilities in some the gray areas that we did not consider the "public" interface and were just helper classes and functions used by ``S3Transfer``.

Let me list out some of these gray areas:

**Added a back compat layer**
* Able to modify a property on ``TransferConfig`` after it is instantiated to affect behavior in ``S3Transfer``, even if the property was an alias like ``max_io_queue``. (I could see people modifying this in-place for specific transfers without having to create a new S3Transfer)
* Raise ``boto3.exceptions.RetriesExceeded`` exception for exceeded retries on downloads. (It will preserve any retry logic users may have)
* Raise ``boto3.exceptions.S3UploadFailedError`` for ``botocore.exceptions.ClientError`` on uploads. (It will preserve any error logic here as we raised ``S3UploadFailedError`` for failures in upload parts)

**Did not add back compat layer**
* Removed all classes that were internal to S3Transfer and are now used in ``s3transfer``.  The larger internal-ones consisted of:
  * ``ReadFileChunk``
  * ``MultipartUploader``
  * ``MultipartDownloader``
* Leaving only these classes that can still be imported:
  * ``OSUtils``
  * ``TransferConfig``
  * ``S3Transfer``
* If you implemented your own ``OSUtils`` interface there may be instances where because of assumptions made on where a method is called may result on customized functionality not being used. Specifically, ``open_file_chunk_reader()`` is no longer called to open a filename and it now only accepts a list of callbacks instead of a single callback. That method is actually no longer invoked in ``s3transfer``.
* For ``ALLOWED_DOWNLOAD_ARGS`` and ``ALLOWED_UPLOAD_ARGS`` on ``S3Transfer`` if you add or remove arguments **after** instantiation, it will not get picked up in the instantaited ``TransferManager``.

I think that is most of them. Let me know if you find anymore or if you think we should switch any of them.

I am also going to do some testing so stay tuned for number. I just wanted to get the diff out for people to look at as there are quite a few decisions being made.

There are also a few more things that I want to address, but that will come in later pull requests:
* Be more explicit on what is a public interface in the docs
* Decide if we want to allow users to provide file-like objects to ``upload_file`` and ``download_file`` or provide whole new methods and be strict with input validation in terms of allowable file types.

cc @jamesls @JordonPhillips 