### PR TITLE
Vpcendpoint as resource

### DIFF
--- a/boto3/data/ec2/2016-11-15/resources-1.json
+++ b/boto3/data/ec2/2016-11-15/resources-1.json
@@ -142,6 +142,16 @@
           "path": "VpcPeeringConnection"
         }
       },
+      "CreateVpcEndpoint": {
+        "request": { "operation": "CreateVpcEndpoint" },
+        "resource": {
+          "type": "VpcEndpoint",
+          "identifiers": [
+            { "target": "Id", "source": "response", "path": "VpcEndpoint.VpcEndpointId" }
+          ],
+          "path": "VpcEndpoint"
+        }
+      },
       "DisassociateRouteTable": {
         "request": { "operation": "DisassociateRouteTable" }
       },
@@ -288,6 +298,14 @@
       "VpcPeeringConnection": {
         "resource": {
           "type": "VpcPeeringConnection",
+          "identifiers": [
+            { "target": "Id", "source": "input" }
+          ]
+        }
+      },
+      "VpcEndpoint": {
+        "resource": {
+          "type": "VpcEndpoint",
           "identifiers": [
             { "target": "Id", "source": "input" }
           ]
@@ -475,6 +493,16 @@
             { "target": "Id", "source": "response", "path": "Vpcs[].VpcId" }
           ],
           "path": "Vpcs[]"
+        }
+      },
+      "VpcEndpoints": {
+        "request": {"operation": "DescribeVpcEndpoints"},
+        "resource": {
+          "type": "VpcEndpoint",
+          "identifiers": [
+            { "target": "Id", "source": "response", "path": "VpcEndpoints[].VpcEndpointId" }
+          ],
+          "path": "VpcEndpoints[]"
         }
       }
     }
@@ -2144,6 +2172,21 @@
             ]
           }
         },
+        "CreateVpcEndpoint": {
+          "request": {
+            "operation": "CreateVpcEndpoint",
+            "params": [
+              { "target": "VpcId", "source": "identifier", "name": "Id" }
+            ]
+          },
+          "resource": {
+            "type": "VpcEndpoint",
+            "identifiers": [
+              { "target": "Id", "source": "response", "path": "VpcEndpoint.VpcEndpointId" }
+            ],
+            "path": "VpcEndpoint"
+          }
+        },
         "CreateNetworkAcl": {
           "request": {
             "operation": "CreateNetworkAcl",
@@ -2460,6 +2503,22 @@
             "path": "Subnets[]"
           }
         }
+      },
+      "VpcEndpoints": {
+        "request": {
+          "operation": "DescribeVpcEndpoints",
+         "params": [
+            { "target": "Filters[0].Name", "source": "string", "value": "vpc-id" },
+            { "target": "Filters[0].Values[0]", "source": "identifier", "name": "Id" }
+          ]
+        },
+        "resource": {
+          "type": "VpcEndpoint",
+          "identifiers": [
+            { "target": "Id", "source": "response", "path": "VpcEndpoints[].VpcEndpointId" }
+          ],
+          "path": "VpcEndpoints[]"
+        }
       }
     },
     "VpcPeeringConnection": {
@@ -2528,6 +2587,50 @@
             "type": "Vpc",
             "identifiers": [
               { "target": "Id", "source": "data", "path": "RequesterVpcInfo.VpcId" }
+            ]
+          }
+        }
+      }
+    },
+    "VpcEndpoint": {
+      "identifiers": [
+        {
+          "name": "Id",
+          "memberName": "VpcEndpointId"
+        }
+      ],
+      "shape": "VpcEndpoint",
+      "load": {
+        "request": {
+          "operation": "DescribeVpcEndpoints",
+          "params": [
+            { "target": "VpcEndpointIds[0]", "source": "identifier", "name": "Id" }
+          ]
+        },
+        "path": "VpcEndpoints[0]"
+      },
+      "actions": {
+        "Create": {
+          "request": {
+            "operation": "CreateVpcEndpoint",
+            "params": [
+              { "target": "VpcEndpointId", "source": "identifier", "name": "Id" }
+            ]
+          }
+        },
+        "Delete": {
+          "request": {
+            "operation": "DeleteVpcEndpoints",
+            "params": [
+              { "target": "VpcEndpointIds", "source": "identifier", "name": "Id" }
+            ]
+          }
+        },
+        "Modify": {
+          "request": {
+            "operation": "ModifyVpcEndpoint",
+            "params": [
+              { "target": "VpcEndpointId", "source": "identifier", "name": "Id" }
             ]
           }
         }

--- a/tests/unit/ec2/test_vpcendpoint_resource.py
+++ b/tests/unit/ec2/test_vpcendpoint_resource.py
@@ -1,0 +1,193 @@
+import boto3
+import json
+import uuid
+import unittest
+from botocore.exceptions import ClientError
+from botocore.stub import Stubber
+import datetime
+
+def mock_endpoints(region='us-east-1', endpoint_services=['s3', 's3', 's3', 'dynamodb', 'elb']):
+    endpoints = []
+    for service in endpoint_services:
+        endpoints.append({
+            'VpcEndpointId': 'vpce-{}'.format(str(uuid.uuid4())[0:8]),
+            'VpcEndpointType': 'Gateway',  # Interface
+            'VpcId': 'vpc-{}'.format(str(uuid.uuid4())[0:8]),
+            'ServiceName': 'com.amazonaws.{}.{}'.format(region, service),
+            'State': 'Available',
+            'PolicyDocument': json.dumps({
+                'Version': '2008-10-17',
+                'Statement': [
+                    {
+                        'Effect': 'Allow',
+                        'Principal': '*',
+                        'Action': '*',
+                        'Resource': '*'
+                    }
+                ]}),
+            'RouteTableIds': [
+                'rtb-{}'.format(str(uuid.uuid4())[0:8])
+            ],
+            'SubnetIds': [],
+            'Groups': [
+                {
+                    'GroupId': 'string',
+                    'GroupName': 'string'
+                }
+            ],
+            'PrivateDnsEnabled': False,
+            'DnsEntries': [
+                {
+                    'DnsName': 'string',
+                    'HostedZoneId': 'string'
+                },
+            ],
+            'NetworkInterfaceIds': ['string'],
+            'CreationTimestamp': '1952-03-11T12:29:42Z'
+        })
+
+    return {"VpcEndpoints": endpoints}
+
+
+def mock_create_vpc_endpoint():
+        return {
+            'VpcEndpoint': {
+                'VpcId': 'vpc-2cafad42',
+                'PolicyDocument': '{\"Version\":\"2008-10-17\",\"Statement\":[{\"Effect\":\"Allow\",'
+                                  '\"Principal\":\"*\",\"Action\":\"*\",\"Resource\":\"*\"}]}',
+                'NetworkInterfaceIds': [],
+                'SubnetIds': [],
+                'PrivateDnsEnabled': False,
+                'State': 'available',
+                'ServiceName': 'com.amazonaws.us-east-1.s3',
+                'RouteTableIds': [],
+                'Groups': [],
+                'VpcEndpointId': 'vpce-14998642',
+                'VpcEndpointType': 'Gateway',
+                'CreationTimestamp': '14-03-2018T02:42:42Z',
+                'DnsEntries': []
+            }
+        }
+
+def mock_delete_vpc_endpoint(vpc_endpoint_id, failed=False):
+    if not failed:
+        return {'Unsuccessful': []}
+    else:
+        return {'Unsuccessful': [
+            {
+                'Error': {
+                    'Code': 'InvalidVpcEndpoint.NotFound',
+                    'Message': ''  # Message doesnt show up in REAL vpce.delete() API Call, but required by stubber!
+                },
+                'ResourceId': vpc_endpoint_id
+            }
+        ]}
+
+class TestVPCEndpoints(unittest.TestCase):
+
+    def setUp(self):
+        self.session = boto3.session.Session(region_name='us-east-1')
+        self.service_resource = self.session.resource('ec2')
+
+    def test_get_endpoint(self):
+        expected_endpoints = mock_endpoints(endpoint_services=['s3'])
+        endpoint_id = expected_endpoints['VpcEndpoints'][0]['VpcEndpointId']
+        with Stubber(self.service_resource.meta.client) as stubber:
+            stubber.add_response('describe_vpc_endpoints', expected_endpoints)
+            response = self.service_resource.VpcEndpoint(endpoint_id)
+            self.assertEqual(response.vpc_id, expected_endpoints['VpcEndpoints'][0]['VpcId'])
+            self.assertEqual(response.service_name, expected_endpoints['VpcEndpoints'][0]['ServiceName'])
+            self.assertEqual(response.vpc_endpoint_id, expected_endpoints['VpcEndpoints'][0]['VpcEndpointId'])
+            stubber.assert_no_pending_responses()
+
+    def test_get_endpoint_not_found(self):
+        with Stubber(self.service_resource.meta.client) as stubber:
+            stubber.add_client_error('describe_vpc_endpoints',
+                                     service_error_code='InvalidVpcEndpointId.NotFound',
+                                     service_message="The Vpc Endpoint Id 'vpce-babababa' does not exist",
+                                     http_status_code=400)
+
+            with self.assertRaises(ClientError) as ex:
+                response = self.service_resource.VpcEndpoint('vpce-babababa')
+                vpc_endpoint_service_name = response.service_name
+                stubber.assert_no_pending_responses()
+            self.assertEqual(
+                    str(ex.exception),
+                    "An error occurred (InvalidVpcEndpointId.NotFound) when calling the DescribeVpcEndpoints "
+                    "operation: The Vpc Endpoint Id 'vpce-babababa' does not exist"
+                )
+            self.assertEqual(ex.exception.response['ResponseMetadata']['HTTPStatusCode'], 400)
+
+    def test_describe_endpoints(self):
+        expected_endpoints = mock_endpoints()
+        with Stubber(self.service_resource.meta.client) as stubber:
+            stubber.add_response('describe_vpc_endpoints', expected_endpoints)
+            response = list(self.service_resource.vpc_endpoints.all())
+            stubber.assert_no_pending_responses()
+
+        self.assertEqual(len(response), len(expected_endpoints['VpcEndpoints']))
+        self.assertEqual(sorted([x.vpc_endpoint_id for x in response]),
+                         sorted([x['VpcEndpointId'] for x in expected_endpoints['VpcEndpoints']]))
+
+    def test_describe_endpoints_filter(self):
+        # Filter doesnt really do anything here in unittests as botocore is doing actual work not boto3
+        expected_endpoints = mock_endpoints(endpoint_services=['dynamodb'])
+        with Stubber(self.service_resource.meta.client) as stubber:
+            stubber.add_response('describe_vpc_endpoints', expected_endpoints)
+            response = list(self.service_resource.vpc_endpoints.filter(
+                Filters=[{'Name': 'service-name', 'Values': ['com.amazonaws.us-east-1.dynamodb']}]
+            ))
+            stubber.assert_no_pending_responses()
+
+        self.assertEqual(response[0].id, expected_endpoints['VpcEndpoints'][0]['VpcEndpointId'])
+        self.assertEqual(response[0].vpc_id, expected_endpoints['VpcEndpoints'][0]['VpcId'])
+        self.assertEqual(response[0].service_name, expected_endpoints['VpcEndpoints'][0]['ServiceName'])
+
+    def test_describe_endpoints_none(self):
+        with Stubber(self.service_resource.meta.client) as stubber:
+            stubber.add_response('describe_vpc_endpoints', {'VpcEndpoints': []})
+            response = list(self.service_resource.vpc_endpoints.filter(
+                Filters=[{'Name': 'service-name', 'Values': ['com.amazonaws.us-east-1.dynamodb']}]
+            ))
+            stubber.assert_no_pending_responses()
+
+        self.assertEqual(response, [])
+
+    def test_create_endpoint(self):
+        expected_response = mock_create_vpc_endpoint()
+        with Stubber(self.service_resource.meta.client) as stubber:
+            stubber.add_response('create_vpc_endpoint', expected_response)
+            response = self.service_resource.create_vpc_endpoint(VpcId='vpc-2fefad42',
+                                                                 ServiceName='com.amazonaws.us-east-1.s3')
+            stubber.assert_no_pending_responses()
+
+        self.assertEqual(response.vpc_endpoint_id, expected_response['VpcEndpoint']['VpcEndpointId'])
+        self.assertEqual(response.vpc_id, expected_response['VpcEndpoint']['VpcId'])
+        self.assertEqual(response.service_name, expected_response['VpcEndpoint']['ServiceName'])
+
+    def test_delete_endpoint(self):
+        expected_response1 = mock_endpoints(endpoint_services=['s3'])
+        expected_response2 = mock_delete_vpc_endpoint(expected_response1['VpcEndpoints'][0]['VpcEndpointId'])
+        with Stubber(self.service_resource.meta.client) as stubber:
+            stubber.add_response('describe_vpc_endpoints', expected_response1)
+            stubber.add_response('delete_vpc_endpoints', expected_response2)
+            endpoint = self.service_resource.VpcEndpoint(expected_response1['VpcEndpoints'][0]['VpcEndpointId'])
+            service_name = endpoint.service_name  # dequeue stubber - list would do this for iterators.
+            self.assertEqual(service_name, expected_response1['VpcEndpoints'][0]['ServiceName'])
+            response = endpoint.delete(VpcEndpointIds=[endpoint.vpc_endpoint_id])
+            stubber.assert_no_pending_responses()
+
+        self.assertEqual(response['Unsuccessful'], [])
+
+    def test_delete_endpoint_not_found_error(self):
+        expected_response1 = mock_endpoints(endpoint_services=['s3'])
+        expected_response2 = mock_delete_vpc_endpoint('vpce-babababa', True)
+        with Stubber(self.service_resource.meta.client) as stubber:
+            stubber.add_response('describe_vpc_endpoints', expected_response1)
+            endpoint = self.service_resource.VpcEndpoint(expected_response1['VpcEndpoints'][0]['VpcEndpointId'])
+            service_name = endpoint.service_name  # need this to dequeue stubber
+            stubber.add_response('delete_vpc_endpoints', expected_response2)
+            response = endpoint.delete(VpcEndpointIds=['vpce-babababa'])
+            stubber.assert_no_pending_responses()
+
+        self.assertEqual(response, mock_delete_vpc_endpoint('vpce-babababa', True))

--- a/tests/unit/ec2/test_vpcendpoint_resource.py
+++ b/tests/unit/ec2/test_vpcendpoint_resource.py
@@ -4,9 +4,11 @@ import uuid
 import unittest
 from botocore.exceptions import ClientError
 from botocore.stub import Stubber
-import datetime
 
-def mock_endpoints(region='us-east-1', endpoint_services=['s3', 's3', 's3', 'dynamodb', 'elb']):
+
+def mock_endpoints(region='us-east-1',
+                   endpoint_services=['s3', 's3', 's3', 'dynamodb', 'elb']):
+
     endpoints = []
     for service in endpoint_services:
         endpoints.append({
@@ -53,8 +55,17 @@ def mock_create_vpc_endpoint():
         return {
             'VpcEndpoint': {
                 'VpcId': 'vpc-2cafad42',
-                'PolicyDocument': '{\"Version\":\"2008-10-17\",\"Statement\":[{\"Effect\":\"Allow\",'
-                                  '\"Principal\":\"*\",\"Action\":\"*\",\"Resource\":\"*\"}]}',
+                'PolicyDocument': json.dumps({
+                    'Version': '2008-10-17',
+                    'Statement': [
+                        {
+                            'Effect': 'Allow',
+                            'Principal': '*',
+                            'Action': '*',
+                            'Resource': '*'
+                        }
+                    ]
+                }),
                 'NetworkInterfaceIds': [],
                 'SubnetIds': [],
                 'PrivateDnsEnabled': False,
@@ -69,6 +80,7 @@ def mock_create_vpc_endpoint():
             }
         }
 
+
 def mock_delete_vpc_endpoint(vpc_endpoint_id, failed=False):
     if not failed:
         return {'Unsuccessful': []}
@@ -77,117 +89,139 @@ def mock_delete_vpc_endpoint(vpc_endpoint_id, failed=False):
             {
                 'Error': {
                     'Code': 'InvalidVpcEndpoint.NotFound',
-                    'Message': ''  # Message doesnt show up in REAL vpce.delete() API Call, but required by stubber!
+                    # noqa: E501 - Message doesnt show up in REAL vpce.delete() API Call, but required by stubber!
+                    'Message': ''
                 },
                 'ResourceId': vpc_endpoint_id
             }
         ]}
 
+
 class TestVPCEndpoints(unittest.TestCase):
 
     def setUp(self):
         self.session = boto3.session.Session(region_name='us-east-1')
-        self.service_resource = self.session.resource('ec2')
+        self.resource = self.session.resource('ec2')
 
     def test_get_endpoint(self):
         expected_endpoints = mock_endpoints(endpoint_services=['s3'])
-        endpoint_id = expected_endpoints['VpcEndpoints'][0]['VpcEndpointId']
-        with Stubber(self.service_resource.meta.client) as stubber:
+        vpc_endpoints = expected_endpoints['VpcEndpoints'][0]
+        endpoint_id = vpc_endpoints['VpcEndpointId']
+
+        with Stubber(self.resource.meta.client) as stubber:
             stubber.add_response('describe_vpc_endpoints', expected_endpoints)
-            response = self.service_resource.VpcEndpoint(endpoint_id)
-            self.assertEqual(response.vpc_id, expected_endpoints['VpcEndpoints'][0]['VpcId'])
-            self.assertEqual(response.service_name, expected_endpoints['VpcEndpoints'][0]['ServiceName'])
-            self.assertEqual(response.vpc_endpoint_id, expected_endpoints['VpcEndpoints'][0]['VpcEndpointId'])
+            r = self.resource.VpcEndpoint(endpoint_id)
+            self.assertEqual(r.vpc_id, vpc_endpoints['VpcId'])
+            self.assertEqual(r.service_name, vpc_endpoints['ServiceName'])
+            self.assertEqual(r.vpc_endpoint_id, vpc_endpoints['VpcEndpointId'])
             stubber.assert_no_pending_responses()
 
     def test_get_endpoint_not_found(self):
-        with Stubber(self.service_resource.meta.client) as stubber:
-            stubber.add_client_error('describe_vpc_endpoints',
-                                     service_error_code='InvalidVpcEndpointId.NotFound',
-                                     service_message="The Vpc Endpoint Id 'vpce-babababa' does not exist",
-                                     http_status_code=400)
+        with Stubber(self.resource.meta.client) as stubber:
+            stubber.add_client_error(
+                'describe_vpc_endpoints',
+                service_error_code='InvalidVpcEndpointId.NotFound',
+                service_message="The Vpc Endpoint Id 'vpce-babababa' does not exist",  # noqa E501
+                http_status_code=400
+            )
 
             with self.assertRaises(ClientError) as ex:
-                response = self.service_resource.VpcEndpoint('vpce-babababa')
-                vpc_endpoint_service_name = response.service_name
+                r = self.resource.VpcEndpoint('vpce-babababa')
+                vpce_service_name = r.service_name  # noqa: F841 E501 - force dequeue of stubber
                 stubber.assert_no_pending_responses()
             self.assertEqual(
                     str(ex.exception),
-                    "An error occurred (InvalidVpcEndpointId.NotFound) when calling the DescribeVpcEndpoints "
-                    "operation: The Vpc Endpoint Id 'vpce-babababa' does not exist"
+                    "An error occurred (InvalidVpcEndpointId.NotFound) when "
+                    "calling the DescribeVpcEndpoints operation: The Vpc "
+                    "Endpoint Id 'vpce-babababa' does not exist"
                 )
-            self.assertEqual(ex.exception.response['ResponseMetadata']['HTTPStatusCode'], 400)
+            self.assertEqual(ex.exception.response['ResponseMetadata']['HTTPStatusCode'], 400)  # noqa E501
 
     def test_describe_endpoints(self):
         expected_endpoints = mock_endpoints()
-        with Stubber(self.service_resource.meta.client) as stubber:
+
+        with Stubber(self.resource.meta.client) as stubber:
             stubber.add_response('describe_vpc_endpoints', expected_endpoints)
-            response = list(self.service_resource.vpc_endpoints.all())
+            r = list(self.resource.vpc_endpoints.all())
             stubber.assert_no_pending_responses()
 
-        self.assertEqual(len(response), len(expected_endpoints['VpcEndpoints']))
-        self.assertEqual(sorted([x.vpc_endpoint_id for x in response]),
-                         sorted([x['VpcEndpointId'] for x in expected_endpoints['VpcEndpoints']]))
+        self.assertEqual(len(r), len(expected_endpoints['VpcEndpoints']))
+        self.assertEqual(
+            sorted([x.vpc_endpoint_id for x in r]),
+            sorted([x['VpcEndpointId'] for x in expected_endpoints['VpcEndpoints']])   # noqa E501
+        )
 
     def test_describe_endpoints_filter(self):
-        # Filter doesnt really do anything here in unittests as botocore is doing actual work not boto3
+        # noqa E501 - Filter doesnt really do anything here in unittests as botocore is doing actual work not boto3
         expected_endpoints = mock_endpoints(endpoint_services=['dynamodb'])
-        with Stubber(self.service_resource.meta.client) as stubber:
+        vpc_endpoints = expected_endpoints['VpcEndpoints'][0]
+
+        with Stubber(self.resource.meta.client) as stubber:
             stubber.add_response('describe_vpc_endpoints', expected_endpoints)
-            response = list(self.service_resource.vpc_endpoints.filter(
-                Filters=[{'Name': 'service-name', 'Values': ['com.amazonaws.us-east-1.dynamodb']}]
+            r = list(self.resource.vpc_endpoints.filter(
+                Filters=[{'Name': 'service-name',
+                          'Values': ['com.amazonaws.us-east-1.dynamodb']}]
             ))
             stubber.assert_no_pending_responses()
 
-        self.assertEqual(response[0].id, expected_endpoints['VpcEndpoints'][0]['VpcEndpointId'])
-        self.assertEqual(response[0].vpc_id, expected_endpoints['VpcEndpoints'][0]['VpcId'])
-        self.assertEqual(response[0].service_name, expected_endpoints['VpcEndpoints'][0]['ServiceName'])
+        self.assertEqual(r[0].id, vpc_endpoints['VpcEndpointId'])
+        self.assertEqual(r[0].vpc_id, vpc_endpoints['VpcId'])
+        self.assertEqual(r[0].service_name, vpc_endpoints['ServiceName'])
 
     def test_describe_endpoints_none(self):
-        with Stubber(self.service_resource.meta.client) as stubber:
-            stubber.add_response('describe_vpc_endpoints', {'VpcEndpoints': []})
-            response = list(self.service_resource.vpc_endpoints.filter(
-                Filters=[{'Name': 'service-name', 'Values': ['com.amazonaws.us-east-1.dynamodb']}]
+        with Stubber(self.resource.meta.client) as stubber:
+            stubber.add_response('describe_vpc_endpoints', {'VpcEndpoints': []})  # noqa E501
+            r = list(self.resource.vpc_endpoints.filter(
+                Filters=[{'Name': 'service-name',
+                          'Values': ['com.amazonaws.us-east-1.dynamodb']}]
             ))
             stubber.assert_no_pending_responses()
 
-        self.assertEqual(response, [])
+        self.assertEqual(r, [])
 
     def test_create_endpoint(self):
         expected_response = mock_create_vpc_endpoint()
-        with Stubber(self.service_resource.meta.client) as stubber:
+        vpc_endpoints = expected_response['VpcEndpoint']
+
+        with Stubber(self.resource.meta.client) as stubber:
             stubber.add_response('create_vpc_endpoint', expected_response)
-            response = self.service_resource.create_vpc_endpoint(VpcId='vpc-2fefad42',
-                                                                 ServiceName='com.amazonaws.us-east-1.s3')
+            r = self.resource.create_vpc_endpoint(
+                VpcId='vpc-2fefad42',
+                ServiceName='com.amazonaws.us-east-1.s3'
+            )
             stubber.assert_no_pending_responses()
 
-        self.assertEqual(response.vpc_endpoint_id, expected_response['VpcEndpoint']['VpcEndpointId'])
-        self.assertEqual(response.vpc_id, expected_response['VpcEndpoint']['VpcId'])
-        self.assertEqual(response.service_name, expected_response['VpcEndpoint']['ServiceName'])
+        self.assertEqual(r.vpc_endpoint_id, vpc_endpoints['VpcEndpointId'])
+        self.assertEqual(r.vpc_id, vpc_endpoints['VpcId'])
+        self.assertEqual(r.service_name, vpc_endpoints['ServiceName'])
 
     def test_delete_endpoint(self):
         expected_response1 = mock_endpoints(endpoint_services=['s3'])
-        expected_response2 = mock_delete_vpc_endpoint(expected_response1['VpcEndpoints'][0]['VpcEndpointId'])
-        with Stubber(self.service_resource.meta.client) as stubber:
+        vpc_endpoints1 = expected_response1['VpcEndpoints'][0]
+        expected_response2 = mock_delete_vpc_endpoint(vpc_endpoints1['VpcEndpointId'])  # noqa E501
+
+        with Stubber(self.resource.meta.client) as stubber:
             stubber.add_response('describe_vpc_endpoints', expected_response1)
             stubber.add_response('delete_vpc_endpoints', expected_response2)
-            endpoint = self.service_resource.VpcEndpoint(expected_response1['VpcEndpoints'][0]['VpcEndpointId'])
-            service_name = endpoint.service_name  # dequeue stubber - list would do this for iterators.
-            self.assertEqual(service_name, expected_response1['VpcEndpoints'][0]['ServiceName'])
-            response = endpoint.delete(VpcEndpointIds=[endpoint.vpc_endpoint_id])
+            vpce = self.resource.VpcEndpoint(vpc_endpoints1['VpcEndpointId'])
+            service_name = vpce.service_name  # noqa: F841 E501 - dequeue stubber - list does this for iterators.
+            self.assertEqual(service_name, vpc_endpoints1['ServiceName'])
+            response = vpce.delete(VpcEndpointIds=[vpce.vpc_endpoint_id])
             stubber.assert_no_pending_responses()
 
         self.assertEqual(response['Unsuccessful'], [])
 
     def test_delete_endpoint_not_found_error(self):
         expected_response1 = mock_endpoints(endpoint_services=['s3'])
+        vpc_endpoints1 = expected_response1['VpcEndpoints'][0]
         expected_response2 = mock_delete_vpc_endpoint('vpce-babababa', True)
-        with Stubber(self.service_resource.meta.client) as stubber:
+
+        with Stubber(self.resource.meta.client) as stubber:
             stubber.add_response('describe_vpc_endpoints', expected_response1)
-            endpoint = self.service_resource.VpcEndpoint(expected_response1['VpcEndpoints'][0]['VpcEndpointId'])
-            service_name = endpoint.service_name  # need this to dequeue stubber
+            vpce = self.resource.VpcEndpoint(vpc_endpoints1['VpcEndpointId'])
+            service_name = vpce.service_name  # noqa: F841 E501 - need this to dequeue stubber
             stubber.add_response('delete_vpc_endpoints', expected_response2)
-            response = endpoint.delete(VpcEndpointIds=['vpce-babababa'])
+            response = vpce.delete(VpcEndpointIds=['vpce-babababa'])
             stubber.assert_no_pending_responses()
 
-        self.assertEqual(response, mock_delete_vpc_endpoint('vpce-babababa', True))
+        self.assertEqual(response, mock_delete_vpc_endpoint('vpce-babababa', True))  # noqa E501


### PR DESCRIPTION
First attempt at adding feature to Boto3. This provides resource for VPC Endpoint so one can say 

vpc_endpoint = resource.vpc_endpoints.all()
for vpce in vpc_endpoint
      blah

or 

vpc_endpoint = resource.VpcEndpoint('vpce-12345678')

Tested against python 2.7 and 3.6.4 using AWS: can filter, create, delete etc. on resource. Unittests included as well.
