### PR TITLE
Handle dynamo operations with no output

### DIFF
--- a/.changes/next-release/bugfix-dynamodb-48781.json
+++ b/.changes/next-release/bugfix-dynamodb-48781.json
@@ -1,0 +1,5 @@
+{
+  "description": "Fixes a bug causing dynamodb operations with no output to throw errors.",
+  "type": "bugfix",
+  "category": "dynamodb"
+}

--- a/boto3/dynamodb/transform.py
+++ b/boto3/dynamodb/transform.py
@@ -198,9 +198,11 @@ class TransformationInjector(object):
 
     def inject_attribute_value_output(self, parsed, model, **kwargs):
         """Injects DynamoDB deserialization into responses"""
-        self._transformer.transform(
-            parsed, model.output_shape, self._deserializer.deserialize,
-            'AttributeValue')
+        if model.output_shape is not None:
+            self._transformer.transform(
+                parsed, model.output_shape, self._deserializer.deserialize,
+                'AttributeValue'
+            )
 
 
 class ConditionExpressionTransformation(object):

--- a/tests/functional/dynamodb/test_table.py
+++ b/tests/functional/dynamodb/test_table.py
@@ -13,6 +13,7 @@
 from tests import unittest, mock
 
 import boto3
+from botocore.stub import Stubber
 
 
 class TestTableResourceCustomizations(unittest.TestCase):
@@ -25,3 +26,17 @@ class TestTableResourceCustomizations(unittest.TestCase):
     def test_resource_has_batch_writer_added(self):
         table = self.resource.Table('mytable')
         self.assertTrue(hasattr(table, 'batch_writer'))
+
+    def test_operation_without_output(self):
+        table = self.resource.Table('mytable')
+        stubber = Stubber(table.meta.client)
+        stubber.add_response('tag_resource', {})
+        arn = 'arn:aws:dynamodb:us-west-2:123456789:table/mytable'
+
+        with stubber:
+            table.meta.client.tag_resource(
+                ResourceArn=arn,
+                Tags=[{'Key': 'project', 'Value': 'val'}]
+            )
+
+        stubber.assert_no_pending_responses()

--- a/tests/unit/dynamodb/test_transform.py
+++ b/tests/unit/dynamodb/test_transform.py
@@ -464,6 +464,33 @@ class TestTransformAttributeValueOutput(BaseTransformAttributeValueTest):
         )
 
 
+    def test_no_output(self):
+        service_model = ServiceModel({
+            'operations': {
+                'SampleOperation': {
+                    'name': 'SampleOperation',
+                    'input': {'shape': 'SampleOperationInputOutput'},
+                }
+            },
+            'shapes': {
+                'SampleOperationInput': {
+                    'type': 'structure',
+                    'members': {}
+                },
+                'String': {
+                    'type': 'string'
+                }
+            }
+        })
+        operation_model = service_model.operation_model('SampleOperation')
+
+        parsed = {}
+        self.injector.inject_attribute_value_output(
+            parsed=parsed, model=operation_model)
+        self.assertEqual(parsed, {})
+
+
+
 class TestTransformConditionExpression(BaseTransformationTest):
     def setUp(self):
         super(TestTransformConditionExpression, self).setUp()


### PR DESCRIPTION
This fixes a bug reported in #1464 where dynamodb operations that have
no defined output structure would result in an exception due to the code
assuming there  will always be a defined model.

Fixes #1464