### PR TITLE
region == region_name

### DIFF
--- a/docs/source/guide/configuration.rst
+++ b/docs/source/guide/configuration.rst
@@ -403,7 +403,7 @@ If your profile name has spaces, you'll need to surround this value in quotes:
 in the ``~/.aws/config`` file:
 
 ``region``
-    The default region to use, e.g. ``us-west-2``, ``us-west-2``, etc.
+    The default region to use, e.g. ``us-west-2``, ``us-west-2``, etc. When specifying a region inline during client initialization, this property is named ``region_name``
 ``aws_access_key_id``
     The access key to use.
 ``aws_secret_access_key``


### PR DESCRIPTION
Specifying that during inline client creation, "region_name" needs to be used in place of "region".
Eg:
lambda_client = boto3.client('lambda', aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key, region_name='us-east-1')