### PR TITLE
Update s3transfer to range dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,4 @@ universal = 1
 requires-dist =
 	botocore>=1.4.1,<1.5.0
 	jmespath>=0.7.1,<1.0.0
-        s3transfer==0.1.0
+        s3transfer>=0.1.0,<0.2.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ VERSION_RE = re.compile(r'''__version__ = ['"]([0-9.]+)['"]''')
 requires = [
     'botocore>=1.4.1,<1.5.0',
     'jmespath>=0.7.1,<1.0.0',
-    's3transfer==0.1.0'
+    's3transfer>=0.1.0,<0.2.0'
 ]
 
 


### PR DESCRIPTION
Since we want ``s3tranfer`` to be used directly eventually it did not make sense to have a specific version dependency in ``boto3``. Treating it with the same approach that we do with the ``botocore`` dependency in ``boto3``.

cc @jamesls @JordonPhillips 