### PR TITLE
Add exponential backoff support to dynamodb BatchWriter

### DIFF
--- a/tests/functional/docs/test_dynamodb.py
+++ b/tests/functional/docs/test_dynamodb.py
@@ -27,7 +27,7 @@ class TestDynamoDBCustomizations(BaseDocsFunctionalTests):
         self.assert_contains_lines_in_order([
             '.. py:class:: DynamoDB.Table(name)',
             '  *   :py:meth:`batch_writer()`',
-            '  .. py:method:: batch_writer(overwrite_by_pkeys=None)'],
+            '  .. py:method:: batch_writer(overwrite_by_pkeys=None, max_retries=-1, max_backoff=0)'],
             self.generated_contents
         )
 


### PR DESCRIPTION
The docs for [batch_write_item](http://boto3.readthedocs.io/en/latest/reference/services/dynamodb.html#DynamoDB.Client.batch_write_item) _strongly recommend that you use an exponential backoff algorithm_ if any unprocessed items are returned. However, looking at the `batch_writer` implementation (which internally uses `batch_write_item` to flush records to dynamo) I noticed that there is no support for exponential backoff.

This PR adds support for the recommended exponential backoff using a truncated exponential backoff algorithm that supports a max backoff time and an upper bound on the number of consecutive retries.