### PR TITLE
Add copy transfer method

### DIFF
--- a/.changes/next-release/feature-s3-26638.json
+++ b/.changes/next-release/feature-s3-26638.json
@@ -1,0 +1,5 @@
+{
+  "description": "Add managed copies to S3 client, Bucket, and Object.",
+  "category": "s3",
+  "type": "feature"
+}

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -15,6 +15,7 @@ from tests import unittest
 from botocore.stub import Stubber
 
 import boto3.session
+from boto3.s3.transfer import TransferConfig
 
 
 class TestS3MethodInjection(unittest.TestCase):
@@ -25,6 +26,8 @@ class TestS3MethodInjection(unittest.TestCase):
                         'upload_file was not injected onto S3 client')
         self.assertTrue(hasattr(client, 'download_file'),
                         'download_file was not injected onto S3 client')
+        self.assertTrue(hasattr(client, 'copy'),
+                        'copy was not injected onto S3 client')
 
     def test_bucket_resource_has_load_method(self):
         session = boto3.session.Session(region_name='us-west-2')
@@ -38,6 +41,8 @@ class TestS3MethodInjection(unittest.TestCase):
                         'upload_file was not injected onto S3 bucket')
         self.assertTrue(hasattr(bucket, 'download_file'),
                         'download_file was not injected onto S3 bucket')
+        self.assertTrue(hasattr(bucket, 'copy'),
+                        'copy was not injected onto S3 bucket')
 
     def test_transfer_methods_injected_to_object(self):
         obj = boto3.resource('s3').Object('my_bucket', 'my_key')
@@ -45,6 +50,179 @@ class TestS3MethodInjection(unittest.TestCase):
                         'upload_file was not injected onto S3 object')
         self.assertTrue(hasattr(obj, 'download_file'),
                         'download_file was not injected onto S3 object')
+        self.assertTrue(hasattr(obj, 'copy'),
+                        'copy was not injected onto S3 object')
+
+
+class TestCopy(unittest.TestCase):
+    def setUp(self):
+        self.session = boto3.session.Session(
+            aws_access_key_id='foo', aws_secret_access_key='bar',
+            region_name='us-west-2')
+        self.s3 = self.session.resource('s3')
+        self.stubber = Stubber(self.s3.meta.client)
+        self.copy_source = {'Bucket': 'foo', 'Key': 'bar'}
+        self.bucket = 'mybucket'
+        self.key = 'mykey'
+        self.upload_id = 'uploadid'
+        self.etag = '"example0etag"'
+        self.progress = 0
+        self.progress_times_called = 0
+
+    def stub_single_part_copy(self):
+        self.stub_head()
+        self.stub_copy_object()
+
+    def stub_multipart_copy(self, part_size, num_parts):
+        # Set the HEAD to return the total size
+        total_size = part_size * num_parts
+        self.stub_head(content_length=total_size)
+
+        # Add the response and assert params for CreateMultipartUpload
+        create_upload_response = {
+            "Bucket": self.bucket,
+            "Key": self.key,
+            "UploadId": self.upload_id
+        }
+        expected_params = {
+            "Bucket": self.bucket,
+            "Key": self.key,
+        }
+        self.stubber.add_response(
+            method='create_multipart_upload',
+            service_response=create_upload_response,
+            expected_params=expected_params)
+
+        # Add the responses for each UploadPartCopy
+        parts = []
+        for i in range(num_parts):
+            # Fill in the parts
+            part_number = i + 1
+            copy_range = "bytes=%s-%s" % (
+                i * part_size,
+                i * part_size + (part_size - 1)
+            )
+            self.stub_copy_part(part_number=part_number, copy_range=copy_range)
+            parts.append({'ETag': self.etag, 'PartNumber': part_number})
+
+        # Add the response for completing the upload
+        complete_upload_response = {
+            "Location": "us-west-2",
+            "Bucket": self.bucket,
+            "Key": self.key,
+            "ETag": self.etag
+        }
+        expected_params = {
+            "Bucket": self.bucket,
+            "Key": self.key,
+            "MultipartUpload": {
+                "Parts": parts
+            },
+            "UploadId": self.upload_id
+        }
+
+        self.stubber.add_response(
+            method='complete_multipart_upload',
+            service_response=complete_upload_response,
+            expected_params=expected_params)
+
+    def stub_head(self, content_length=4):
+        head_response = {
+            'AcceptRanges': 'bytes',
+            'ContentLength': content_length,
+            'ContentType': 'binary/octet-stream',
+            'ETag': self.etag,
+            'Metadata': {},
+            'ResponseMetadata': {
+                'HTTPStatusCode': 200,
+            }
+        }
+
+        self.stubber.add_response(
+            method='head_object', service_response=head_response,
+            expected_params=self.copy_source)
+
+    def stub_copy_object(self):
+        copy_response = {
+            'CopyObjectResult': {
+                'ETag': self.etag
+            },
+            'ResponseMetadata': {
+                'HTTPStatusCode': 200
+            }
+        }
+        expected_params = {
+            "Bucket": self.bucket,
+            "Key": self.key,
+            "CopySource": self.copy_source
+        }
+        self.stubber.add_response(
+            method='copy_object', service_response=copy_response,
+            expected_params=expected_params)
+
+    def stub_copy_part(self, part_number, copy_range):
+        copy_part_response = {
+            "CopyPartResult": {
+                "ETag": self.etag
+            },
+            'ResponseMetadata': {
+                'HTTPStatusCode': 200
+            }
+        }
+        expected_params = {
+            "Bucket": self.bucket,
+            "Key": self.key,
+            "CopySource": self.copy_source,
+            "UploadId": self.upload_id,
+            "PartNumber": part_number,
+            "CopySourceRange": copy_range
+        }
+        self.stubber.add_response(
+            method='upload_part_copy', service_response=copy_part_response,
+            expected_params=expected_params)
+
+    def test_client_copy(self):
+        self.stub_single_part_copy()
+        with self.stubber:
+            response = self.s3.meta.client.copy(
+                self.copy_source, self.bucket, self.key)
+        # The response will be none on a successful transfer.
+        self.assertIsNone(response)
+
+    def test_bucket_copy(self):
+        self.stub_single_part_copy()
+        bucket = self.s3.Bucket(self.bucket)
+        with self.stubber:
+            response = bucket.copy(self.copy_source, self.key)
+        # The response will be none on a successful transfer.
+        self.assertIsNone(response)
+
+    def test_object_copy(self):
+        self.stub_single_part_copy()
+        obj = self.s3.Object(self.bucket, self.key)
+        with self.stubber:
+            response = obj.copy(self.copy_source)
+        self.assertIsNone(response)
+
+    def test_copy_progress(self):
+        self.stub_multipart_copy(5, 11)
+        transfer_config = TransferConfig(
+            multipart_chunksize=5, multipart_threshold=1,
+            max_concurrency=1)
+
+        def progress_callback(amount):
+            self.progress += amount
+            self.progress_times_called += 1
+
+        with self.stubber:
+            self.s3.meta.client.copy(
+                Bucket=self.bucket, Key=self.key, CopySource=self.copy_source,
+                Config=transfer_config, Callback=progress_callback)
+
+        # Assert that the progress callback was called the correct number of
+        # times with the correct amounts.
+        self.assertEqual(self.progress_times_called, 11)
+        self.assertEqual(self.progress, 55)
 
 
 class TestS3ObjectSummary(unittest.TestCase):

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -237,7 +237,6 @@ class TestS3Resource(unittest.TestCase):
         self.assertEqual(len(versions), 0)
 
 
-
 class TestS3Transfers(unittest.TestCase):
     """Tests for the high level boto3.s3.transfer module."""
 
@@ -280,6 +279,19 @@ class TestS3Transfers(unittest.TestCase):
         public_read = [g['Grantee'].get('URI', '') for g in grants
                        if g['Permission'] == 'READ']
         self.assertIn('groups/global/AllUsers', public_read[0])
+
+    def test_copy(self):
+        self.client.put_object(
+            Bucket=self.bucket_name, Key='foo', Body='beach')
+        self.addCleanup(self.delete_object, 'foo')
+
+        self.client.copy(
+            CopySource={'Bucket': self.bucket_name, 'Key': 'foo'},
+            Bucket=self.bucket_name, Key='bar'
+        )
+        self.addCleanup(self.delete_object, 'bar')
+
+        self.object_exists('bar')
 
     def test_upload_below_threshold(self):
         config = boto3.s3.transfer.TransferConfig(

--- a/tests/unit/s3/test_inject.py
+++ b/tests/unit/s3/test_inject.py
@@ -81,6 +81,7 @@ class TestBucketTransferMethods(unittest.TestCase):
 
     def setUp(self):
         self.bucket = mock.Mock(name='my_bucket')
+        self.copy_source = {'Bucket': 'foo', 'Key': 'bar'}
 
     def test_upload_file_proxies_to_meta_client(self):
         inject.bucket_upload_file(self.bucket, Filename='foo', Key='key')
@@ -94,11 +95,18 @@ class TestBucketTransferMethods(unittest.TestCase):
             Bucket=self.bucket.name, Key='key', Filename='foo',
             ExtraArgs=None, Callback=None, Config=None)
 
+    def test_copy(self):
+        inject.bucket_copy(self.bucket, self.copy_source, Key='key')
+        self.bucket.meta.client.copy.assert_called_with(
+            CopySource=self.copy_source, Bucket=self.bucket.name, Key='key',
+            ExtraArgs=None, Callback=None, SourceClient=None, Config=None)
+
 
 class TestObjectTransferMethods(unittest.TestCase):
 
     def setUp(self):
         self.obj = mock.Mock(bucket_name='my_bucket', key='my_key')
+        self.copy_source = {'Bucket': 'foo', 'Key': 'bar'}
 
     def test_upload_file_proxies_to_meta_client(self):
         inject.object_upload_file(self.obj, Filename='foo')
@@ -111,6 +119,13 @@ class TestObjectTransferMethods(unittest.TestCase):
         self.obj.meta.client.download_file.assert_called_with(
             Bucket=self.obj.bucket_name, Key=self.obj.key, Filename='foo',
             ExtraArgs=None, Callback=None, Config=None)
+
+    def test_copy(self):
+        inject.object_copy(self.obj, self.copy_source)
+        self.obj.meta.client.copy.assert_called_with(
+            CopySource=self.copy_source, Bucket=self.obj.bucket_name,
+            Key=self.obj.key, ExtraArgs=None, Callback=None,
+            SourceClient=None, Config=None)
 
 
 class TestObejctSummaryLoad(unittest.TestCase):


### PR DESCRIPTION
This adds a copy method to the client, bucket, and object which uses s3transfer to perform the operation.

I feel like there may be some discussion on naming, particularly considering that the `Object` resource already has `copy_from`.

cc @kyleknap @jamesls 