### PR TITLE
Expose the use_threads configuration

### DIFF
--- a/.changes/next-release/feature-s3-5833.json
+++ b/.changes/next-release/feature-s3-5833.json
@@ -1,0 +1,5 @@
+{
+  "category": "``s3``", 
+  "type": "feature", 
+  "description": "Add ability to disable thread use with ``use_threads`` option"
+}

--- a/boto3/s3/inject.py
+++ b/boto3/s3/inject.py
@@ -10,10 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from s3transfer.manager import TransferManager, TransferConfig
 from botocore.exceptions import ClientError
 
-from boto3.s3.transfer import S3Transfer, ProgressCallbackInvoker
+from boto3.s3.transfer import create_transfer_manager
+from boto3.s3.transfer import TransferConfig, S3Transfer
+from boto3.s3.transfer import ProgressCallbackInvoker
 from boto3 import utils
 
 
@@ -258,7 +259,7 @@ def copy(self, CopySource, Bucket, Key, ExtraArgs=None, Callback=None,
     if config is None:
         config = TransferConfig()
 
-    with TransferManager(self, config) as manager:
+    with create_transfer_manager(self, config) as manager:
         future = manager.copy(
             copy_source=CopySource, bucket=Bucket, key=Key,
             extra_args=ExtraArgs, subscribers=subscribers,
@@ -419,7 +420,7 @@ def upload_fileobj(self, Fileobj, Bucket, Key, ExtraArgs=None,
     if config is None:
         config = TransferConfig()
 
-    with TransferManager(self, config) as manager:
+    with create_transfer_manager(self, config) as manager:
         future = manager.upload(
             fileobj=Fileobj, bucket=Bucket, key=Key,
             extra_args=ExtraArgs, subscribers=subscribers)
@@ -558,7 +559,7 @@ def download_fileobj(self, Bucket, Key, Fileobj, ExtraArgs=None,
     if config is None:
         config = TransferConfig()
 
-    with TransferManager(self, config) as manager:
+    with create_transfer_manager(self, config) as manager:
         future = manager.download(
             bucket=Bucket, key=Key, fileobj=Fileobj,
             extra_args=ExtraArgs, subscribers=subscribers)

--- a/docs/source/guide/s3.rst
+++ b/docs/source/guide/s3.rst
@@ -61,6 +61,7 @@ S3. Functionality includes:
   * Multipart transfer thresholds
   * Multipart transfer part sizes
   * Number of download retry attempts
+  * Enabling/disabling the use of threads
 
 
 Uploads
@@ -431,6 +432,26 @@ amount of concurrent S3 transfer-related API requests::
     # Increase the max concurrency to 20 to potentially consume more
     # downstream bandwidth.
     config = TransferConfig(max_concurrency=20)
+
+    # Download object at bucket-name with key-name to tmp.txt with the
+    # set configuration
+    s3.download_file("bucket-name", "key-name", "tmp.txt", Config=config)
+
+
+Threads are used by default in the managed transfer methods. To ensure no
+threads are used in the transfer process, set ``use_threads`` to
+``False``. Note that in setting ``use_threads`` to ``False``, the value for
+``max_concurrency`` is ignored as the main thread will only ever be used::
+
+
+    import boto3
+    from boto3.s3.transfer import TransferConfig
+
+    # Get the service client
+    s3 = boto3.client('s3')
+
+    # Ensure that no threads are used.
+    config = TransferConfig(use_threads=False)
 
     # Download object at bucket-name with key-name to tmp.txt with the
     # set configuration

--- a/docs/source/guide/upgrading.rst
+++ b/docs/source/guide/upgrading.rst
@@ -4,7 +4,7 @@ Upgrading Notes
 
 Notes to refer to when upgrading ``boto3`` versions.
 
-1.4.0
+1.4.x
 =====
 
 * Logic from the `s3transfer <https://github.com/boto/s3transfer>`_ package
@@ -27,3 +27,9 @@ Notes to refer to when upgrading ``boto3`` versions.
     objects for transfers, use the newly added ``upload_fileobj``
     and ``download_fileobj`` methods that support both nonmultipart and
     multipart transfers.
+
+  * By default, all managed transfer methods are now threaded. In prior
+    versions, threads were only created if a non multipart upload or download
+    was initiated. To run the managed transfer methods with no threads
+    (i.e. all of the transfer logic happens in the main thread), set
+    ``use_threads`` to ``False`` when providing a ``TransferConfig`` object.

--- a/docs/source/guide/upgrading.rst
+++ b/docs/source/guide/upgrading.rst
@@ -4,6 +4,17 @@ Upgrading Notes
 
 Notes to refer to when upgrading ``boto3`` versions.
 
+
+1.4.2
+=====
+
+* The ``use_threads`` option was added to
+  :py:class:`boto3.s3.transfer.TransferConfig`.
+  Starting in version ``1.4.0``, all managed S3 transfer methods became
+  threaded instead of possibly being threaded. If it is not desired to use
+  threads for managed S3 transfers, set ``use_threads`` to ``False``.
+
+
 1.4.0
 =====
 

--- a/docs/source/guide/upgrading.rst
+++ b/docs/source/guide/upgrading.rst
@@ -4,7 +4,7 @@ Upgrading Notes
 
 Notes to refer to when upgrading ``boto3`` versions.
 
-1.4.x
+1.4.0
 =====
 
 * Logic from the `s3transfer <https://github.com/boto/s3transfer>`_ package
@@ -33,3 +33,5 @@ Notes to refer to when upgrading ``boto3`` versions.
     was initiated. To run the managed transfer methods with no threads
     (i.e. all of the transfer logic happens in the main thread), set
     ``use_threads`` to ``False`` when providing a ``TransferConfig`` object.
+    The ``use_threads`` option is only available in ``boto3`` versions higher
+    than ``1.4.1``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,6 @@ universal = 1
 
 [metadata]
 requires-dist =
-	botocore>=1.4.1,<1.5.0
-	jmespath>=0.7.1,<1.0.0
-        s3transfer>=0.1.0,<0.2.0
+    botocore>=1.4.1,<1.5.0
+    jmespath>=0.7.1,<1.0.0
+    s3transfer>=0.1.10,<0.2.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ VERSION_RE = re.compile(r'''__version__ = ['"]([0-9.]+)['"]''')
 requires = [
     'botocore>=1.4.1,<1.5.0',
     'jmespath>=0.7.1,<1.0.0',
-    's3transfer>=0.1.0,<0.2.0'
+    's3transfer>=0.1.10,<0.2.0'
 ]
 
 

--- a/tests/unit/s3/test_transfer.py
+++ b/tests/unit/s3/test_transfer.py
@@ -14,12 +14,39 @@ from tests import unittest
 
 import mock
 from s3transfer.manager import TransferManager
+from s3transfer.futures import NonThreadedExecutor
 
 from boto3.exceptions import RetriesExceededError
 from boto3.exceptions import S3UploadFailedError
+from boto3.s3.transfer import create_transfer_manager
 from boto3.s3.transfer import S3Transfer
 from boto3.s3.transfer import OSUtils, TransferConfig, ProgressCallbackInvoker
 from boto3.s3.transfer import ClientError, S3TransferRetriesExceededError
+
+
+class TestCreateTransferManager(unittest.TestCase):
+    def test_create_transfer_manager(self):
+        client = object()
+        config = TransferConfig()
+        osutil = OSUtils()
+        with mock.patch('boto3.s3.transfer.TransferManager') as manager:
+            create_transfer_manager(client, config, osutil)
+            self.assertEqual(
+                manager.call_args,
+                mock.call(client, config, osutil, None)
+            )
+
+    def test_create_transfer_manager_with_no_threads(self):
+        client = object()
+        config = TransferConfig()
+        config.use_threads = False
+        with mock.patch(
+                'boto3.s3.transfer.TransferManager') as manager:
+            create_transfer_manager(client, config)
+            self.assertEqual(
+                manager.call_args,
+                mock.call(client, config, None, NonThreadedExecutor)
+            )
 
 
 class TestTransferConfig(unittest.TestCase):


### PR DESCRIPTION
By setting `use_threads` to `False`, it allows users to use the managed transfer manager in a non-threaded environment.

Fixes https://github.com/boto/boto3/issues/814

Here is an example from the linked issue of how it can be used:

``` py
from flask import Flask
from celery import Celery
import boto3
from boto3.s3.transfer import TransferConfig
import tempfile


celery = Celery(__name__)

app = Flask(__name__)

s3 = boto3.client('s3')
env_file = 'test'

config = TransferConfig(use_threads=False)
with tempfile.NamedTemporaryFile() as s3_file:
    print("Downloading file...")
    response = s3.download_file(
        'mybucketfoo', env_file, s3_file.name, Config=config)
    print("Download complete!")
```

Note that when running it no longer hangs in the download portion of the code.

It builds on top of: https://github.com/boto/s3transfer/pull/70 so test will fail till that gets merged.

cc @jamesls @JordonPhillips 
