### PR TITLE
Add equality check for dynamodb.conditions.AttributeBase to support testing with Stubber.

### DIFF
--- a/boto3/dynamodb/conditions.py
+++ b/boto3/dynamodb/conditions.py
@@ -146,6 +146,9 @@ class ConditionAttributeBase(ConditionBase, AttributeBase):
     def __eq__(self, other):
         return ConditionBase.__eq__(self, other) and AttributeBase.__eq__(self, other)
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
 
 class ComparisonCondition(ConditionBase):
     expression_format = '{0} {operator} {1}'

--- a/boto3/dynamodb/conditions.py
+++ b/boto3/dynamodb/conditions.py
@@ -124,6 +124,12 @@ class AttributeBase(object):
         """
         return Between(self, low_value, high_value)
 
+    def __eq__(self, other):
+        return isinstance(other, type(self)) and self.name == other.name
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
 
 class ConditionAttributeBase(ConditionBase, AttributeBase):
     """This base class is for conditions that can have attribute methods.
@@ -136,6 +142,9 @@ class ConditionAttributeBase(ConditionBase, AttributeBase):
         # This is assuming the first value to the condition is the attribute
         # in which can be used to generate its attribute base.
         AttributeBase.__init__(self, values[0].name)
+
+    def __eq__(self, other):
+        return ConditionBase.__eq__(self, other) and AttributeBase.__eq__(self, other)
 
 
 class ComparisonCondition(ConditionBase):

--- a/boto3/dynamodb/conditions.py
+++ b/boto3/dynamodb/conditions.py
@@ -144,7 +144,8 @@ class ConditionAttributeBase(ConditionBase, AttributeBase):
         AttributeBase.__init__(self, values[0].name)
 
     def __eq__(self, other):
-        return ConditionBase.__eq__(self, other) and AttributeBase.__eq__(self, other)
+        return ConditionBase.__eq__(self, other) and \
+               AttributeBase.__eq__(self, other)
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/tests/functional/dynamodb/test_stubber_conditions.py
+++ b/tests/functional/dynamodb/test_stubber_conditions.py
@@ -1,0 +1,56 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from botocore.stub import Stubber
+
+import boto3
+from boto3.dynamodb.conditions import Attr, Key
+from tests import unittest
+
+
+class TestStubberSupportsFilterExpressions(unittest.TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        self.resource = boto3.resource('dynamodb', 'us-east-1')
+
+    def test_table_query_can_be_stubbed_with_expressions(self):
+        table = self.resource.Table('mytable')
+
+        stubber = Stubber(table.meta.client)
+        stubber.add_response('query', dict(Items=list()), expected_params=dict(
+                TableName='mytable',
+                KeyConditionExpression=Key('mykey').eq('testkey'),
+                FilterExpression=Attr('myattr').eq('foo') & (Attr('myattr2').lte('buzz') | Attr('myattr2').gte('fizz'))
+        ))
+
+        with stubber:
+            response = table.query(KeyConditionExpression=Key('mykey').eq('testkey'),
+                                   FilterExpression=Attr('myattr').eq('foo') & (Attr('myattr2').lte('buzz') | Attr('myattr2').gte('fizz')))
+
+        self.assertEqual(list(), response['Items'])
+        stubber.assert_no_pending_responses()
+
+    def test_table_scan_can_be_stubbed_with_expressions(self):
+        table = self.resource.Table('mytable')
+
+        stubber = Stubber(table.meta.client)
+        stubber.add_response('scan', dict(Items=list()), expected_params=dict(
+                TableName='mytable',
+                FilterExpression=Attr('myattr').eq('foo') & (Attr('myattr2').lte('buzz') | Attr('myattr2').gte('fizz'))
+        ))
+
+        with stubber:
+            response = table.scan(FilterExpression=Attr('myattr').eq('foo') & (Attr('myattr2').lte('buzz') | Attr('myattr2').gte('fizz')))
+
+        self.assertEqual(list(), response['Items'])
+        stubber.assert_no_pending_responses()

--- a/tests/functional/dynamodb/test_stubber_conditions.py
+++ b/tests/functional/dynamodb/test_stubber_conditions.py
@@ -25,32 +25,39 @@ class TestStubberSupportsFilterExpressions(unittest.TestCase):
 
     def test_table_query_can_be_stubbed_with_expressions(self):
         table = self.resource.Table('mytable')
+        key_expr = Key('mykey').eq('testkey')
+        filter_expr = Attr('myattr').eq('foo') & (
+            Attr('myattr2').lte('buzz') | Attr('myattr2').gte('fizz')
+        )
 
         stubber = Stubber(table.meta.client)
         stubber.add_response('query', dict(Items=list()), expected_params=dict(
                 TableName='mytable',
-                KeyConditionExpression=Key('mykey').eq('testkey'),
-                FilterExpression=Attr('myattr').eq('foo') & (Attr('myattr2').lte('buzz') | Attr('myattr2').gte('fizz'))
+                KeyConditionExpression=key_expr,
+                FilterExpression=filter_expr
         ))
 
         with stubber:
-            response = table.query(KeyConditionExpression=Key('mykey').eq('testkey'),
-                                   FilterExpression=Attr('myattr').eq('foo') & (Attr('myattr2').lte('buzz') | Attr('myattr2').gte('fizz')))
+            response = table.query(KeyConditionExpression=key_expr,
+                                   FilterExpression=filter_expr)
 
         self.assertEqual(list(), response['Items'])
         stubber.assert_no_pending_responses()
 
     def test_table_scan_can_be_stubbed_with_expressions(self):
         table = self.resource.Table('mytable')
+        filter_expr = Attr('myattr').eq('foo') & (
+                Attr('myattr2').lte('buzz') | Attr('myattr2').gte('fizz')
+        )
 
         stubber = Stubber(table.meta.client)
         stubber.add_response('scan', dict(Items=list()), expected_params=dict(
                 TableName='mytable',
-                FilterExpression=Attr('myattr').eq('foo') & (Attr('myattr2').lte('buzz') | Attr('myattr2').gte('fizz'))
+                FilterExpression=filter_expr
         ))
 
         with stubber:
-            response = table.scan(FilterExpression=Attr('myattr').eq('foo') & (Attr('myattr2').lte('buzz') | Attr('myattr2').gte('fizz')))
+            response = table.scan(FilterExpression=filter_expr)
 
         self.assertEqual(list(), response['Items'])
         stubber.assert_no_pending_responses()

--- a/tests/unit/dynamodb/test_conditions.py
+++ b/tests/unit/dynamodb/test_conditions.py
@@ -82,12 +82,17 @@ class TestK(unittest.TestCase):
         attr_copy = copy.deepcopy(self.attr)
         self.assertIsNot(self.attr, attr_copy)
         self.assertEqual(self.attr, attr_copy)
-        
+
     def test_eq_equality(self):
         attr_copy = copy.deepcopy(self.attr)
         comp = self.attr.eq(self.value)
         comp2 = attr_copy.eq(self.value)
         self.assertEqual(comp, comp2)
+
+    def test_eq_inequality(self):
+        attr_copy = copy.deepcopy(self.attr)
+        self.assertNotEqual(self.attr.eq(self.value),
+                            attr_copy.eq(self.value2))
 
     def test_lt_equality(self):
         attr_copy = copy.deepcopy(self.attr)

--- a/tests/unit/dynamodb/test_conditions.py
+++ b/tests/unit/dynamodb/test_conditions.py
@@ -10,6 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import copy
+
 from tests import unittest
 
 from boto3.exceptions import DynamoDBOperationNotSupportedError
@@ -76,6 +78,53 @@ class TestK(unittest.TestCase):
         self.assertEqual(self.attr.between(self.value, self.value2),
                          Between(self.attr, self.value, self.value2))
 
+    def test_attribute_equality(self):
+        attr_copy = copy.deepcopy(self.attr)
+        self.assertIsNot(self.attr, attr_copy)
+        self.assertEqual(self.attr, attr_copy)
+        
+    def test_eq_equality(self):
+        attr_copy = copy.deepcopy(self.attr)
+        comp = self.attr.eq(self.value)
+        comp2 = attr_copy.eq(self.value)
+        self.assertEqual(comp, comp2)
+
+    def test_lt_equality(self):
+        attr_copy = copy.deepcopy(self.attr)
+        comp = self.attr.lt(self.value)
+        comp2 = attr_copy.lt(self.value)
+        self.assertEqual(comp, comp2)
+
+    def test_lte_equality(self):
+        attr_copy = copy.deepcopy(self.attr)
+        comp = self.attr.lte(self.value)
+        comp2 = attr_copy.lte(self.value)
+        self.assertEqual(comp, comp2)
+
+    def test_gt_equality(self):
+        attr_copy = copy.deepcopy(self.attr)
+        comp = self.attr.gt(self.value)
+        comp2 = attr_copy.gt(self.value)
+        self.assertEqual(comp, comp2)
+
+    def test_gte_equality(self):
+        attr_copy = copy.deepcopy(self.attr)
+        comp = self.attr.gte(self.value)
+        comp2 = attr_copy.gte(self.value)
+        self.assertEqual(comp, comp2)
+
+    def test_begins_with_equality(self):
+        attr_copy = copy.deepcopy(self.attr)
+        comp = self.attr.begins_with(self.value)
+        comp2 = attr_copy.begins_with(self.value)
+        self.assertEqual(comp, comp2)
+
+    def test_between_equality(self):
+        attr_copy = copy.deepcopy(self.attr)
+        comp = self.attr.between(self.value, self.value2)
+        comp2 = attr_copy.between(self.value, self.value2)
+        self.assertEqual(comp, comp2)
+
 
 class TestA(TestK):
     def setUp(self):
@@ -108,6 +157,48 @@ class TestA(TestK):
     def test_attribute_type(self):
         self.assertEqual(self.attr.attribute_type(self.value),
                          AttributeType(self.attr, self.value))
+
+    def test_ne_equality(self):
+        attr_copy = copy.deepcopy(self.attr)
+        comp = self.attr.ne(self.value)
+        comp2 = attr_copy.ne(self.value)
+        self.assertEqual(comp, comp2)
+
+    def test_is_in_equality(self):
+        attr_copy = copy.deepcopy(self.attr)
+        comp = self.attr.is_in([self.value])
+        comp2 = attr_copy.is_in([self.value])
+        self.assertEqual(comp, comp2)
+
+    def test_exists_equality(self):
+        attr_copy = copy.deepcopy(self.attr)
+        comp = self.attr.exists()
+        comp2 = attr_copy.exists()
+        self.assertEqual(comp, comp2)
+
+    def test_not_exists_equality(self):
+        attr_copy = copy.deepcopy(self.attr)
+        comp = self.attr.not_exists()
+        comp2 = attr_copy.not_exists()
+        self.assertEqual(comp, comp2)
+
+    def test_contains_equality(self):
+        attr_copy = copy.deepcopy(self.attr)
+        comp = self.attr.contains(self.value)
+        comp2 = attr_copy.contains(self.value)
+        self.assertEqual(comp, comp2)
+
+    def test_size_equality(self):
+        attr_copy = copy.deepcopy(self.attr)
+        comp = self.attr.size()
+        comp2 = attr_copy.size()
+        self.assertEqual(comp, comp2)
+
+    def test_attribute_type_equality(self):
+        attr_copy = copy.deepcopy(self.attr)
+        comp = self.attr.attribute_type(self.value)
+        comp2 = attr_copy.attribute_type(self.value)
+        self.assertEqual(comp, comp2)
 
 
 class TestConditions(unittest.TestCase):


### PR DESCRIPTION
I've constantly had problems testing code that interacts with DynamoDB because the objects returned by the expression generators (`dynamodb.conditions.Key().*`, `dynamodb.conditions.Attr().*`) do not fully implement equality checks. Further, the DynamoDB API executes a `deepcopy` on the expressions, so pre-generating an expression object and returning it from a mocked `Attr` object, for example, results in the same problem.

Digging into the code, it appears `__eq__` and `__ne__` were only implemented for `ConditionBase` and not `AttributeBase`. Since all of the Condition classes (`Equals`, `LessThan`, etc.) execute a Tuple equality check on their `values`, and the first element of that tuple is typically an `Attr` or `Key`, this resulted in an equality failure for the entire condition because the objects were not the same even though they were functionally equivalent.

I implemented a simple `__eq__` method for `AttributeBase` and updated the `ConditionAttributeBase` to ensure it checks equality for both of its superclasses.

There are unit tests validating equality checks for all of the ComparisonConditions as well as functional tests ensuring that the Stubber call check works with `FilterExpression` and `KeyConditionExpression` objects during `scan` and `query` operations.

I hope this gets merged in ASAP. Its been causing headaches for a while and I'd love to be able to simplify our test cases to use Stubber so we get the argument validation!