### PR TITLE
Update s3 transfer reference docs 

### DIFF
--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -264,6 +264,10 @@ class S3Transfer(object):
 
         Variants have also been injected into S3 client, Bucket and Object.
         You don't have to use S3Transfer.upload_file() directly.
+
+        .. seealso::
+            :py:meth:`S3.Client.upload_file`
+            :py:meth:`S3.Client.upload_fileobj`
         """
         if not isinstance(filename, six.string_types):
             raise ValueError('Filename must be a string')
@@ -288,6 +292,10 @@ class S3Transfer(object):
 
         Variants have also been injected into S3 client, Bucket and Object.
         You don't have to use S3Transfer.download_file() directly.
+
+        .. seealso::
+            :py:meth:`S3.Client.download_file`
+            :py:meth:`S3.Client.download_fileobj`
         """
         if not isinstance(filename, six.string_types):
             raise ValueError('Filename must be a string')

--- a/docs/source/reference/customizations/s3.rst
+++ b/docs/source/reference/customizations/s3.rst
@@ -13,7 +13,16 @@ S3 Transfers
    exposed to breaking changes. If a class from the ``boto3.s3.transfer``
    module is not documented below, it is considered internal and users
    should be very cautious in directly using them because breaking changes may
-   be introduced from version to version of the library.
+   be introduced from version to version of the library. It is recommended to
+   use the variants of the transfer functions injected into the S3 client
+   instead.
+
+   .. seealso::
+      :py:meth:`S3.Client.upload_file`
+      :py:meth:`S3.Client.upload_fileobj`
+      :py:meth:`S3.Client.download_file`
+      :py:meth:`S3.Client.download_fileobj`
+
 
 
 .. autoclass:: boto3.s3.transfer.TransferConfig


### PR DESCRIPTION
This updates the s3 transfer reference docs to have see also links to the versions injected into the s3 client.