### PR TITLE
Add canned and custom ACL examples to S3 guide

### DIFF
--- a/docs/source/guide/s3.rst
+++ b/docs/source/guide/s3.rst
@@ -108,19 +108,31 @@ from, **not** text::
         s3.upload_fileobj(f, "bucket-name", "key-name")
 
 
-To upload a file using any extra parameters such as user metadata, use the
-``ExtraArgs`` parameter::
+When uploading, ``ExtraArgs`` can be used to specify a variety of
+additional parameters.  For example, to supply user metadata::
 
-
-    import boto3
-
-    # Get the service client
-    s3 = boto3.client('s3')
-
-    # Upload tmp.txt to bucket-name at key-name
     s3.upload_file(
         "tmp.txt", "bucket-name", "key-name",
         ExtraArgs={"Metadata": {"mykey": "myvalue"}}
+    )
+
+
+To set a canned ACL::
+
+    s3.upload_file(
+        'tmp.txt', 'bucket-name', 'key-name',
+        ExtraArgs={'ACL': 'public-read'}
+    )
+
+
+To set custom or multiple ACLs::
+
+    s3.upload_file(
+        'tmp.txt', 'bucket-name', 'key-name',
+        ExtraArgs={
+            'GrantRead': 'uri="http://acs.amazonaws.com/groups/global/AllUsers"',
+            'GrantFullControl': 'id="79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be"',
+        }
     )
 
 


### PR DESCRIPTION
Today I needed to set multiple ACLs on an object while uploading.  It took me a while to figure out how to do that from the existing docs.  This adds some simple examples that might help others.