### PR TITLE
Add LifecycleConfiguration resource

### DIFF
--- a/.changes/next-release/enhancement-s3-18350.json
+++ b/.changes/next-release/enhancement-s3-18350.json
@@ -1,0 +1,5 @@
+{
+  "category": "s3",
+  "description": "Add a LifecycleConfiguration resource to resolve issues with the existing Lifecycle resource.",
+  "type": "enhancement"
+}

--- a/boto3/data/s3/2006-03-01/resources-1.json
+++ b/boto3/data/s3/2006-03-01/resources-1.json
@@ -120,6 +120,18 @@
             ]
           }
         },
+        "LifecycleConfiguration": {
+          "resource": {
+            "type": "BucketLifecycleConfiguration",
+            "identifiers": [
+              {
+                "target": "BucketName",
+                "source": "identifier",
+                "name": "Name"
+              }
+            ]
+          }
+        },
         "Logging": {
           "resource": {
             "type": "BucketLogging",
@@ -355,6 +367,67 @@
             "type": "Bucket",
             "identifiers": [
               { "target": "Name", "source": "identifier", "name": "BucketName" }
+            ]
+          }
+        }
+      }
+    },
+    "BucketLifecycleConfiguration": {
+      "identifiers": [
+        {
+          "name": "BucketName"
+        }
+      ],
+      "shape": "GetBucketLifecycleConfigurationOutput",
+      "load": {
+        "request": {
+          "operation": "GetBucketLifecycleConfiguration",
+          "params": [
+            {
+              "target": "Bucket",
+              "source": "identifier",
+              "name": "BucketName"
+            }
+          ]
+        },
+        "path": "@"
+      },
+      "actions": {
+        "Delete": {
+          "request": {
+            "operation": "DeleteBucketLifecycle",
+            "params": [
+              {
+                "target": "Bucket",
+                "source": "identifier",
+                "name": "BucketName"
+              }
+            ]
+          }
+        },
+        "Put": {
+          "request": {
+            "operation": "PutBucketLifecycleConfiguration",
+            "params": [
+              {
+                "target": "Bucket",
+                "source": "identifier",
+                "name": "BucketName"
+              }
+            ]
+          }
+        }
+      },
+      "has": {
+        "Bucket": {
+          "resource": {
+            "type": "Bucket",
+            "identifiers": [
+              {
+                "target": "Name",
+                "source": "identifier",
+                "name": "BucketName"
+              }
             ]
           }
         }


### PR DESCRIPTION
The BucketLifecycle resource uses the old GetBucketLifecycle
operation to load data. That operation only returns a single
transistion, even though there could be multiple transitions in a
single rule. This was fixed up by adding another command to the SDKs,
GetBucketLifecycleConfiguration. A new command was needed due to the
shift between a single object and a list of objects. The same change
is needed for the resource, and requires a new resource for the same
reason we needed a new command.

This adds the BucketLifecycleConfiguration resource in all the same
places that the BucketLifecycle resource existed. The resource itself
is identical in almost every way aside from which operations it
calls.