### PR TITLE
Allow recent Sphinx versions

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,3 @@
-Sphinx>=1.1.3,<1.3
+Sphinx>=1.1.3,<1.7
 guzzle_sphinx_theme>=0.7.10,<0.8
 -rrequirements.txt


### PR DESCRIPTION
Bump upper boundary of allowed version of Shpinx to 1.7.

requirements-docs.txt (which hasn't been updated since 2015) declares
that Sphinx of version older than 1.3 should be used. However, Sphinx
1.6.5 builds docs successfully.