### PR TITLE
Give Binary a __bytes__ interface

### DIFF
--- a/.changes/next-release/enhancement-DynamoDB-97758.json
+++ b/.changes/next-release/enhancement-DynamoDB-97758.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "DynamoDB",
+  "description": "Add a `__bytes__` method to the `Binary` DynamoDB type."
+}

--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ docs/source/.vs
 
 # Project-specific
 .doctrees
+
 source/_build

--- a/boto3/dynamodb/types.py
+++ b/boto3/dynamodb/types.py
@@ -65,6 +65,9 @@ class Binary(object):
     def __str__(self):
         return self.value
 
+    def __bytes__(self):
+        return self.value
+
     def __hash__(self):
         return hash(self.value)
 

--- a/tests/unit/dynamodb/test_types.py
+++ b/tests/unit/dynamodb/test_types.py
@@ -49,6 +49,9 @@ class TestBinary(unittest.TestCase):
     def test_str(self):
         self.assertEqual(Binary(b'\x01').__str__(), b'\x01')
 
+    def test_bytes(self):
+        self.assertEqual(bytes(Binary(b'\x01')), b'\x01')
+
     def test_repr(self):
         self.assertIn('Binary', repr(Binary(b'1')))
 


### PR DESCRIPTION
The `boto3.dynamodb.types.Binary` class is meant to make it easier to work with values across Python 2/3, but it lacks a `bytes` interface, which makes working with it sanely in Python 3 difficult, requiring special custom logic for `Binary`. By providing a `bytes` interface, we can just treat `Binary` objects as any other `bytes`-like object.

Also, adding pyenv config to `.gitignore` to make things easier for anyone using pyenv.