### PR TITLE
Fix typo in sqs resource model

### DIFF
--- a/.changes/next-release/bugfix-sqsQueue-44515.json
+++ b/.changes/next-release/bugfix-sqsQueue-44515.json
@@ -1,0 +1,5 @@
+{
+  "category": "``sqs.Queue``", 
+  "type": "bugfix", 
+  "description": "Fix issue in DeadLetterSourceQueues collection"
+}

--- a/boto3/data/sqs/2012-11-05/resources-1.json
+++ b/boto3/data/sqs/2012-11-05/resources-1.json
@@ -222,7 +222,7 @@
           "resource": {
             "type": "Queue",
             "identifiers": [
-              { "target": "Url", "source": "response", "path": "QueueUrls[]" }
+              { "target": "Url", "source": "response", "path": "queueUrls[]" }
             ]
           }
         }


### PR DESCRIPTION
The ``QueueUrl`` should be ``queueUrl`` for the target. I was able to manually confirm that this works as well. Also confirmed in [service model](https://github.com/boto/botocore/blob/develop/botocore/data/sqs/2012-11-05/service-2.json#L754).

Fixes https://github.com/boto/boto3/issues/817

cc @jamesls @JordonPhillips 