### PR TITLE
Fix typo in return type annotation

### DIFF
--- a/boto3/__init__.py
+++ b/boto3/__init__.py
@@ -65,7 +65,7 @@ def _get_default_session():
     """
     Get the default session, creating one if needed.
 
-    :rtype: :py:class:`~boto3.session.Sesssion`
+    :rtype: :py:class:`~boto3.session.Session`
     :return: The default session
     """
     if DEFAULT_SESSION is None:


### PR DESCRIPTION
This PR fixes a typo `Sesssion` instead of `Session` in the return type of the `_get_default_session` method.