### PR TITLE
Add managed file-like object S3 transfers

### DIFF
--- a/.changes/next-release/feature-s3-39540.json
+++ b/.changes/next-release/feature-s3-39540.json
@@ -1,0 +1,5 @@
+{
+  "description": "Add managed downloads to file-like objects in the S3 client, Bucket, and Object.",
+  "category": "s3",
+  "type": "feature"
+}

--- a/.changes/next-release/feature-s3-53032.json
+++ b/.changes/next-release/feature-s3-53032.json
@@ -1,0 +1,5 @@
+{
+  "description": "Add managed file-like object uploads to S3 client, Bucket, and Object.",
+  "type": "feature",
+  "category": "s3"
+}

--- a/boto3/s3/inject.py
+++ b/boto3/s3/inject.py
@@ -21,6 +21,7 @@ def inject_s3_transfer_methods(class_attributes, **kwargs):
     utils.inject_attribute(class_attributes, 'upload_file', upload_file)
     utils.inject_attribute(class_attributes, 'download_file', download_file)
     utils.inject_attribute(class_attributes, 'copy', copy)
+    utils.inject_attribute(class_attributes, 'upload_fileobj', upload_fileobj)
 
 
 def inject_bucket_methods(class_attributes, **kwargs):
@@ -29,6 +30,8 @@ def inject_bucket_methods(class_attributes, **kwargs):
     utils.inject_attribute(
         class_attributes, 'download_file', bucket_download_file)
     utils.inject_attribute(class_attributes, 'copy', bucket_copy)
+    utils.inject_attribute(
+        class_attributes, 'upload_fileobj', bucket_upload_fileobj)
 
 
 def inject_object_methods(class_attributes, **kwargs):
@@ -36,6 +39,8 @@ def inject_object_methods(class_attributes, **kwargs):
     utils.inject_attribute(
         class_attributes, 'download_file', object_download_file)
     utils.inject_attribute(class_attributes, 'copy', object_copy)
+    utils.inject_attribute(
+        class_attributes, 'upload_fileobj', object_upload_fileobj)
 
 
 def inject_object_summary_methods(class_attributes, **kwargs):
@@ -356,3 +361,142 @@ def object_copy(self, CopySource, ExtraArgs=None, Callback=None,
         CopySource=CopySource, Bucket=self.bucket_name, Key=self.key,
         ExtraArgs=ExtraArgs, Callback=Callback, SourceClient=SourceClient,
         Config=Config)
+
+
+def upload_fileobj(self, Fileobj, Bucket, Key, ExtraArgs=None,
+                   Callback=None, Config=None):
+    """Upload a file-like object to S3.
+
+    The file-like object must be in binary mode.
+
+    This is a managed transfer which will perform a multipart upload in
+    multiple threads if necessary.
+
+    Usage::
+
+        import boto3
+        s3 = boto3.client('s3')
+
+        with open('filename', 'rb') as data:
+            s3.upload_fileobj(data, 'mybucket', 'mykey')
+
+    :type Fileobj: a file-like object
+    :param Fileobj: A file-like object to upload. At a minimum, it must
+        implement the `read` method, and must return bytes.
+
+    :type Bucket: str
+    :param Bucket: The name of the bucket to upload to.
+
+    :type Key: str
+    :param Key: The name of the key to upload to.
+
+    :type ExtraArgs: dict
+    :param ExtraArgs: Extra arguments that may be passed to the
+        client operation.
+
+    :type Callback: method
+    :param Callback: A method which takes a number of bytes transferred to
+        be periodically called during the upload.
+
+    :type Config: boto3.s3.transfer.TransferConfig
+    :param Config: The transfer configuration to be used when performing the
+        upload.
+    """
+    if not hasattr(Fileobj, 'read'):
+        raise ValueError('Fileobj must implement read')
+
+    subscribers = None
+    if Callback is not None:
+        subscribers = [ProgressCallbackInvoker(Callback)]
+
+    config = Config
+    if config is None:
+        config = TransferConfig()
+
+    with TransferManager(self, config) as manager:
+        future = manager.upload(
+            fileobj=Fileobj, bucket=Bucket, key=Key,
+            extra_args=ExtraArgs, subscribers=subscribers)
+        return future.result()
+
+
+def bucket_upload_fileobj(self, Fileobj, Key, ExtraArgs=None,
+                          Callback=None, Config=None):
+    """Upload a file-like object to this bucket.
+
+    The file-like object must be in binary mode.
+
+    This is a managed transfer which will perform a multipart upload in
+    multiple threads if necessary.
+
+    Usage::
+
+        import boto3
+        s3 = boto3.resource('s3')
+        bucket = s3.Bucket('mybucket')
+
+        with open('filename', 'rb') as data:
+            bucket.upload_fileobj(data, 'mykey')
+
+    :type Fileobj: a file-like object
+    :param Fileobj: A file-like object to upload. At a minimum, it must
+        implement the `read` method, and must return bytes.
+
+    :type Key: str
+    :param Key: The name of the key to upload to.
+
+    :type ExtraArgs: dict
+    :param ExtraArgs: Extra arguments that may be passed to the
+        client operation.
+
+    :type Callback: method
+    :param Callback: A method which takes a number of bytes transferred to
+        be periodically called during the upload.
+
+    :type Config: boto3.s3.transfer.TransferConfig
+    :param Config: The transfer configuration to be used when performing the
+        upload.
+    """
+    return self.meta.client.upload_fileobj(
+        Fileobj=Fileobj, Bucket=self.name, Key=Key, ExtraArgs=ExtraArgs,
+        Callback=Callback, Config=Config)
+
+
+def object_upload_fileobj(self, Fileobj, ExtraArgs=None, Callback=None,
+                          Config=None):
+    """Upload a file-like object to this object.
+
+    The file-like object must be in binary mode.
+
+    This is a managed transfer which will perform a multipart upload in
+    multiple threads if necessary.
+
+    Usage::
+
+        import boto3
+        s3 = boto3.resource('s3')
+        bucket = s3.Bucket('mybucket')
+        obj = bucket.Object('mykey')
+
+        with open('filename', 'rb') as data:
+            obj.upload_fileobj(data)
+
+    :type Fileobj: a file-like object
+    :param Fileobj: A file-like object to upload. At a minimum, it must
+        implement the `read` method, and must return bytes.
+
+    :type ExtraArgs: dict
+    :param ExtraArgs: Extra arguments that may be passed to the
+        client operation.
+
+    :type Callback: method
+    :param Callback: A method which takes a number of bytes transferred to
+        be periodically called during the upload.
+
+    :type Config: boto3.s3.transfer.TransferConfig
+    :param Config: The transfer configuration to be used when performing the
+        upload.
+    """
+    return self.meta.client.upload_fileobj(
+        Fileobj=Fileobj, Bucket=self.bucket_name, Key=self.key,
+        ExtraArgs=ExtraArgs, Callback=Callback, Config=Config)

--- a/boto3/s3/inject.py
+++ b/boto3/s3/inject.py
@@ -22,6 +22,8 @@ def inject_s3_transfer_methods(class_attributes, **kwargs):
     utils.inject_attribute(class_attributes, 'download_file', download_file)
     utils.inject_attribute(class_attributes, 'copy', copy)
     utils.inject_attribute(class_attributes, 'upload_fileobj', upload_fileobj)
+    utils.inject_attribute(
+        class_attributes, 'download_fileobj', download_fileobj)
 
 
 def inject_bucket_methods(class_attributes, **kwargs):
@@ -32,6 +34,8 @@ def inject_bucket_methods(class_attributes, **kwargs):
     utils.inject_attribute(class_attributes, 'copy', bucket_copy)
     utils.inject_attribute(
         class_attributes, 'upload_fileobj', bucket_upload_fileobj)
+    utils.inject_attribute(
+        class_attributes, 'download_fileobj', bucket_download_fileobj)
 
 
 def inject_object_methods(class_attributes, **kwargs):
@@ -41,6 +45,8 @@ def inject_object_methods(class_attributes, **kwargs):
     utils.inject_attribute(class_attributes, 'copy', object_copy)
     utils.inject_attribute(
         class_attributes, 'upload_fileobj', object_upload_fileobj)
+    utils.inject_attribute(
+        class_attributes, 'download_fileobj', object_download_fileobj)
 
 
 def inject_object_summary_methods(class_attributes, **kwargs):
@@ -500,3 +506,143 @@ def object_upload_fileobj(self, Fileobj, ExtraArgs=None, Callback=None,
     return self.meta.client.upload_fileobj(
         Fileobj=Fileobj, Bucket=self.bucket_name, Key=self.key,
         ExtraArgs=ExtraArgs, Callback=Callback, Config=Config)
+
+
+def download_fileobj(self, Bucket, Key, Fileobj, ExtraArgs=None,
+                     Callback=None, Config=None):
+    """Download an object from S3 to a file-like object.
+
+    The file-like object must be in binary mode.
+
+    This is a managed transfer which will perform a multipart download in
+    multiple threads if necessary.
+
+    Usage::
+
+        import boto3
+        s3 = boto3.client('s3')
+
+        with open('filename', 'wb') as data:
+            s3.download_fileobj('mybucket', 'mykey', data)
+
+    :type Fileobj: a file-like object
+    :param Fileobj: A file-like object to upload. At a minimum, it must
+        implement the `write` method and must accept bytes.
+
+    :type Bucket: str
+    :param Bucket: The name of the bucket to download from.
+
+    :type Key: str
+    :param Key: The name of the key to download from.
+
+    :type ExtraArgs: dict
+    :param ExtraArgs: Extra arguments that may be passed to the
+        client operation.
+
+    :type Callback: method
+    :param Callback: A method which takes a number of bytes transferred to
+        be periodically called during the download.
+
+    :type Config: boto3.s3.transfer.TransferConfig
+    :param Config: The transfer configuration to be used when performing the
+        download.
+    """
+    if not hasattr(Fileobj, 'write'):
+        raise ValueError('Fileobj must implement write')
+
+    subscribers = None
+    if Callback is not None:
+        subscribers = [ProgressCallbackInvoker(Callback)]
+
+    config = Config
+    if config is None:
+        config = TransferConfig()
+
+    with TransferManager(self, config) as manager:
+        future = manager.download(
+            bucket=Bucket, key=Key, fileobj=Fileobj,
+            extra_args=ExtraArgs, subscribers=subscribers)
+        return future.result()
+
+
+def bucket_download_fileobj(self, Key, Fileobj, ExtraArgs=None,
+                            Callback=None, Config=None):
+    """Download an object from this bucket to a file-like-object.
+
+    The file-like object must be in binary mode.
+
+    This is a managed transfer which will perform a multipart download in
+    multiple threads if necessary.
+
+    Usage::
+
+        import boto3
+        s3 = boto3.client('s3')
+        bucket = s3.Bucket('mybucket')
+
+        with open('filename', 'wb') as data:
+            bucket.download_fileobj('mykey', data)
+
+    :type Fileobj: a file-like object
+    :param Fileobj: A file-like object to upload. At a minimum, it must
+        implement the `write` method and must accept bytes.
+
+    :type Key: str
+    :param Key: The name of the key to download from.
+
+    :type ExtraArgs: dict
+    :param ExtraArgs: Extra arguments that may be passed to the
+        client operation.
+
+    :type Callback: method
+    :param Callback: A method which takes a number of bytes transferred to
+        be periodically called during the download.
+
+    :type Config: boto3.s3.transfer.TransferConfig
+    :param Config: The transfer configuration to be used when performing the
+        download.
+    """
+    return self.meta.client.download_fileobj(
+        Bucket=self.name, Key=Key, Fileobj=Fileobj, ExtraArgs=ExtraArgs,
+        Callback=Callback, Config=Config)
+
+
+def object_download_fileobj(self, Fileobj, ExtraArgs=None, Callback=None,
+                            Config=None):
+    """Download this object from S3 to a file-like object.
+
+    The file-like object must be in binary mode.
+
+    This is a managed transfer which will perform a multipart download in
+    multiple threads if necessary.
+
+    Usage::
+
+        import boto3
+        s3 = boto3.client('s3')
+        bucket = s3.Bucket('mybucket')
+        obj = bucket.Object('mykey')
+
+        with open('filename', 'wb') as data:
+            obj.download_fileobj(data)
+
+    :type Fileobj: a file-like object
+    :param Fileobj: A file-like object to upload. At a minimum, it must
+        implement the `write` method and must accept bytes.
+
+    :type ExtraArgs: dict
+    :param ExtraArgs: Extra arguments that may be passed to the
+        client operation.
+
+    :type Callback: method
+    :param Callback: A method which takes a number of bytes transferred to
+        be periodically called during the download.
+
+    :type Config: boto3.s3.transfer.TransferConfig
+    :param Config: The transfer configuration to be used when performing the
+        download.
+    """
+    return self.meta.client.download_fileobj(
+        Bucket=self.bucket_name, Key=self.key, Fileobj=Fileobj,
+        ExtraArgs=ExtraArgs, Callback=Callback, Config=Config)
+

--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -123,6 +123,7 @@ transfer.  For example:
 
 """
 from botocore.exceptions import ClientError
+from botocore.compat import six
 from s3transfer.exceptions import RetriesExceededError as \
     S3TransferRetriesExceededError
 from s3transfer.manager import TransferConfig as S3TransferConfig
@@ -201,6 +202,9 @@ class S3Transfer(object):
         Variants have also been injected into S3 client, Bucket and Object.
         You don't have to use S3Transfer.upload_file() directly.
         """
+        if not isinstance(filename, six.string_types):
+            raise ValueError('Filename must be a string')
+
         subscribers = self._get_subscribers(callback)
         future = self._manager.upload(
             filename, bucket, key, extra_args, subscribers)
@@ -222,6 +226,9 @@ class S3Transfer(object):
         Variants have also been injected into S3 client, Bucket and Object.
         You don't have to use S3Transfer.download_file() directly.
         """
+        if not isinstance(filename, six.string_types):
+            raise ValueError('Filename must be a string')
+
         subscribers = self._get_subscribers(callback)
         future = self._manager.download(
             bucket, key, filename, extra_args, subscribers)

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -252,6 +252,7 @@ class TestS3Transfers(unittest.TestCase):
 
     def setUp(self):
         self.files = FileCreator()
+        self.progress = 0
 
     def tearDown(self):
         self.files.remove_all()
@@ -323,6 +324,17 @@ class TestS3Transfers(unittest.TestCase):
 
         self.object_exists('foo')
         self.assertEqual(self.progress, chunksize * 3)
+
+    def test_download_fileobj(self):
+        fileobj = six.BytesIO()
+        self.client.put_object(
+            Bucket=self.bucket_name, Key='foo', Body=b'beach')
+        self.addCleanup(self.delete_object, 'foo')
+
+        self.client.download_fileobj(
+            Bucket=self.bucket_name, Key='foo', Fileobj=fileobj)
+
+        self.assertEqual(fileobj.getvalue(), b'beach')
 
     def test_upload_below_threshold(self):
         config = boto3.s3.transfer.TransferConfig(

--- a/tests/unit/s3/test_inject.py
+++ b/tests/unit/s3/test_inject.py
@@ -109,6 +109,13 @@ class TestBucketTransferMethods(unittest.TestCase):
             Bucket=self.bucket.name, Fileobj=fileobj, Key='key',
             ExtraArgs=None, Callback=None, Config=None)
 
+    def test_download_fileobj(self):
+        obj = six.BytesIO()
+        inject.bucket_download_fileobj(self.bucket, Key='key', Fileobj=obj)
+        self.bucket.meta.client.download_fileobj.assert_called_with(
+            Bucket=self.bucket.name, Key='key', Fileobj=obj, ExtraArgs=None,
+            Callback=None, Config=None)
+
 
 class TestObjectTransferMethods(unittest.TestCase):
 
@@ -140,6 +147,13 @@ class TestObjectTransferMethods(unittest.TestCase):
         inject.object_upload_fileobj(self.obj, Fileobj=fileobj)
         self.obj.meta.client.upload_fileobj.assert_called_with(
             Bucket=self.obj.bucket_name, Fileobj=fileobj, Key=self.obj.key,
+            ExtraArgs=None, Callback=None, Config=None)
+
+    def test_download_fileobj(self):
+        fileobj = six.BytesIO()
+        inject.object_download_fileobj(self.obj, Fileobj=fileobj)
+        self.obj.meta.client.download_fileobj.assert_called_with(
+            Bucket=self.obj.bucket_name, Key=self.obj.key, Fileobj=fileobj,
             ExtraArgs=None, Callback=None, Config=None)
 
 

--- a/tests/unit/s3/test_inject.py
+++ b/tests/unit/s3/test_inject.py
@@ -10,12 +10,13 @@
 # distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from tests import unittest
 import mock
 
 from botocore.exceptions import ClientError
+from botocore.compat import six
 
 from boto3.s3 import inject
+from tests import unittest
 
 
 class TestInjectTransferMethods(unittest.TestCase):
@@ -101,6 +102,13 @@ class TestBucketTransferMethods(unittest.TestCase):
             CopySource=self.copy_source, Bucket=self.bucket.name, Key='key',
             ExtraArgs=None, Callback=None, SourceClient=None, Config=None)
 
+    def test_upload_fileobj(self):
+        fileobj = six.BytesIO(b'foo')
+        inject.bucket_upload_fileobj(self.bucket, Key='key', Fileobj=fileobj)
+        self.bucket.meta.client.upload_fileobj.assert_called_with(
+            Bucket=self.bucket.name, Fileobj=fileobj, Key='key',
+            ExtraArgs=None, Callback=None, Config=None)
+
 
 class TestObjectTransferMethods(unittest.TestCase):
 
@@ -126,6 +134,13 @@ class TestObjectTransferMethods(unittest.TestCase):
             CopySource=self.copy_source, Bucket=self.obj.bucket_name,
             Key=self.obj.key, ExtraArgs=None, Callback=None,
             SourceClient=None, Config=None)
+
+    def test_upload_fileobj(self):
+        fileobj = six.BytesIO(b'foo')
+        inject.object_upload_fileobj(self.obj, Fileobj=fileobj)
+        self.obj.meta.client.upload_fileobj.assert_called_with(
+            Bucket=self.obj.bucket_name, Fileobj=fileobj, Key=self.obj.key,
+            ExtraArgs=None, Callback=None, Config=None)
 
 
 class TestObejctSummaryLoad(unittest.TestCase):

--- a/tests/unit/s3/test_transfer.py
+++ b/tests/unit/s3/test_transfer.py
@@ -154,3 +154,13 @@ class TestS3Transfer(unittest.TestCase):
     def test_osutil_and_manager_are_mutually_exclusive(self):
         with self.assertRaises(ValueError):
             S3Transfer(osutil=mock.Mock(), manager=self.manager)
+
+    def test_upload_requires_string_filename(self):
+        transfer = S3Transfer(client=mock.Mock())
+        with self.assertRaises(ValueError):
+            transfer.upload_file(filename=object(), bucket='foo', key='bar')
+
+    def test_download_requires_string_filename(self):
+        transfer = S3Transfer(client=mock.Mock())
+        with self.assertRaises(ValueError):
+            transfer.download_file(bucket='foo', key='bar', filename=object())


### PR DESCRIPTION
This adds transfer methods for both uploading from and downloading to file-like objects.

cc @kyleknap @jamesls