### PR TITLE
Remove links to SDK for Javascript guide

### DIFF
--- a/docs/source/guide/sqs-example-dead-letter-queue.rst
+++ b/docs/source/guide/sqs-example-dead-letter-queue.rst
@@ -44,7 +44,7 @@ To set up and run this example, you must first complete these tasks:
 * Configure your AWS credentials, as described in :doc:`quickstart`.
 
 * Create an Amazon SQS queue to serve as a dead letter queue. For an example of creating a queue, see 
-  `Using Queues <http://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/sqs-examples-using-queues.html>`_ in *Amazon SQS*.
+  :doc:`Using Queues <sqs-examples-using-queues>` in *Amazon SQS*.
 
 Configure Source Queues
 =======================

--- a/docs/source/guide/sqs-example-sending-receiving-msgs.rst
+++ b/docs/source/guide/sqs-example-sending-receiving-msgs.rst
@@ -43,7 +43,8 @@ To set up and run this example, you must first complete these tasks:
 * Configure your AWS credentials, as described in :doc:`quickstart`.
 
 * Create an Amazon SQS queue. For an example of creating a queue, see 
-  `Using Queues in Amazon SQS <http://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/sqs-examples-using-queues.html>`_.
+  :doc:`Using Queues in Amazon SQS <sqs-examples-using-queues>`.
+
 
 Send a Message to a Queue
 =========================

--- a/docs/source/guide/sqs-example-visibility-timeout.rst
+++ b/docs/source/guide/sqs-example-visibility-timeout.rst
@@ -39,10 +39,10 @@ To set up and run this example, you must first complete these tasks:
 * Configure your AWS credentials, as described in :doc:`quickstart`.
 
 * Create an Amazon SQS queue. For an example of creating a queue, see 
-  `Using Queues in Amazon SQS <http://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/sqs-examples-using-queues.html>`_.
+  :doc:`Using Queues in Amazon SQS <sqs-examples-using-queues>`.
 
 * Send a message to the queue. For an example of sending a message to a queue, see 
-  `Sending and Receiving Messages in Amazon SQS <http://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/sqs-examples-send-receive-messages.html>`_.
+  :doc:`Sending and Receiving Messages in Amazon SQS <sqs-example-sending-receiving-msgs>`.
 
 Change the Visibility Timeout
 =============================


### PR DESCRIPTION
Replaced with links to articles within Boto3 Developer Guide.

I discovered in the SQS articles there were some links to the SDK for Javascript developer guide. 
After some investigation, I found a comparable article within the Boto3 Documentation, so I replaced the links to the Javascript guide with articles within this guide. 

I am assuming that you would prefer to not link out to another language. 