### PR TITLE
Update s3 glacier example

### DIFF
--- a/boto3/examples/s3.rst
+++ b/boto3/examples/s3.rst
@@ -52,7 +52,7 @@ restoration is finished.
             # request.
             if obj.restore is None:
                 print('Submitting restoration request: %s' % obj.key)
-                obj.restore_object()
+                obj.restore_object(RestoreRequest={'Days': 1})
             # Print out objects whose restoration is on-going
             elif 'ongoing-request="true"' in obj.restore:
                 print('Restoration in-progress: %s' % obj.key)


### PR DESCRIPTION
The `restore_object` operation doesn't work when no arguments are provided, this updates the example to include a minimal request.