### PR TITLE
S3 Documentation Update

### DIFF
--- a/docs/source/guide/s3.rst
+++ b/docs/source/guide/s3.rst
@@ -79,7 +79,7 @@ interfaces of ``boto3``:
 
    Even though there is an ``upload_file`` and ``upload_fileobj`` method for
    a variety of classes, they all share the exact same functionality.
-   Other than conveniency, there are no benefits from using one method from
+   Other than for convenience, there are no benefits from using one method from
    one class over using the same method for a different class.
 
 
@@ -129,8 +129,11 @@ All valid ``ExtraArgs`` are listed at :py:attr:`boto3.s3.transfer.S3Transfer.ALL
 To track the progess of a transfer, a progress callback can be provided such
 that the callback gets invoked each time progress is made on the transfer::
 
-    import boto3
+    import os
+    import sys
+    import threading
 
+    import boto3
 
     class ProgressPercentage(object):
         def __init__(self, filename):

--- a/docs/source/guide/s3.rst
+++ b/docs/source/guide/s3.rst
@@ -37,45 +37,142 @@ config parameter when you create your client or resource.::
 Using the Transfer Manager
 --------------------------
 
-The `s3 transfer manager`_ provides you with less painful multipart uploads and
-downloads. Its functions are automatically added into the client when you create
-it, so there is no need to create your own transfer manager. Below you will see
-several examples of how to use it.
+``boto3`` provides interfaces for managing various types of transfers with
+S3. Functionality includes:
 
-The methods on the base client are :py:meth:`S3.Client.upload_file` and
-:py:meth:`S3.Client.download_file`::
+* Automatically managing multipart and non-multipart uploads
+* Automatically managing multipart and non-multipart downloads
+* Automatically managing multipart and non-multipart copies
+* Uploading from:
+
+  * a file name
+  * a readable file-like object
+
+* Downloading to:
+
+  * a file name
+  * a writeable file-like object
+
+* Tracking progress of individual transfers
+* Managing retries of transfers
+* Configuring various transfer settings such as:
+
+  * Max request concurrency
+  * Multipart transfer thresholds
+  * Multipart transfer part sizes
+  * Number of download retry attempts
+
+
+Uploads
+~~~~~~~
+The managed upload methods are exposed in both the client and resource
+interfaces of ``boto3``:
+
+* :py:class:`S3.Client` method to upload a file by name: :py:meth:`S3.Client.upload_file`
+* :py:class:`S3.Client` method to upload a readable file-like object: :py:meth:`S3.Client.upload_fileobj`
+* :py:class:`S3.Bucket` method to upload a file by name: :py:meth:`S3.Bucket.upload_file`
+* :py:class:`S3.Bucket` method to upload a readable file-like object: :py:meth:`S3.Bucket.upload_fileobj`
+* :py:class:`S3.Object` method to upload a file by name: :py:meth:`S3.Object.upload_file`
+* :py:class:`S3.Object` method to upload a readable file-like object: :py:meth:`S3.Object.upload_fileobj`
+
+.. note::
+
+   Even though there is an ``upload_file`` and ``upload_fileobj`` method for
+   a variety of classes, they all share the exact same functionality.
+   Other than conveniency, there are no benefits from using one method from
+   one class over using the same method for a different class.
+
+
+To upload a file by name, use one of the ``upload_file`` methods::
 
     import boto3
 
     # Get the service client
     s3 = boto3.client('s3')
 
-    # Upload tmp.txt to bucket-name
-    s3.upload_file("tmp.txt", "bucket-name", "tmp.txt")
+    # Upload tmp.txt to bucket-name at key-name
+    s3.upload_file("tmp.txt", "bucket-name", "key-name")
 
-    # Download tmp.txt as tmp2.txt
-    s3.download_file("bucket-name", "tmp.txt", "tmp2.txt")
 
-If you happen to be using the resource model, the same function are accessed
-through :py:meth:`S3.Object.upload_file` and
-:py:meth:`S3.Object.download_file`::
+To upload a readable file-like object, use one of the ``upload_fileobj``
+methods. Note that this file-like object **must** produce binary when read
+from, **not** text::
 
     import boto3
 
-    # Get the service resource
-    s3 = boto3.resource('s3')
+    # Get the service client
+    s3 = boto3.client('s3')
 
-    # Get bucket-name
-    bucket = s3.Bucket('bucket-name')
+    # Upload a file-like object to bucket-name at key-name
+    with open("tmp.txt", "rb") as f:
+        s3.upload_fileobj(f, "bucket-name", "key-name")
 
-    # Get the object representation
-    obj = bucket.Object('tmp.txt')
 
-    # Upload tmp.txt
-    obj.upload_file('tmp.txt')
+To upload a file using any extra parameters such as user metadata, use the
+``ExtraArgs`` parameter::
 
-    # Download tmp.txt as tmp2.txt
-    obj.download_file('tmp2.txt')
+
+    import boto3
+
+    # Get the service client
+    s3 = boto3.client('s3')
+
+    # Upload tmp.txt to bucket-name at key-name
+    s3.upload_file(
+        "tmp.txt", "bucket-name", "key-name",
+        ExtraArgs={"Metadata": {"mykey": "myvalue"}}
+    )
+
+
+All valid ``ExtraArgs`` are listed at :py:attr:`boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS`
+
+To track the progess of a transfer, a progress callback can be provided such
+that the callback gets invoked each time progress is made on the transfer::
+
+    import boto3
+
+
+    class ProgressPercentage(object):
+        def __init__(self, filename):
+            self._filename = filename
+            self._size = float(os.path.getsize(filename))
+            self._seen_so_far = 0
+            self._lock = threading.Lock()
+        def __call__(self, bytes_amount):
+            # To simplify we'll assume this is hooked up
+            # to a single filename.
+            with self._lock:
+                self._seen_so_far += bytes_amount
+                percentage = (self._seen_so_far / self._size) * 100
+                sys.stdout.write(
+                    "\r%s  %s / %s  (%.2f%%)" % (
+                        self._filename, self._seen_so_far, self._size,
+                        percentage))
+                sys.stdout.flush()
+
+
+    # Get the service client
+    s3 = boto3.client('s3')
+
+    # Upload tmp.txt to bucket-name at key-name
+    s3.upload_file(
+        "tmp.txt", "bucket-name", "key-name",
+        Callback=ProgressPercentage("tmp.txt"))
+
+
+Downloads
+~~~~~~~~~
+TODO
+
+
+Copies
+~~~~~~
+TODO
+
+
+Configuration Settings
+~~~~~~~~~~~~~~~~~~~~~~
+TODO
 
 
 Generating Presigned URLs
@@ -184,5 +281,4 @@ conditions when you generate the POST data.::
 Note: if your bucket is new and you require CORS, it is advised that
 you use path style addressing (which is set by default in signature version 4).
 
-.. _s3 transfer manager: https://boto3.readthedocs.io/en/latest/reference/customizations/s3.html#module-boto3.s3.transfer
 .. _virtual host addressing: http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html

--- a/docs/source/reference/customizations/s3.rst
+++ b/docs/source/reference/customizations/s3.rst
@@ -4,17 +4,22 @@
 S3 Customization Reference
 ==========================
 
-S3 Command Injection
---------------------
-
-.. automodule:: boto3.s3.inject
-   :members:
-   :undoc-members:
-   :inherited-members:
-
 S3 Transfers
 ------------
 
-.. automodule:: boto3.s3.transfer
+.. note::
+
+   All classes documented below are considered public and thus will not be
+   exposed to breaking changes. If a class from the ``boto3.s3.transfer``
+   module is not documented below, it is considered internal and users
+   should be very cautious in directly using them because breaking changes may
+   be introduced from version to version of the library.
+
+
+.. autoclass:: boto3.s3.transfer.TransferConfig
+   :members:
+   :undoc-members:
+
+.. autoclass:: boto3.s3.transfer.S3Transfer
    :members:
    :undoc-members:


### PR DESCRIPTION
With all of the changes we are making to the boto3's s3 functionality, I thought it would be good to better document the functionality. This is not all of the documentation updates that I am looking to do, but I figured that where I am at right now is a good review point.

What this PR adds:
* Remove the autodoc of the module and be explicit on what is public.
* Layout a structure for updating the S3 user guide
* Fill out the upload section (I can see the download and copy sections following the same pattern as the upload)

What I still need to do:
* Fill out all sections decided upon based on feedback from this PR.

cc @jamesls @JordonPhillips 