### PR TITLE
Fix instances of classes implementing `__eq__` but not `__hash__`

### DIFF
--- a/boto3/resources/base.py
+++ b/boto3/resources/base.py
@@ -52,6 +52,8 @@ class ResourceMeta(object):
 
         return self.__dict__ == other.__dict__
 
+    __hash__ = None
+
     def copy(self):
         """
         Create a copy of this metadata object.
@@ -140,3 +142,5 @@ class ServiceResource(object):
                 return False
 
         return True
+
+    __hash__ = None


### PR DESCRIPTION
I've been working through looking at adopting Python 3, and I've been utilizing the -3 flag to help idenitfy issues with Python 3.

Here's a quick write up I did last week:

https://gist.github.com/rowillia/c0feed97c1863b2d8e5a3ed73712df65

The -3 flagged a few issues in boto3 worth fixing, namely around eq shadowing hash in PY3.

Fixing these issues will help make the -3 flag less noisey for folks running boto3 in production.
