### PR TITLE
Travis CI: Don't freeze the defaults and explain the exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,26 +3,14 @@ language: python
 matrix:
   include:
     - python: 2.6
-      dist: trusty
-      sudo: false
     - python: 2.7
-      dist: trusty
-      sudo: false
     - python: 3.3
-      dist: trusty
-      sudo: false
     - python: 3.4
-      dist: trusty
-      sudo: false
     - python: 3.5
-      dist: trusty
-      sudo: false
     - python: 3.6
-      dist: trusty
-      sudo: false
     - python: 3.7
-      dist: xenial
-      sudo: true
+      dist: xenial  # required for Python 3.7 (travis-ci/travis-ci#9069)
+      sudo: true    # required for Python 3.7 (travis-ci/travis-ci#9069)
 
 before_install:
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ matrix:
     - python: 3.6
     - python: 3.7
       dist: xenial  # required for Python 3.7 (travis-ci/travis-ci#9069)
-      sudo: true    # required for Python 3.7 (travis-ci/travis-ci#9069)
 
 before_install:
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,5 @@ before_install:
       echo "No pull requests can be sent to the master branch" 1>&2;
       exit 1;
     fi
-install:
-  - python scripts/ci/install
-script: python scripts/ci/run-tests
+install: python scripts/ci/install
+script:  python scripts/ci/run-tests


### PR DESCRIPTION
Remove clutter by leveraging the current Travis default: Trusty without sudo.  Letting these values float will allow our tests to remain current when the distro of Travis is upgraded.

Use comments to explain why exceptions to the defaults are required for Python 3.7.