### PR TITLE
Add example on how to disable signing of requests

### DIFF
--- a/boto3/examples/s3.rst
+++ b/boto3/examples/s3.rst
@@ -14,6 +14,18 @@ the objects in the bucket.
         print(obj.key)
 
 
+To disable signing of requests (therefore allowing "anonymous" access) you can
+do:
+
+.. code-block:: python
+
+    import boto3
+
+    from botocore.handlers import disable_signing
+    s3 = boto3.resource('s3')
+    s3.meta.client.meta.events.register('choose-signer.s3.*', disable_signing)
+
+
 List top-level common prefixes in Amazon S3 bucket
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This is is taken from: https://github.com/boto/boto3/issues/134#issuecomment-116766812.

It seems like a fairly common pitfall, that deserves a prominently shown example.