### PR TITLE
Fix for MaxKeys kwarg in collection __iter__

### DIFF
--- a/boto3/resources/collection.py
+++ b/boto3/resources/collection.py
@@ -77,7 +77,7 @@ class ResourceCollection(object):
             'key2'
 
         """
-        limit = self._params.get('limit', None)
+        limit = self._params.get('MaxKeys', None)
 
         count = 0
         for page in self.pages():


### PR DESCRIPTION
Potential fix for Issue #1108 

Looks like MaxKeys is ignored by the object iterator.

example code to trigger bug:

```python
import boto3

session = boto3.session.Session()
resource = session.resource('s3', aws_access_key_id=S3_ACCESS_KEY, aws_secret_access_key=S3_SECRET_KEY, endpoint_url=S3_HOST)
bucket = resource.Bucket(S3_BUCKET)
objects = bucket.objects.filter(MaxKeys=10)

for obj in objects:
    print obj.key
```