### PR TITLE
Update for s3 bucket metadata

### DIFF
--- a/docs/source/guide/migrations3.rst
+++ b/docs/source/guide/migrations3.rst
@@ -133,7 +133,8 @@ It's possible to set arbitrary metadata on keys::
 
     # Boto 3
     key.put(Metadata={'meta1': 'This is my metadata value'})
-    print(key.metadata['meta1'])
+    target_object = key.Object()
+    print(target_object.metadata['meta1'])
 
 Managing CORS Configuration
 ---------------------------


### PR DESCRIPTION
The metadata attribute needs to be accessed via sub-resource of key.Object() according to https://github.com/boto/boto3/issues/258. I verified that this is indeed the behavior.