### PR TITLE
Set ContentType header based on file extension when possible

### DIFF
--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -122,6 +122,8 @@ transfer.  For example:
 
 
 """
+import mimetypes
+
 from botocore.exceptions import ClientError
 from botocore.compat import six
 from s3transfer.exceptions import RetriesExceededError as \
@@ -267,6 +269,12 @@ class S3Transfer(object):
         """
         if not isinstance(filename, six.string_types):
             raise ValueError('Filename must be a string')
+
+        if (extra_args is None or not extra_args.has_key('ContentType')):
+            guessed_mimetype = mimetypes.guess_type(key)[0]
+            if guessed_mimetype:
+                extra_args = extra_args or {}
+                extra_args['ContentType'] = guessed_mimetype
 
         subscribers = self._get_subscribers(callback)
         future = self._manager.upload(

--- a/docs/source/guide/s3.rst
+++ b/docs/source/guide/s3.rst
@@ -148,7 +148,7 @@ on the given key.
 
 All valid ``ExtraArgs`` are listed at :py:attr:`boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS`
 
-To track the progess of a transfer, a progress callback can be provided such
+To track the progress of a transfer, a progress callback can be provided such
 that the callback gets invoked each time progress is made on the transfer::
 
     import os

--- a/docs/source/guide/s3.rst
+++ b/docs/source/guide/s3.rst
@@ -136,6 +136,15 @@ To set custom or multiple ACLs::
         }
     )
 
+To set custom ContentType::
+
+    s3.upload_file(
+        'tmp.txt', 'bucket-name', 'key-name',
+        ExtraArgs={'ContentType': 'text/plain'}
+    )
+
+Otherwise, the ``mimetypes`` library will be used to guess the ContentType based
+on the given key.
 
 All valid ``ExtraArgs`` are listed at :py:attr:`boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS`
 


### PR DESCRIPTION
This is a signal boost for the request found in issue #548 in pull request form. In short, if we can guess the proper ContentType, do so. Includes doc fix, unit tests, and a trivial typo fix.