### PR TITLE
Improved Error message for issue #1298

### DIFF
--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -278,7 +278,10 @@ class S3Transfer(object):
         # ever thrown for upload_parts but now can be thrown for any related
         # client error.
         except ClientError as e:
-            metadata = extra_args.get('Metadata', {})
+            if extra_args is not None:
+                metadata = extra_args.get('Metadata', {})
+            else:
+                metadata = {}
             if len(set(f.lower() for f in metadata)) != len(metadata):
                 raise S3UploadFailedError(
                     "Failed to upload %s to %s: Metadata may have "

--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -278,9 +278,16 @@ class S3Transfer(object):
         # ever thrown for upload_parts but now can be thrown for any related
         # client error.
         except ClientError as e:
-            raise S3UploadFailedError(
-                "Failed to upload %s to %s: %s" % (
-                    filename, '/'.join([bucket, key]), e))
+            metadata = extra_args.get('Metadata', {})
+            if len(set(f.lower() for f in metadata)) != len(metadata):
+                raise S3UploadFailedError(
+                    "Failed to upload %s to %s: Metadata may have "
+                    "duplicate keys differing only in case: %s" % (
+                        filename, '/'.join([bucket, key]), e))
+            else:
+                raise S3UploadFailedError(
+                    "Failed to upload %s to %s: %s" % (
+                        filename, '/'.join([bucket, key]), e))
 
     def download_file(self, bucket, key, filename, extra_args=None,
                       callback=None):

--- a/tests/unit/s3/test_transfer.py
+++ b/tests/unit/s3/test_transfer.py
@@ -157,6 +157,17 @@ class TestS3Transfer(unittest.TestCase):
         with self.assertRaises(S3UploadFailedError):
             self.transfer.upload_file('smallfile', 'bucket', 'key')
 
+    def test_propogation_s3_upload_failed_error_with_metadata(self):
+        future = mock.Mock()
+        future.result.side_effect = ClientError({'Error': {}}, 'op_name')
+        self.manager.upload.return_value = future
+        with self.assertRaisesRegexp(S3UploadFailedError,
+                                     "Metadata may have duplicate "
+                                     "keys differing only in case"):
+            self.transfer.upload_file(
+                'smallfile', 'bucket', 'key',
+                extra_args={'Metadata': {'a': 1, 'A': 1}})
+
     def test_can_create_with_just_client(self):
         transfer = S3Transfer(client=mock.Mock())
         self.assertIsInstance(transfer, S3Transfer)


### PR DESCRIPTION
Added a more specific error message when included metadata has collisions due to differing case in the keys.