### PR TITLE
Added path attribute to the hasMany stacks collection

### DIFF
--- a/boto3/data/cloudformation/2010-05-15/resources-1.json
+++ b/boto3/data/cloudformation/2010-05-15/resources-1.json
@@ -36,7 +36,8 @@
           "type": "Stack",
           "identifiers": [
             { "target": "Name", "source": "response", "path": "Stacks[].StackName" }
-          ]
+          ],
+          "path": "Stacks[]"
         }
       }
     }


### PR DESCRIPTION
The the cloudformations hasMany collection includes Stacks.
This is populated by the describe stacks call, but unlike other
resources of this type (i.e. ec2 instances) it does not populate the individual
stack resources with the results of this call.
The missing path attribute has been added to fix this.