### PR TITLE
Use strings when writing contents

### DIFF
--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -629,7 +629,7 @@ class TestS3Transfers(unittest.TestCase):
         # use ``boto3.s3.transfer.S3Transfer`` and the other should be
         # using ``s3transfer.manager.TransferManager`` directly
         content = b'my content'
-        filename = self.files.create_file('myfile', content)
+        filename = self.files.create_file('myfile', content.decode('utf-8'))
         key = 'foo'
         config = boto3.s3.transfer.TransferConfig(use_threads=False)
 


### PR DESCRIPTION
The helper method only accepted stings not bytes, which failed on Python 3. I tested it locally and it worked for python3.

cc @jamesls @JordonPhillips @stealthycoin 