### PR TITLE
log only when actually skipping request

### DIFF
--- a/boto3/dynamodb/table.py
+++ b/boto3/dynamodb/table.py
@@ -108,8 +108,6 @@ class BatchWriter(object):
     def _add_request_and_process(self, request):
         if self._overwrite_by_pkeys:
             self._remove_dup_pkeys_request_if_any(request)
-            logger.debug("With overwrite_by_pkeys enabled, skipping "
-                         "request:%s", request)
         self._items_buffer.append(request)
         self._flush_if_needed()
 
@@ -118,6 +116,8 @@ class BatchWriter(object):
         for item in self._items_buffer:
             if self._extract_pkey_values(item) == pkey_values_new:
                 self._items_buffer.remove(item)
+                logger.debug("With overwrite_by_pkeys enabled, skipping "
+                             "request:%s", item)
 
     def _extract_pkey_values(self, request):
         if request.get('PutRequest'):


### PR DESCRIPTION
Log the exact skipped request.

Example (http://boto3.readthedocs.io/en/latest/guide/dynamodb.html#batch-writing) output:
actual:
```
2016-07-22 20:34:19,901 boto3.dynamodb.table [DEBUG] With overwrite_by_pkeys enabled, skipping request:{'PutRequest': {'Item': {'sort_key': 's1', 'partition_key': 'p1', 'other': '111'}}}
2016-07-22 20:34:19,901 boto3.dynamodb.table [DEBUG] With overwrite_by_pkeys enabled, skipping request:{'PutRequest': {'Item': {'sort_key': 's1', 'partition_key': 'p1', 'other': '222'}}}
2016-07-22 20:34:19,901 boto3.dynamodb.table [DEBUG] With overwrite_by_pkeys enabled, skipping request:{'DeleteRequest': {'Key': {'sort_key': 's2', 'partition_key': 'p1'}}}
2016-07-22 20:34:19,902 boto3.dynamodb.table [DEBUG] With overwrite_by_pkeys enabled, skipping request:{'PutRequest': {'Item': {'sort_key': 's2', 'partition_key': 'p1', 'other': '444'}}}
```
expected:
```
2016-07-22 20:35:35,030 boto3.dynamodb.table [DEBUG] With overwrite_by_pkeys enabled, skipping request:{'PutRequest': {'Item': {'sort_key': 's1', 'partition_key': 'p1', 'other': '111'}}}
2016-07-22 20:35:35,030 boto3.dynamodb.table [DEBUG] With overwrite_by_pkeys enabled, skipping request:{'DeleteRequest': {'Key': {'sort_key': 's2', 'partition_key': 'p1'}}}
```