### PR TITLE
Add BOTO_CONFIG to the documentation.

### DIFF
--- a/docs/source/guide/configuration.rst
+++ b/docs/source/guide/configuration.rst
@@ -262,7 +262,8 @@ Boto2 Config
 ~~~~~~~~~~~~
 
 Boto3 will attempt to load credentials from the Boto2 config file.
-It will check ``/etc/boto.cfg`` and ``~/.boto``.  Note that
+It first checks the file pointed to by ``BOTO_CONFIG`` if set, otherwise
+it will check ``/etc/boto.cfg`` and ``~/.boto``.  Note that
 *only* the ``[Credentials]`` section of the boto config file is used.
 All other configuration data in the boto config file is ignored.
 Example::
@@ -349,6 +350,11 @@ Environment Variable Configuration
     The location of the shared credentials file.  By default this value
     is ``~/.aws/credentials``.  You only need to set this variable if
     you want to change this location.
+
+``BOTO_CONFIG``
+    The location of the boto2 credentials file. This is not set by default.
+    You only need to set this variable if want to use credentials stored in
+    boto2 format in a location other than ``/etc/boto.cfg`` or ``~/.boto``.
 
 ``AWS_CA_BUNDLE``
     The path to a custom certificate bundle to use when establishing


### PR DESCRIPTION
 The documentation is missing the info about BOTO_CONFIG variable where  boto looks for boto2 compatible credentials file.