### PR TITLE
Fill out rest of s3 documentation

### DIFF
--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -151,6 +151,36 @@ class TransferConfig(S3TransferConfig):
                  num_download_attempts=5,
                  max_io_queue=100,
                  io_chunksize=64 * KB):
+        """Configuration object for managed S3 transfers
+
+        :param multipart_threshold: The transfer size threshold for which
+            multipart uploads, downloads, and copies will automatically be
+            triggered.
+
+        :param max_concurrency: The maximum number of threads that will be
+            making requests to perform a transfer.
+
+        :param multipart_chunksize: The partition size of each part for a
+            multipart transfer.
+
+        :param num_download_attempts: The number of download attempts that
+            will be retried upon errors with downloading an object in S3.
+            Note that these retries account for errors that occur when
+            streaming  down the data from s3 (i.e. socket errors and read
+            timeouts that occur after recieving an OK response from s3).
+            Other retryable exceptions such as throttling errors and 5xx
+            errors are already retried by botocore (this default is 5). This
+            does not take into account the number of exceptions retried by
+            botocore.
+
+        :param max_io_queue: The maximum amount of read parts that can be
+            queued in memory to be written for a download. The size of each
+            of these read parts is at most the size of ``io_chunksize``.
+
+        :param io_chunksize: The max size of each chunk in the io queue.
+            Currently, this is size used when ``read`` is called on the
+            downloaded stream as well.
+        """
         super(TransferConfig, self).__init__(
             multipart_threshold=multipart_threshold,
             max_request_concurrency=max_concurrency,

--- a/docs/source/guide/s3.rst
+++ b/docs/source/guide/s3.rst
@@ -230,12 +230,14 @@ All valid ``ExtraArgs`` are listed at :py:attr:`boto3.s3.transfer.S3Transfer.ALL
 To track the progess of a transfer, a progress callback can be provided such
 that the callback gets invoked each time progress is made on the transfer::
 
+    import sys
+    import threading
+
     import boto3
 
     class ProgressPercentage(object):
         def __init__(self, filename):
             self._filename = filename
-            self._size = float(os.path.getsize(filename))
             self._seen_so_far = 0
             self._lock = threading.Lock()
         def __call__(self, bytes_amount):
@@ -243,13 +245,10 @@ that the callback gets invoked each time progress is made on the transfer::
             # to a single filename.
             with self._lock:
                 self._seen_so_far += bytes_amount
-                percentage = (self._seen_so_far / self._size) * 100
                 sys.stdout.write(
-                    "\r%s  %s / %s  (%.2f%%)" % (
-                        self._filename, self._seen_so_far, self._size,
-                        percentage))
+                    "\r%s --> %s bytes transferred" % (
+                        self._filename, self._seen_so_far))
                 sys.stdout.flush()
-
 
     # Get the service client
     s3 = boto3.client('s3')
@@ -331,7 +330,7 @@ existing object, use the ``ExtraArgs`` parameter::
         'Key': 'mykey'
     }
     s3.copy(
-        copy_source, 'otherbucket', 'otherkey',
+        copy_source, 'bucket', 'mykey',
         ExtraArgs={
             "Metadata": {
                 "my-new-key": "my-new-value"
@@ -344,12 +343,14 @@ existing object, use the ``ExtraArgs`` parameter::
 To track the progess of a transfer, a progress callback can be provided such
 that the callback gets invoked each time progress is made on the transfer::
 
+    import sys
+    import threading
+
     import boto3
 
     class ProgressPercentage(object):
         def __init__(self, filename):
             self._filename = filename
-            self._size = float(os.path.getsize(filename))
             self._seen_so_far = 0
             self._lock = threading.Lock()
         def __call__(self, bytes_amount):
@@ -357,17 +358,13 @@ that the callback gets invoked each time progress is made on the transfer::
             # to a single filename.
             with self._lock:
                 self._seen_so_far += bytes_amount
-                percentage = (self._seen_so_far / self._size) * 100
                 sys.stdout.write(
-                    "\r%s  %s / %s  (%.2f%%)" % (
-                        self._filename, self._seen_so_far, self._size,
-                        percentage))
+                    "\r%s --> %s bytes transferred" % (
+                        self._filename, self._seen_so_far))
                 sys.stdout.flush()
-
 
     # Get the service client
     s3 = boto3.client('s3')
-
 
     # Copies object located in mybucket at mykey
     # to the location otherbucket at otherkey

--- a/docs/source/guide/s3.rst
+++ b/docs/source/guide/s3.rst
@@ -165,7 +165,99 @@ that the callback gets invoked each time progress is made on the transfer::
 
 Downloads
 ~~~~~~~~~
-TODO
+The managed download methods are exposed in both the client and resource
+interfaces of ``boto3``:
+
+* :py:class:`S3.Client` method to download an object to a file by name: :py:meth:`S3.Client.download_file`
+* :py:class:`S3.Client` method to download an object to a writeable file-like object: :py:meth:`S3.Client.download_fileobj`
+* :py:class:`S3.Bucket` method to download an object to a file by name: :py:meth:`S3.Bucket.download_file`
+* :py:class:`S3.Bucket` method to download an object to a writeable file-like object: :py:meth:`S3.Bucket.download_fileobj`
+* :py:class:`S3.Object` method to download an object to a file by name: :py:meth:`S3.Object.download_file`
+* :py:class:`S3.Object` method to download an object to a writeable file-like object: :py:meth:`S3.Object.download_fileobj`
+
+.. note::
+
+   Even though there is a ``download_file`` and ``download_fileobj`` method for
+   a variety of classes, they all share the exact same functionality.
+   Other than for convenience, there are no benefits from using one method from
+   one class over using the same method for a different class.
+
+
+To download to a file by name, use one of the ``download_file``
+methods::
+
+    import boto3
+
+    # Get the service client
+    s3 = boto3.client('s3')
+
+    # Download object at bucket-name with key-name to tmp.txt
+    s3.download_file("bucket-name", "key-name", "tmp.txt")
+
+
+To download to a writeable file-like object, use one of the
+``download_fileobj`` methods. Note that this file-like object **must**
+allow binary to be written to it, **not** just text::
+
+    import boto3
+
+    # Get the service client
+    s3 = boto3.client('s3')
+
+    # Download object at bucket-name with key-name to file-like object
+    with open("tmp.txt", "wb") as f:
+        s3.download_fileobj("bucket-name", "key-name", f)
+
+
+To download using any extra parameters such as version ids, use the
+``ExtraArgs`` parameter::
+
+
+    import boto3
+
+    # Get the service client
+    s3 = boto3.client('s3')
+
+    # Download object at bucket-name with key-name to tmp.txt
+    s3.download_file(
+        "bucket-name", "key-name", "tmp.txt",
+        ExtraArgs={"VersionId": "my-version-id"}
+    )
+
+
+All valid ``ExtraArgs`` are listed at :py:attr:`boto3.s3.transfer.S3Transfer.ALLOWED_DOWNLOAD_ARGS`
+
+To track the progess of a transfer, a progress callback can be provided such
+that the callback gets invoked each time progress is made on the transfer::
+
+    import boto3
+
+    class ProgressPercentage(object):
+        def __init__(self, filename):
+            self._filename = filename
+            self._size = float(os.path.getsize(filename))
+            self._seen_so_far = 0
+            self._lock = threading.Lock()
+        def __call__(self, bytes_amount):
+            # To simplify we'll assume this is hooked up
+            # to a single filename.
+            with self._lock:
+                self._seen_so_far += bytes_amount
+                percentage = (self._seen_so_far / self._size) * 100
+                sys.stdout.write(
+                    "\r%s  %s / %s  (%.2f%%)" % (
+                        self._filename, self._seen_so_far, self._size,
+                        percentage))
+                sys.stdout.flush()
+
+
+    # Get the service client
+    s3 = boto3.client('s3')
+
+    # Download object at bucket-name with key-name to tmp.txt
+    s3.download_file(
+        "bucket-name", "key-name", "tmp.txt",
+        Callback=ProgressPercentage("tmp.txt"))
 
 
 Copies

--- a/docs/source/guide/s3.rst
+++ b/docs/source/guide/s3.rst
@@ -262,7 +262,126 @@ that the callback gets invoked each time progress is made on the transfer::
 
 Copies
 ~~~~~~
-TODO
+The managed copy methods are exposed in both the client and resource
+interfaces of ``boto3``:
+
+* :py:class:`S3.Client` method to copy an s3 object: :py:meth:`S3.Client.copy`
+* :py:class:`S3.Bucket` method to copy an s3 object: :py:meth:`S3.Client.copy`
+* :py:class:`S3.Object` method to copy an s3 object: :py:meth:`S3.Object.copy`
+
+
+.. note::
+
+   Even though there is a ``copy`` method for a variety of classes,
+   they all share the exact same functionality.
+   Other than for convenience, there are no benefits from using one method from
+   one class over using the same method for a different class.
+
+
+To do a managed copy, use one of the ``copy`` methods::
+
+    import boto3
+
+    # Get the service client
+    s3 = boto3.client('s3')
+
+    # Copies object located in mybucket at mykey
+    # to the location otherbucket at otherkey
+    copy_source = {
+        'Bucket': 'mybucket',
+        'Key': 'mykey'
+    }
+    s3.copy(copy_source, 'otherbucket', 'otherkey')
+
+
+To do a managed copy where the region of the source bucket is different than
+the region of the final bucket, provide a ``SourceClient`` that shares the
+same region as the source bucket::
+
+    import boto3
+
+    # Get a service client for us-west-2 region
+    s3 = boto3.client('s3', 'us-west-2')
+    # Get a service client for the eu-central-1 region
+    source_client = boto3.client('s3', 'eu-central-1')
+
+    # Copies object located in mybucket at mykey in eu-central-1 region
+    # to the location otherbucket at otherkey in the us-west-2 region
+    copy_source = {
+        'Bucket': 'mybucket',
+        'Key': 'mykey'
+    }
+    s3.copy(copy_source, 'otherbucket', 'otherkey', SourceClient=source_client)
+
+
+
+To copy using any extra parameters such as replacing user metadata on an
+existing object, use the ``ExtraArgs`` parameter::
+
+
+    import boto3
+
+    # Get the service client
+    s3 = boto3.client('s3')
+
+    # Copies object located in mybucket at mykey
+    # to the location otherbucket at otherkey
+    copy_source = {
+        'Bucket': 'mybucket',
+        'Key': 'mykey'
+    }
+    s3.copy(
+        copy_source, 'otherbucket', 'otherkey',
+        ExtraArgs={
+            "Metadata": {
+                "my-new-key": "my-new-value"
+            },
+            "MetadataDirective": "REPLACE"
+        }
+    )
+
+
+To track the progess of a transfer, a progress callback can be provided such
+that the callback gets invoked each time progress is made on the transfer::
+
+    import boto3
+
+    class ProgressPercentage(object):
+        def __init__(self, filename):
+            self._filename = filename
+            self._size = float(os.path.getsize(filename))
+            self._seen_so_far = 0
+            self._lock = threading.Lock()
+        def __call__(self, bytes_amount):
+            # To simplify we'll assume this is hooked up
+            # to a single filename.
+            with self._lock:
+                self._seen_so_far += bytes_amount
+                percentage = (self._seen_so_far / self._size) * 100
+                sys.stdout.write(
+                    "\r%s  %s / %s  (%.2f%%)" % (
+                        self._filename, self._seen_so_far, self._size,
+                        percentage))
+                sys.stdout.flush()
+
+
+    # Get the service client
+    s3 = boto3.client('s3')
+
+
+    # Copies object located in mybucket at mykey
+    # to the location otherbucket at otherkey
+    copy_source = {
+        'Bucket': 'mybucket',
+        'Key': 'mykey'
+    }
+    s3.copy(copy_source, 'otherbucket', 'otherkey',
+            Callback=ProgressPercentage("otherbucket/otherkey"))
+
+
+Note that the grainularity of these callbacks will be much larger than the
+upload and download methods because copies are all done server side and so
+there is no local file to track the streaming of data.
 
 
 Configuration Settings

--- a/docs/source/guide/s3.rst
+++ b/docs/source/guide/s3.rst
@@ -386,7 +386,58 @@ there is no local file to track the streaming of data.
 
 Configuration Settings
 ~~~~~~~~~~~~~~~~~~~~~~
-TODO
+
+To configure the various managed transfer methods, a
+:py:class:`boto3.s3.transfer.TransferConfig` object can be provided to
+the ``Config`` parameter. Please note that the default configuration should
+be well-suited for most scenarios and a ``Config`` should only be provided
+for specific use cases. Here are some common use cases for configuring the
+managed s3 transfer methods:
+
+To ensure that multipart uploads only happen when absolutely necessary, you
+can use the ``multipart_threshold`` configuration parameter::
+
+    import boto3
+    from boto3.s3.transfer import TransferConfig
+
+    # Get the service client
+    s3 = boto3.client('s3')
+
+    GB = 1024 ** 3
+    # Ensure that multipart uploads only happen if the size of a transfer
+    # is larger than S3's size limit for nonmultipart uploads, which is 5 GB.
+    config = TransferConfig(multipart_threshold=5 * GB)
+
+    # Upload tmp.txt to bucket-name at key-name
+    s3.upload_file("tmp.txt", "bucket-name", "key-name", Config=config)
+
+
+Sometimes depending on your connection speed, it is desired to limit or
+increase potential bandwidth usage. Setting the ``max_concurrency`` can help
+tune the potential bandwidth usage by decreasing or increasing the maximum
+amount of concurrent S3 transfer-related API requests::
+
+    import boto3
+    from boto3.s3.transfer import TransferConfig
+
+    # Get the service client
+    s3 = boto3.client('s3')
+
+    # Decrease the max concurrency from 10 to 5 to potentially consume
+    # less downstream bandwidth.
+    config = TransferConfig(max_concurrency=5)
+
+    # Download object at bucket-name with key-name to tmp.txt with the
+    # set configuration
+    s3.download_file("bucket-name", "key-name", "tmp.txt", Config=config)
+
+    # Increase the max concurrency to 20 to potentially consume more
+    # downstream bandwidth.
+    config = TransferConfig(max_concurrency=20)
+
+    # Download object at bucket-name with key-name to tmp.txt with the
+    # set configuration
+    s3.download_file("bucket-name", "key-name", "tmp.txt", Config=config)
 
 
 Generating Presigned URLs


### PR DESCRIPTION
It is based off of this PR: https://github.com/boto/boto3/pull/728. So it probably would be good to get that merged first.

This PR fills out the s3 documentation sections for downloads, copies, and configuration setting that I marked with a TODO in the linked PR.

cc @jamesls @JordonPhillips 