### PR TITLE
Added parent session to service context

### DIFF
--- a/boto3/docs/service.py
+++ b/boto3/docs/service.py
@@ -100,7 +100,8 @@ class ServiceDocumenter(BaseServiceDocumenter):
                         resource_json_definitions=json_resource_model[
                             'resources'],
                         service_model=service_model,
-                        service_waiter_model=None
+                        service_waiter_model=None,
+                        session=self._boto3_session
                     )
                 )
             identifiers = resource_cls.meta.resource_model.identifiers

--- a/boto3/resources/base.py
+++ b/boto3/resources/base.py
@@ -24,9 +24,12 @@ class ResourceMeta(object):
     An object containing metadata about a resource.
     """
     def __init__(self, service_name, identifiers=None, client=None,
-                 data=None, resource_model=None):
+                 data=None, resource_model=None, session=None):
         #: (``string``) The service name, e.g. 's3'
         self.service_name = service_name
+
+        #: (:py:class:`~boto3.Session`) Session used to create this resource
+        self.session = session
 
         if identifiers is None:
             identifiers = []

--- a/boto3/resources/factory.py
+++ b/boto3/resources/factory.py
@@ -81,7 +81,9 @@ class ResourceFactory(object):
 
         # Set some basic info
         meta = ResourceMeta(
-            service_context.service_name, resource_model=resource_model)
+            service_context.service_name, resource_model=resource_model,
+            session=service_context.session
+        )
         attrs = {
             'meta': meta,
         }

--- a/boto3/session.py
+++ b/boto3/session.py
@@ -395,7 +395,7 @@ class Session(object):
                 service_name=service_name, service_model=service_model,
                 resource_json_definitions=resource_model['resources'],
                 service_waiter_model=boto3.utils.LazyLoadedWaiterModel(
-                    self._session, service_name, api_version)
+                    self._session, service_name, api_version), session=self
         )
 
         # Create the service resource class.

--- a/boto3/utils.py
+++ b/boto3/utils.py
@@ -17,7 +17,7 @@ from collections import namedtuple
 _ServiceContext = namedtuple(
     'ServiceContext',
     ['service_name', 'service_model', 'service_waiter_model',
-     'resource_json_definitions']
+     'resource_json_definitions', 'session']
 )
 
 

--- a/tests/unit/resources/test_action.py
+++ b/tests/unit/resources/test_action.py
@@ -104,7 +104,8 @@ class TestServiceActionCall(BaseTestCase):
             service_name='test',
             service_model=service_model,
             resource_json_definitions=resource_defs,
-            service_waiter_model=None
+            service_waiter_model=None,
+            session=None
         )
 
         action = ServiceAction(

--- a/tests/unit/resources/test_collection.py
+++ b/tests/unit/resources/test_collection.py
@@ -61,7 +61,8 @@ class TestCollectionFactory(BaseTestCase):
             service_name='test',
             resource_json_definitions=resource_defs,
             service_model=self.service_model,
-            service_waiter_model=None
+            service_waiter_model=None,
+            session=None
         )
         collection_cls = self.load(
             resource_name='Chain',
@@ -122,7 +123,8 @@ class TestCollectionFactory(BaseTestCase):
             service_name='test',
             resource_json_definitions=resource_defs,
             service_model=self.service_model,
-            service_waiter_model=None
+            service_waiter_model=None,
+            session=None
         )
         collection_cls = self.load(
             resource_name='Chain',
@@ -193,7 +195,8 @@ class TestResourceCollection(BaseTestCase):
                 service_name='test',
                 service_model=self.service_model,
                 resource_json_definitions=resource_defs,
-                service_waiter_model=None
+                service_waiter_model=None,
+                session=None
             )
         )
         return collection

--- a/tests/unit/resources/test_factory.py
+++ b/tests/unit/resources/test_factory.py
@@ -37,9 +37,10 @@ class BaseTestResourceFactory(BaseTestCase):
             service_name='test',
             resource_json_definitions=resource_json_definitions,
             service_model=service_model,
-            service_waiter_model=None
+            service_waiter_model=None,
+            session=None
         )
-                
+
         return self.factory.load_from_definition(
             resource_name=resource_name,
             single_resource_json_definition=resource_json_definition,
@@ -685,6 +686,13 @@ class TestResourceFactoryDanglingResource(BaseTestResourceFactory):
 
         self.assertEqual(resource.meta.client, q.meta.client,
             'Client was not shared to dangling resource instance')
+
+    def test_dangling_resource_shares_session(self):
+        resource = self.load('test', self.model, self.defs)()
+        q = resource.Queue('test')
+
+        self.assertEqual(resource.meta.session, q.meta.session,
+            'Session was not shared to dangling resource instance')
 
     def test_dangling_resource_requires_identifier(self):
         resource = self.load('test', self.model, self.defs)()

--- a/tests/unit/resources/test_response.py
+++ b/tests/unit/resources/test_response.py
@@ -350,7 +350,8 @@ class TestResourceHandler(BaseTestCase):
                 service_name='myservice',
                 resource_json_definitions=self.resource_defs,
                 service_model=self.service_model,
-                service_waiter_model=None
+                service_waiter_model=None,
+                session=None
             ),
             operation_name='GetFrobs'
         )


### PR DESCRIPTION
This allows a resource instance to access its parent session.
It is useful for creating other resources or service clients without passing around the session to every location that you have access to a resource.

This is especially useful in the context of multiple sessions and multiple AWS accounts.

For example:
```python
def get_resource_account_id(resource):
  session = resource.meta.session
  sts = session.client('sts')
  return  sts.get_caller_identity()['Account']
```