### PR TITLE
Allow Bucket.load() to work on cross-account buckets

### DIFF
--- a/boto3/s3/inject.py
+++ b/boto3/s3/inject.py
@@ -64,15 +64,18 @@ def bucket_load(self, *args, **kwargs):
 
     # We can't actually get the bucket's attributes from a HeadBucket,
     # so we need to use a ListBuckets and search for our bucket.
-    response = self.meta.client.list_buckets()
-    for bucket_data in response['Buckets']:
-        if bucket_data['Name'] == self.name:
-            self.meta.data = bucket_data
-            break
-    else:
-        raise ClientError({'Error': {'Code': '404', 'Message': 'NotFound'}},
-                          'ListBuckets')
-
+    # However, we may fail if we lack permissions to ListBuckets
+    # or the bucket is in another account. In which case, creation_date
+    # will be None.
+    self.meta.data = {}
+    try:
+        response = self.meta.client.list_buckets()
+        for bucket_data in response['Buckets']:
+            if bucket_data['Name'] == self.name:
+                self.meta.data = bucket_data
+                break
+    except ClientError:
+        pass
 
 def object_summary_load(self, *args, **kwargs):
     """

--- a/boto3/s3/inject.py
+++ b/boto3/s3/inject.py
@@ -74,8 +74,9 @@ def bucket_load(self, *args, **kwargs):
             if bucket_data['Name'] == self.name:
                 self.meta.data = bucket_data
                 break
-    except ClientError:
-        pass
+    except ClientError as e:
+        if not e.response.get('Error', {}).get('Code') == 'AccessDenied':
+            raise
 
 def object_summary_load(self, *args, **kwargs):
     """

--- a/tests/unit/s3/test_inject.py
+++ b/tests/unit/s3/test_inject.py
@@ -70,7 +70,7 @@ class TestBucketLoad(unittest.TestCase):
             self.resource.meta.data,
             {'Name': self.resource.name, 'CreationDate': 2})
 
-    def test_bucket_load_raise_error(self):
+    def test_bucket_load_doesnt_find_bucket(self):
         self.resource.name = 'MyBucket'
         self.client.list_buckets.return_value = {
             'Buckets': [
@@ -78,9 +78,13 @@ class TestBucketLoad(unittest.TestCase):
                 {'Name': 'NotMine2', 'CreationDate': 2},
             ],
         }
-        with self.assertRaises(ClientError):
-            inject.bucket_load(self.resource)
+        inject.bucket_load(self.resource)
+        self.assertEqual(self.resource.meta.data, {})
 
+    def test_bucket_load_encounters_exception(self):
+        self.client.list_buckets.side_effect = ClientError({'Error': {}}, 'op_name')
+        inject.bucket_load(self.resource)
+        self.assertEqual(self.resource.meta.data, {})
 
 class TestBucketTransferMethods(unittest.TestCase):
 

--- a/tests/unit/s3/test_inject.py
+++ b/tests/unit/s3/test_inject.py
@@ -81,10 +81,23 @@ class TestBucketLoad(unittest.TestCase):
         inject.bucket_load(self.resource)
         self.assertEqual(self.resource.meta.data, {})
 
-    def test_bucket_load_encounters_exception(self):
-        self.client.list_buckets.side_effect = ClientError({'Error': {}}, 'op_name')
+    def test_bucket_load_encounters_access_exception(self):
+        self.client.list_buckets.side_effect = ClientError(
+            {'Error':
+             {'Code': 'AccessDenied',
+              'Message': 'Access Denied'}},
+            'ListBuckets')
         inject.bucket_load(self.resource)
         self.assertEqual(self.resource.meta.data, {})
+
+    def test_bucket_load_encounters_other_exception(self):
+        self.client.list_buckets.side_effect = ClientError(
+            {'Error':
+             {'Code': 'ExpiredToken',
+              'Message': 'The provided token has expired.'}},
+            'ListBuckets')
+        with self.assertRaises(ClientError):
+            inject.bucket_load(self.resource)
 
 class TestBucketTransferMethods(unittest.TestCase):
 


### PR DESCRIPTION
This will cause it to no longer raise an exception if the bucket can't be found via ListBuckets (#1063). This means that the creation_date attribute will return None in some cases, but the Bucket resource is straight up unusable in those cases right now. Should I update the `creation_date` attribute description in botocore to note this?