### PR TITLE
Expose io chunksize in TransferConfig

### DIFF
--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -133,7 +133,8 @@ from s3transfer.utils import OSUtils
 from boto3.exceptions import RetriesExceededError, S3UploadFailedError
 
 
-MB = 1024 * 1024
+KB = 1024
+MB = KB * KB
 
 
 class TransferConfig(S3TransferConfig):
@@ -147,13 +148,15 @@ class TransferConfig(S3TransferConfig):
                  max_concurrency=10,
                  multipart_chunksize=8 * MB,
                  num_download_attempts=5,
-                 max_io_queue=100):
+                 max_io_queue=100,
+                 io_chunksize=64 * KB):
         super(TransferConfig, self).__init__(
             multipart_threshold=multipart_threshold,
             max_request_concurrency=max_concurrency,
             multipart_chunksize=multipart_chunksize,
             num_download_attempts=num_download_attempts,
-            max_io_queue_size=max_io_queue
+            max_io_queue_size=max_io_queue,
+            io_chunksize=io_chunksize,
         )
         # Some of the argument names are not the same as the inherited
         # S3TransferConfig so we add aliases so you can still access the


### PR DESCRIPTION
This is very important for environments that have very fast bandwidth and slow disk writes because if the io chunksize is too small it starts to become the bottleneck when downloading files as there is only one thread processing these io writes.

So the main reason that I want to expose this is because of this issue: https://github.com/boto/boto3/issues/691

I was doing testing on an EC2 instance with relatively high bandwidth (i.e. hits this scenario) and I found that with the default settings of ``s3transfer`` integrated into boto3, boto3 is as fast as the version of boto3 not integrated with s3transfer but is roughly 50% slower than the CLI when dealing with relatively large files (e.g. size > 100MB). Changing the ``io_chunksize`` value to 1 MB which is the size that the CLI uses results in the same speed as the CLI, which is great.

You may wonder why not set the default to 1MB but that is not ideal because:

1) Optimizes for the scenario of very fast bandwidth, which is not necessarily ideal for slower bandwidth or is memory sensitive.
2) It destroys the grainularity of the progress callbacks.

So for these reasons, I am suggesting that we expose this configuration option for users to optimize for their environment instead, and hopefully gives some documentation on how you should look into tweaking your configurations.

Let me know what you think.

cc @jamesls @JordonPhillips 