### PR TITLE
Increase io_chunksize default

### DIFF
--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -150,7 +150,7 @@ class TransferConfig(S3TransferConfig):
                  multipart_chunksize=8 * MB,
                  num_download_attempts=5,
                  max_io_queue=100,
-                 io_chunksize=64 * KB):
+                 io_chunksize=256 * KB):
         """Configuration object for managed S3 transfers
 
         :param multipart_threshold: The transfer size threshold for which


### PR DESCRIPTION
This proves to significantly improve speed where the download bandwidth speed
is high. The value appears to be a sweet spot with the other default
configuration values as the io queue is no longer the bottleneck under these
sorts of environments.

This is pretty much a supplement to: https://github.com/boto/s3transfer/pull/36

cc @jamesls @JordonPhillips 