### PR TITLE
Add a method for uploading file-like objects in S3Transfer

### DIFF
--- a/tests/unit/s3/test_transfer.py
+++ b/tests/unit/s3/test_transfer.py
@@ -10,6 +10,8 @@
 # distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import io
+
 from tests import unittest
 
 import mock
@@ -120,6 +122,13 @@ class TestS3Transfer(unittest.TestCase):
                                   extra_args=extra_args)
         self.manager.upload.assert_called_with(
             'smallfile', 'bucket', 'key', extra_args, None)
+
+    def test_upload_fileobj(self):
+        bytes_object = io.BytesIO()
+        extra_args = {'ACL': 'public-read'}
+        self.transfer.upload_fileobj(bytes_object, 'bucket', 'key', extra_args=extra_args)
+        self.manager.upload.assert_called_with(
+            bytes_object, 'bucket', 'key', extra_args, None)
 
     def test_download_file(self):
         extra_args = {


### PR DESCRIPTION
This pull request solves the problem of uploading file-like objects with S3Transfer.
To mitigate this issue method upload_fileobj was added (similarly to existing upload_file).

Also, I've done some refactoring to private method  __upload avoiding code duplication.