### PR TITLE
Make the DEFAULT_SESSION value thread safe.

### DIFF
--- a/boto3/__init__.py
+++ b/boto3/__init__.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 
 import logging
+import threading
 
 from boto3.session import Session
 
@@ -21,7 +22,8 @@ __version__ = '1.4.0'
 
 
 # The default Boto3 session; autoloaded when needed.
-DEFAULT_SESSION = None
+_active = threading.local()
+_active.DEFAULT_SESSION = None
 
 
 def setup_default_session(**kwargs):
@@ -30,8 +32,8 @@ def setup_default_session(**kwargs):
     constructor. There is no need to call this unless you wish to pass custom
     parameters, because a default session will be created for you.
     """
-    global DEFAULT_SESSION
-    DEFAULT_SESSION = Session(**kwargs)
+    global _active
+    _active.DEFAULT_SESSION = Session(**kwargs)
 
 
 def set_stream_logger(name='boto3', level=logging.DEBUG, format_string=None):
@@ -68,10 +70,10 @@ def _get_default_session():
     :rtype: :py:class:`~boto3.session.Sesssion`
     :return: The default session
     """
-    if DEFAULT_SESSION is None:
+    if _active.DEFAULT_SESSION is None:
         setup_default_session()
 
-    return DEFAULT_SESSION
+    return _active.DEFAULT_SESSION
 
 
 def client(*args, **kwargs):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -69,7 +69,7 @@ class BaseTestCase(unittest.TestCase):
         # We also need to patch the global default session.
         # Otherwise it could be a cached real session came from previous
         # "functional" or "integration" tests.
-        patch_global_session = mock.patch('boto3.DEFAULT_SESSION')
+        patch_global_session = mock.patch('boto3._active.DEFAULT_SESSION')
         patch_global_session.start()
         self.addCleanup(patch_global_session.stop)
 

--- a/tests/unit/test_boto3.py
+++ b/tests/unit/test_boto3.py
@@ -22,7 +22,7 @@ class TestBoto3(unittest.TestCase):
         self.Session = self.session_patch.start()
 
     def tearDown(self):
-        boto3.DEFAULT_SESSION = None
+        boto3._active.DEFAULT_SESSION = None
         self.session_patch.stop()
 
     def test_create_default_session(self):
@@ -30,7 +30,7 @@ class TestBoto3(unittest.TestCase):
 
         boto3.setup_default_session()
 
-        self.assertEqual(boto3.DEFAULT_SESSION, session,
+        self.assertEqual(boto3._active.DEFAULT_SESSION, session,
             'Default session not created properly')
 
     def test_create_default_session_with_args(self):
@@ -45,63 +45,63 @@ class TestBoto3(unittest.TestCase):
     @mock.patch('boto3.setup_default_session',
                 wraps=boto3.setup_default_session)
     def test_client_creates_default_session(self, setup_session):
-        boto3.DEFAULT_SESSION = None
+        boto3._active.DEFAULT_SESSION = None
 
         boto3.client('sqs')
 
         self.assertTrue(setup_session.called,
             'setup_default_session not called')
-        self.assertTrue(boto3.DEFAULT_SESSION.client.called,
+        self.assertTrue(boto3._active.DEFAULT_SESSION.client.called,
             'Default session client method not called')
 
     @mock.patch('boto3.setup_default_session',
                 wraps=boto3.setup_default_session)
     def test_client_uses_existing_session(self, setup_session):
-        boto3.DEFAULT_SESSION = self.Session()
+        boto3._active.DEFAULT_SESSION = self.Session()
 
         boto3.client('sqs')
 
         self.assertFalse(setup_session.called,
             'setup_default_session should not have been called')
-        self.assertTrue(boto3.DEFAULT_SESSION.client.called,
+        self.assertTrue(boto3._active.DEFAULT_SESSION.client.called,
             'Default session client method not called')
 
     def test_client_passes_through_arguments(self):
-        boto3.DEFAULT_SESSION = self.Session()
+        boto3._active.DEFAULT_SESSION = self.Session()
 
         boto3.client('sqs', region_name='us-west-2', verify=False)
 
-        boto3.DEFAULT_SESSION.client.assert_called_with(
+        boto3._active.DEFAULT_SESSION.client.assert_called_with(
             'sqs', region_name='us-west-2', verify=False)
 
     @mock.patch('boto3.setup_default_session',
                 wraps=boto3.setup_default_session)
     def test_resource_creates_default_session(self, setup_session):
-        boto3.DEFAULT_SESSION = None
+        boto3._active.DEFAULT_SESSION = None
 
         boto3.resource('sqs')
 
         self.assertTrue(setup_session.called,
             'setup_default_session not called')
-        self.assertTrue(boto3.DEFAULT_SESSION.resource.called,
+        self.assertTrue(boto3._active.DEFAULT_SESSION.resource.called,
             'Default session resource method not called')
 
     @mock.patch('boto3.setup_default_session',
                 wraps=boto3.setup_default_session)
     def test_resource_uses_existing_session(self, setup_session):
-        boto3.DEFAULT_SESSION = self.Session()
+        boto3._active.DEFAULT_SESSION = self.Session()
 
         boto3.resource('sqs')
 
         self.assertFalse(setup_session.called,
             'setup_default_session should not have been called')
-        self.assertTrue(boto3.DEFAULT_SESSION.resource.called,
+        self.assertTrue(boto3._active.DEFAULT_SESSION.resource.called,
             'Default session resource method not called')
 
     def test_resource_passes_through_arguments(self):
-        boto3.DEFAULT_SESSION = self.Session()
+        boto3._active.DEFAULT_SESSION = self.Session()
 
         boto3.resource('sqs', region_name='us-west-2', verify=False)
 
-        boto3.DEFAULT_SESSION.resource.assert_called_with(
+        boto3._active.DEFAULT_SESSION.resource.assert_called_with(
             'sqs', region_name='us-west-2', verify=False)


### PR DESCRIPTION
The default configuration of mod_wsgi is to run 15 threads under 1
process. When using boto3 in this configuration, accessing the
DEFAULT_SESSION is not thread safe and can lead to runtime errors. To
handle this use case, protect the default session using
threading.local().

Fixes #801
