### PR TITLE
Avoid deprecation warning.

### DIFF
--- a/boto3/resources/params.py
+++ b/boto3/resources/params.py
@@ -19,7 +19,7 @@ from botocore import xform_name
 from ..exceptions import ResourceLoadException
 
 
-INDEX_RE = re.compile('\[(.*)\]$')
+INDEX_RE = re.compile(r'\[(.*)\]$')
 
 
 def get_data_member(parent, path):


### PR DESCRIPTION
This supresses a warning in Python 3.6...

```
DeprecationWarning: invalid escape sequence \[
```