### PR TITLE
Correct ordering of credential search mechanisms to reflect reality

### DIFF
--- a/docs/source/guide/configuration.rst
+++ b/docs/source/guide/configuration.rst
@@ -40,9 +40,9 @@ The order in which Boto3 searches for credentials is:
 #. Passing credentials as parameters in the ``boto.client()`` method
 #. Passing credentials as parameters when creating a ``Session`` object
 #. Environment variables
+#. Assume Role provider
 #. Shared credential file (``~/.aws/credentials``)
 #. AWS config file (``~/.aws/config``)
-#. Assume Role provider
 #. Boto2 config file (``/etc/boto.cfg`` and ``~/.boto``)
 #. Instance metadata service on an Amazon EC2 instance that has an
    IAM role configured.


### PR DESCRIPTION
The [Credentials Configuration documentation for Boto 3](https://boto3.readthedocs.io/en/latest/guide/configuration.html) incorrectly states the order in which credential mechanisms are tried. Checking out the [botocore source](https://github.com/boto/botocore/blob/725ebd8a14ed74a5bd64221b0b43181daf6bd697/botocore/credentials.py#L59-L82) you can see that the `AssumeRoleProvider` is actually loaded _before_ `SharedCredentialProvider` and `ConfigProvider`, not after. I filed a bug on this in botocore some months ago (boto/botocore#1138), but as that PR has languished for so long I figure it'd at least be nice to have the documentation reflect reality.

For what it's worth, I believe the documentation here is actually in line with [AWS's documentation](https://docs.aws.amazon.com/cli/latest/topic/config-vars.html), and it would be preferable to merge boto/botocore#1138 instead.
