### PR TITLE
Add test to ensure botocore.UNSIGNED doesn't get corrupted

### DIFF
--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -12,7 +12,9 @@
 # language governing permissions and limitations under the License.
 from tests import unittest
 
+import botocore
 import botocore.stub
+from botocore.config import Config
 from botocore.stub import Stubber
 from botocore.compat import six
 
@@ -531,3 +533,16 @@ class TestS3ObjectSummary(unittest.TestCase):
         # Even though an HeadObject was used to load this, it should
         # only expose the attributes from its shape defined in ListObjects.
         self.assertFalse(hasattr(self.obj_summary, 'content_length'))
+
+
+class TestServiceResource(unittest.TestCase):
+    def setUp(self):
+        self.session = boto3.session.Session()
+
+    def test_unsigned_signature_version_is_not_corrupted(self):
+        config = Config(signature_version=botocore.UNSIGNED)
+        resource = self.session.resource('s3', config=config)
+        self.assertIs(
+            resource.meta.client.meta.config.signature_version,
+            botocore.UNSIGNED
+        )


### PR DESCRIPTION
~Another option would be to muck about with `__deepcopy__` on either `botocore.UNSIGED` or `botocore.Config`, but I'm not sure that's a good idea.~

See boto/botocore#1230 for the fix to the issue. This has been edited to only add a test that verifies the fix.