### PR TITLE
Add delete_tags to EC2 Volume instance

### DIFF
--- a/boto3/session.py
+++ b/boto3/session.py
@@ -450,3 +450,9 @@ class Session(object):
             boto3.utils.lazy_call(
                 'boto3.ec2.deletetags.inject_delete_tags',
                 event_emitter=self.events))
+
+        self._session.register(
+            'creating-resource-class.ec2.Volume',
+            boto3.utils.lazy_call(
+                'boto3.ec2.deletetags.inject_delete_tags',
+                event_emitter=self.events))

--- a/tests/functional/test_ec2.py
+++ b/tests/functional/test_ec2.py
@@ -34,3 +34,23 @@ class TestInstanceDeleteTags(unittest.TestCase):
         stubber.assert_no_pending_responses()
         self.assertEqual(response, {})
         stubber.deactivate()
+
+
+class TestVolumeDeleteTags(unittest.TestCase):
+    def setUp(self):
+        self.session = boto3.session.Session(region_name='us-west-2')
+        self.service_resource = self.session.resource('ec2')
+        self.volume_resource = self.service_resource.Volume('vol-abc123')
+
+    def test_delete_tags_injected(self):
+        self.assertTrue(hasattr(self.volume_resource, 'delete_tags'),
+                        'delete_tags was not injected onto Volume resource.')
+
+    def test_delete_tags(self):
+        stubber = Stubber(self.volume_resource.meta.client)
+        stubber.add_response('delete_tags', {})
+        stubber.activate()
+        response = self.volume_resource.delete_tags(Tags=[{'Key': 'foo'}])
+        stubber.assert_no_pending_responses()
+        self.assertEqual(response, {})
+        stubber.deactivate()


### PR DESCRIPTION
Adds the delete_tags method to EC2 Volume instances in the same manner as `Instance` instances.
