### PR TITLE
Remove redundant docs

### DIFF
--- a/boto3/dynamodb/table.py
+++ b/boto3/dynamodb/table.py
@@ -39,9 +39,7 @@ class TableResource(object):
         in batches.  In addition, the batch writer will also automatically
         handle any unprocessed items and resend them as needed.  All you need
         to do is call ``put_item`` for any items you want to add, and
-        ``delete_item`` for any items you want to delete.  In addition, you can
-        specify ``auto_dedup`` if the batch might contain duplicated requests
-        and you want this writer to handle de-dup for you.
+        ``delete_item`` for any items you want to delete.
 
         Example usage::
 


### PR DESCRIPTION
This removes a redundant (and wrong) doc segment. The correct doc
string is in the parameter section.

Closes #1484