### PR TITLE
Support posargs to tox

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ the ``pip install boto3`` defined above:
 Running Tests
 ~~~~~~~~~~~~~
 You can run tests in all supported Python versions using ``tox``. By default,
-it will run all of the unit tests, but you can also specify your own
+it will run all of the unit and functional tests, but you can also specify your own
 ``nosetests`` options. Note that this requires that you have all supported
 versions of Python installed, otherwise you must pass ``-e`` or run the
 ``nosetests`` command directly:
@@ -96,8 +96,8 @@ versions of Python installed, otherwise you must pass ``-e`` or run the
 .. code-block:: sh
 
     $ tox
-    $ tox tests/unit/test_session.py
-    $ tox -e py26,py33 tests/integration
+    $ tox -- unit/test_session.py
+    $ tox -e py26,py33 -- integration/
 
 You can also run individual tests with your default Python version:
 

--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -4,7 +4,7 @@
 # binary package not from the CWD.
 
 import os
-from optparse import OptionParser
+import sys
 from subprocess import check_call
 
 _dname = os.path.dirname
@@ -12,15 +12,10 @@ _dname = os.path.dirname
 REPO_ROOT = _dname(_dname(_dname(os.path.abspath(__file__))))
 os.chdir(os.path.join(REPO_ROOT, 'tests'))
 
-
-def run(command):
-    return check_call(command, shell=True)
-
-
-_, args = OptionParser(usage="%prog TEST_DIR ...").parse_args()
+args = sys.argv[1:]
 if not args:
     args = ['unit/', 'functional/']
-test_dirs = ' '.join('"%s"' % arg for arg in args)
 
-run('nosetests --with-coverage --cover-erase --cover-package boto3 '
-    '--with-xunit --cover-xml -v ' + test_dirs)
+check_call(['nosetests', '--with-coverage', '--cover-erase',
+            '--cover-package', 'boto3', '--with-xunit', '--cover-xml',
+            '-v'] + args)

--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -4,6 +4,7 @@
 # binary package not from the CWD.
 
 import os
+from optparse import OptionParser
 from subprocess import check_call
 
 _dname = os.path.dirname
@@ -16,5 +17,10 @@ def run(command):
     return check_call(command, shell=True)
 
 
+_, args = OptionParser(usage="%prog TEST_DIR ...").parse_args()
+if not args:
+    args = ['unit/', 'functional/']
+test_dirs = ' '.join('"%s"' % arg for arg in args)
+
 run('nosetests --with-coverage --cover-erase --cover-package boto3 '
-    '--with-xunit --cover-xml -v unit/ functional/')
+    '--with-xunit --cover-xml -v ' + test_dirs)

--- a/tox.ini
+++ b/tox.ini
@@ -8,4 +8,4 @@ skipsdist = True
 [testenv]
 commands =
     {toxinidir}/scripts/ci/install
-    {toxinidir}/scripts/ci/run-tests
+    {toxinidir}/scripts/ci/run-tests {posargs}


### PR DESCRIPTION
Currently tox will always run all tests, which contradicts the README.