### PR TITLE
Add reference to stable docs in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,10 +8,12 @@ Boto3 is the Amazon Web Services (AWS) Software Development Kit (SDK) for
 Python, which allows Python developers to write software that makes use
 of services like Amazon S3 and Amazon EC2. You can find the latest, most
 up to date, documentation at `Read the Docs`_, including a list of
-services that are supported.
+services that are supported. To see only those features which have been
+released, check out the `stable docs`_.
 
 
 .. _boto: https://docs.pythonboto.org/
+.. _`stable docs`: https://boto3.readthedocs.io/en/stable/
 .. _`Read the Docs`: https://boto3.readthedocs.io/en/latest/
 .. |Build Status| image:: http://img.shields.io/travis/boto/boto3/develop.svg?style=flat
     :target: https://travis-ci.org/boto/boto3

--- a/boto3/session.py
+++ b/boto3/session.py
@@ -242,7 +242,7 @@ class Session(object):
             over environment variables and configuration values, but not over
             a region_name value passed explicitly to the method. See
             `botocore config documentation
-            <https://botocore.readthedocs.io/en/latest/reference/config.html>`_
+            <https://botocore.readthedocs.io/en/stable/reference/config.html>`_
             for more details.
 
         :return: Service client instance
@@ -324,7 +324,7 @@ class Session(object):
             user_agent_extra is specified in the client config, it overrides
             the default user_agent_extra provided by the resource API. See
             `botocore config documentation
-            <https://botocore.readthedocs.io/en/latest/reference/config.html>`_
+            <https://botocore.readthedocs.io/en/stable/reference/config.html>`_
             for more details.
 
         :return: Subclass of :py:class:`~boto3.resources.base.ServiceResource`


### PR DESCRIPTION
It can be confusing to customers when they see unreleased features in the
documentation. ReadTheDocs allows users to switch to viewing the stable
version, but latest is the default. This includes a link to the stable
version in the readme for discoverability and alters hard-coded links to
refer to the stable version.

cc @jamesls @kyleknap