### PR TITLE
Upgrading notes

### DIFF
--- a/.changes/next-release/feature-s3-14869.json
+++ b/.changes/next-release/feature-s3-14869.json
@@ -1,0 +1,5 @@
+{
+  "category": "s3", 
+  "type": "feature", 
+  "description": "Add ``io_chunksize`` parameter to ``TransferConfig``"
+}

--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -1,0 +1,25 @@
+===============
+Upgrading Notes
+===============
+
+1.4.0
+=====
+
+* Logic from the ``s3transfer`` package was ported into ``boto3.s3.transfer``
+  module. In upgrading to this new version of ``boto3``, code that relies on
+  the public classes and interfaces of ``boto3.s3.transfer``, such as
+   ``S3Transfer`` and ``TransferConfig``, should not be affected. However,
+  code that relies on the internal classes and functionality of the
+  ``boto3.s3.transfer`` module may be affected in upgrading:
+
+  * Removed internal classes such as ``MultipartUploader``,
+    ``MultipartDownloader``, ``ReadFileChunk``, etc. All of the managed
+    transfer logic now lives inside of ``s3transfer`` and as a result these
+    internal classes are no longer used and is essentially dead code.
+
+  * Custom implementations of ``OSUtils`` may see the
+    ``open_file_chunk_reader`` method no longer being called when uploads
+    occur. If this was for the purpose of being able to provide file-like
+    objects for transfers, use the newly added ``upload_fileobj``
+    and ``download_fileobj`` methods that support both nonmultipart and
+    multipart transfers.


### PR DESCRIPTION
Add upgrading notes in preparation of merging in the recent s3 changes. Seemed like a general place for having these would be useful for the future. The idea/structure was taken from the Ruby SDK's upgrading guide: https://github.com/aws/aws-sdk-ruby/blob/master/UPGRADING.md which seems to work well for them.

I also added a missing changelog entry that I noticed that I forgot to include for ``io_chunksize``.

cc @jamesls @JordonPhillips 