### PR TITLE
[Feature] Provide __repr__ for dynamodb.conditions type

### DIFF
--- a/boto3/dynamodb/conditions.py
+++ b/boto3/dynamodb/conditions.py
@@ -71,6 +71,9 @@ class AttributeBase(object):
     def __invert__(self):
         raise DynamoDBOperationNotSupportedError('NOT', self)
 
+    def __repr__(self):
+        return '%s(%s)' % (self.__class__.__name__, self.name)
+
     def eq(self, value):
         """Creates a condition where the attribute is equal to the value.
 

--- a/boto3/dynamodb/conditions.py
+++ b/boto3/dynamodb/conditions.py
@@ -43,6 +43,11 @@ class ConditionBase(object):
     def __invert__(self):
         return Not(self)
 
+    def __repr__(self):
+        return self.expression_format.format(
+            *self._values,
+            **{'operator': self.expression_operator})
+
     def get_expression(self):
         return {'format': self.expression_format,
                 'operator': self.expression_operator,

--- a/tests/unit/dynamodb/test_conditions.py
+++ b/tests/unit/dynamodb/test_conditions.py
@@ -110,7 +110,7 @@ class TestA(TestK):
                          AttributeType(self.attr, self.value))
 
 
-class TestKRepr(unittest.TestCase):
+class TestRepr(unittest.TestCase):
     def setUp(self):
         self.var_name = 'mykey'
         self.value = 'foo'

--- a/tests/unit/dynamodb/test_conditions.py
+++ b/tests/unit/dynamodb/test_conditions.py
@@ -110,6 +110,20 @@ class TestA(TestK):
                          AttributeType(self.attr, self.value))
 
 
+class TestKRepr(unittest.TestCase):
+    def setUp(self):
+        self.var_name = 'mykey'
+        self.value = 'foo'
+
+    def test_key_repr(self):
+        self.assertEqual(
+            repr(Key(self.var_name)), 'Key(%s)' % self.var_name)
+
+    def test_attr_repr(self):
+        self.assertEqual(
+            repr(Attr(self.var_name)), 'Attr(%s)' % self.var_name)
+
+
 class TestConditions(unittest.TestCase):
     def setUp(self):
         self.value = Attr('mykey')

--- a/tests/unit/dynamodb/test_conditions.py
+++ b/tests/unit/dynamodb/test_conditions.py
@@ -123,6 +123,24 @@ class TestKRepr(unittest.TestCase):
         self.assertEqual(
             repr(Attr(self.var_name)), 'Attr(%s)' % self.var_name)
 
+    def test_key_eq_value(self):
+        self.assertEqual(
+            repr(Equals(Key(self.var_name), self.value)),
+            repr(Key(self.var_name).eq(self.value)))
+
+        self.assertEqual(
+            repr(Equals(Key(self.var_name), self.value)),
+            'Key(%s) = %s' % (self.var_name, self.value))
+
+    def test_attr_eq_value(self):
+        self.assertEqual(
+            repr(Equals(Attr(self.var_name), self.value)),
+            repr(Attr(self.var_name).eq(self.value)))
+
+        self.assertEqual(
+            repr(Equals(Attr(self.var_name), self.value)),
+            'Attr(%s) = %s' % (self.var_name, self.value))
+
 
 class TestConditions(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
#1202 
Providing more meaningful repr for attr and condition object.

```python
>>> Key('var')
Key(var)
>>> Equals(Key('var'), 1)
Key(var) = 1
>>>
```