### PR TITLE
Fix typo in doc guide ec2-example-managing-instances

### DIFF
--- a/docs/source/guide/ec2-example-managing-instances.rst
+++ b/docs/source/guide/ec2-example-managing-instances.rst
@@ -167,7 +167,7 @@ Example
             if 'DryRunOperation' not in str(e):
                 raise
 
-        # Dry run succeeded, call stop_instances witout dryrun
+        # Dry run succeeded, call stop_instances without dryrun
         try:
             response = ec2.stop_instances(InstanceIds=[instance_id], DryRun=False)
             print(response)


### PR DESCRIPTION
witout to without