### PR TITLE
Use TransferManager context manager for s3 transfers

### DIFF
--- a/.changes/next-release/bugfix-s3-85075.json
+++ b/.changes/next-release/bugfix-s3-85075.json
@@ -1,0 +1,5 @@
+{
+  "category": "s3", 
+  "type": "bugfix", 
+  "description": "Fix issue when transfers would not exit quickly from signals"
+}

--- a/boto3/s3/inject.py
+++ b/boto3/s3/inject.py
@@ -99,10 +99,10 @@ def upload_file(self, Filename, Bucket, Key, ExtraArgs=None,
     except that parameters are capitalized. Detailed examples can be found at
     :ref:`S3Transfer's Usage <ref_s3transfer_usage>`.
     """
-    transfer = S3Transfer(self, Config)
-    return transfer.upload_file(
-        filename=Filename, bucket=Bucket, key=Key,
-        extra_args=ExtraArgs, callback=Callback)
+    with S3Transfer(self, Config) as transfer:
+        return transfer.upload_file(
+            filename=Filename, bucket=Bucket, key=Key,
+            extra_args=ExtraArgs, callback=Callback)
 
 
 def download_file(self, Bucket, Key, Filename, ExtraArgs=None,
@@ -119,10 +119,10 @@ def download_file(self, Bucket, Key, Filename, ExtraArgs=None,
     except that parameters are capitalized. Detailed examples can be found at
     :ref:`S3Transfer's Usage <ref_s3transfer_usage>`.
     """
-    transfer = S3Transfer(self, Config)
-    return transfer.download_file(
-        bucket=Bucket, key=Key, filename=Filename,
-        extra_args=ExtraArgs, callback=Callback)
+    with S3Transfer(self, Config) as transfer:
+        return transfer.download_file(
+            bucket=Bucket, key=Key, filename=Filename,
+            extra_args=ExtraArgs, callback=Callback)
 
 
 def bucket_upload_file(self, Filename, Key,

--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -280,6 +280,12 @@ class S3Transfer(object):
             return None
         return [ProgressCallbackInvoker(callback)]
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self._manager.__exit__(*args)
+
 
 class ProgressCallbackInvoker(BaseSubscriber):
     """A back-compat wrapper to invoke a provided callback via a subscriber

--- a/tests/unit/s3/test_inject.py
+++ b/tests/unit/s3/test_inject.py
@@ -31,7 +31,9 @@ class TestInjectTransferMethods(unittest.TestCase):
             inject.upload_file(mock.sentinel.CLIENT,
                                Filename='filename',
                                Bucket='bucket', Key='key')
-            transfer.return_value.upload_file.assert_called_with(
+            transfer_in_context_manager = \
+                transfer.return_value.__enter__.return_value
+            transfer_in_context_manager.upload_file.assert_called_with(
                 filename='filename', bucket='bucket', key='key',
                 extra_args=None, callback=None)
 
@@ -41,7 +43,9 @@ class TestInjectTransferMethods(unittest.TestCase):
                 mock.sentinel.CLIENT,
                 Bucket='bucket', Key='key',
                 Filename='filename')
-            transfer.return_value.download_file.assert_called_with(
+            transfer_in_context_manager = \
+                transfer.return_value.__enter__.return_value
+            transfer_in_context_manager.download_file.assert_called_with(
                 bucket='bucket', key='key', filename='filename',
                 extra_args=None, callback=None)
 


### PR DESCRIPTION
The change introduces a context manager for ``S3Transfer`` that essentially leverages the underlying ``s3transfer.manager.TransferManager`` context manager for enabling quicker clean ups for errors signaled to the main thread.

Fixes https://github.com/boto/boto3/issues/830

I was not sure if we wanted to add an integration test. In the end, I decided not to because ``s3transfer`` already has a good amount of integration tests for this. I also tested it manually and it now exits quickly and does not try to complete the download, but I can be convinced if we want to add one:
```py
import signal
import sys
import boto3
from boto3.s3.transfer import TransferConfig
import logging
logging.basicConfig(level=logging.DEBUG)


s3_resource = boto3.resource('s3')

obj = s3_resource.Object('mybucketfoo', '100MB')
max_secs = 2
local_path = 'some-location'
config = TransferConfig({'num_download_attempts': 1})


class TimeoutError(Exception): pass


def handler(signum, frame):
    print "Got timeout error"
    raise TimeoutError()

signal.signal(signal.SIGALRM, handler)
signal.alarm(max_secs)
try:
    obj.download_file(local_path, Config=config)
    print True
except TimeoutError:
    print False
finally:
    signal.signal(signal.SIGALRM, signal.SIG_DFL)
    signal.alarm(0)

sys.exit()
```

cc @jamesls @JordonPhillips 