### PR TITLE
Avoid noisy logging on INFO level.

### DIFF
--- a/boto3/resources/collection.py
+++ b/boto3/resources/collection.py
@@ -147,7 +147,7 @@ class ResourceCollection(object):
         # page in a list. For non-paginated results, we just ignore
         # the page size parameter.
         if client.can_paginate(self._py_operation_name):
-            logger.info('Calling paginated %s:%s with %r',
+            logger.debug('Calling paginated %s:%s with %r',
                         self._parent.meta.service_name,
                         self._py_operation_name, params)
             paginator = client.get_paginator(self._py_operation_name)
@@ -155,7 +155,7 @@ class ResourceCollection(object):
                 PaginationConfig={
                     'MaxItems': limit, 'PageSize': page_size}, **params)
         else:
-            logger.info('Calling %s:%s with %r',
+            logger.debug('Calling %s:%s with %r',
                         self._parent.meta.service_name,
                         self._py_operation_name, params)
             pages = [getattr(client, self._py_operation_name)(**params)]


### PR DESCRIPTION
Log about called API on `DEBUG` level, but not `INFO`.
Logging such things for every operation, which can be hundreds per second, as `INFO` is a noisy trash in the logs and even an unnecessary information.

See also boto/botocore#1257