### PR TITLE
Add serviceid to tests

### DIFF
--- a/.changes/next-release/feature-Events-89734.json
+++ b/.changes/next-release/feature-Events-89734.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Events",
+  "description": "This migrates the event system to using sevice ids instead of either client name or endpoint prefix. This prevents issues that might arise when a service changes their endpoint prefix, also fixes a long-standing bug where you could not register an event to a particular service if it happened to share its endpoint prefix with another service (e.g. ``autoscaling`` and ``application-autoscaling`` both use the endpoint prefix ``autoscaling``). Please see the `upgrade notes <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/upgrading.html>`_ to determine if you are impacted and how to proceed if you are."
+}

--- a/docs/source/guide/upgrading.rst
+++ b/docs/source/guide/upgrading.rst
@@ -4,9 +4,117 @@ Upgrading Notes
 
 Notes to refer to when upgrading ``boto3`` versions.
 
+1.9.0
+-----
+
+What Changed
+~~~~~~~~~~~~
+
+The boto3 event system was changed to emit events based on the service id
+rather than the endpoint prefix or service name.
+
+Why Was The Change Was Made
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This was done to handle several issues that were becoming increasingly
+problematic:
+
+* Services changing their endpoint prefix would cause some registered events to
+  no longer fire (but not all).
+* New services that launch using an endpoint that another service is using
+  won't be able to be uniquely selected. There are a number of cases of this
+  already.
+* Services whose client name and endpoint prefix differed would require two
+  different strings if you want to register against all events.
+
+How Do I Know If I'm Impacted
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Any users relying on registering an event against one service impacting other
+services are impacted. You can consult the following table to see if you are
+impacted. If you are registering an event using one of the event parts in the
+leftmost column with the intention of impacting an unintended target service
+in the rightmost column, then you are impacted and will need to update.
+
++----------------------+-------------------------+---------------------------------------------------+
+| Event Part           | Intended Target Service | Unintended Target Services                        |
++----------------------+-------------------------+---------------------------------------------------+
+| rds                  | rds                     | neptune                                           |
++----------------------+-------------------------+---------------------------------------------------+
+| autoscaling          | autoscaling             | application-autoscaling, autoscaling-plans        |
++----------------------+-------------------------+---------------------------------------------------+
+| kinesisvideo         | kinesisvideo            | kinesis-video-media, kinesis-video-archived-media |
++----------------------+-------------------------+---------------------------------------------------+
+| elasticloadbalancing | elb                     | elbv2                                             |
++----------------------+-------------------------+---------------------------------------------------+
+
+For example, if you are registering an event against
+``before-call.elasticloadbalancing`` expecting it to run when making calls with
+an ``elbv2`` client, you will be impacted.
+
+If you are registering an event against one of the services in the Unintended
+Targets column, you may be impacted if you were relying on those events not
+firing.
+
+If you are registering events using ``*`` in the service place, or are
+registering against any service not in this table, you will not need a code
+change. In many cases the actual event name will have changed, but for services
+without shared endpoints we do the work of translating the event name at
+registration and emission time. In future versions of boto3 we will remove
+this translation, so you may wish to update your code anyway.
+
+How Do I Update My Code
+~~~~~~~~~~~~~~~~~~~~~~~
+
+You will need to look at the events you are registering against and determine
+which services you wish to impact with your handler. If you only wish to
+impact the intended target service (as defined in the above table), then you
+don't need to change the event. If you wish to impact another service in
+addition to the intended target service, you will need to register a new event
+using that service's event name. Similarly, if you wish to impact another
+service instead you will simply need to change the event you are registered
+against.
+
+To get the new event name, consult this table:
+
++------------------------------+----------------------+------------------------------+
+| Service                      | Old Event Name       | New Event Name               |
++------------------------------+----------------------+------------------------------+
+| application-autoscaling      | autoscaling          | application-auto-scaling     |
++------------------------------+----------------------+------------------------------+
+| autoscaling-plans            | autoscaling          | auto-scaling-plans           |
++------------------------------+----------------------+------------------------------+
+| elbv2                        | elasticloadbalancing | elastic-load-balancing       |
++------------------------------+----------------------+------------------------------+
+| kinesis-video-archived-media | kinesisvideo         | kinesis-video-archived-media |
++------------------------------+----------------------+------------------------------+
+| kinesis-video-media          | kinesisvideo         | kinesis-video-media          |
++------------------------------+----------------------+------------------------------+
+| neptune                      | rds                  | neptune                      |
++------------------------------+----------------------+------------------------------+
+
+Additionally, you can get the new event name in code like so::
+
+    import boto3
+
+    client = boto3.client('elbv2')
+    service_event_name = client.meta.service_model.service_id.hyphenize()
+
+Armed with the service event name, simply replace the old service name in the
+handler with the new service event name. If you were registering an event
+against ``before-call.autoscaling`` intending to impact ``autoscaling-plans``
+for example, you would instead register against
+``before-call.auto-scaling-plans``.
+
+If you are registering an event against one of the services in the Unintended
+Targets column, you will now see those events getting fired where previously
+they were not. While this is enabling that expected behavior, this still
+represents a change in actual behavior. You should not need to update your
+code, but you should test to ensure that you are seeing the behavior you want.
+
 
 1.4.2
-=====
+-----
 
 * The ``use_threads`` option was added to
   :py:class:`boto3.s3.transfer.TransferConfig`.
@@ -16,7 +124,7 @@ Notes to refer to when upgrading ``boto3`` versions.
 
 
 1.4.0
-=====
+-----
 
 * Logic from the `s3transfer <https://github.com/boto/s3transfer>`_ package
   was ported into the ``boto3.s3.transfer`` module. In upgrading to this

--- a/tests/unit/docs/__init__.py
+++ b/tests/unit/docs/__init__.py
@@ -72,7 +72,8 @@ class BaseDocsTest(unittest.TestCase):
                 'endpointPrefix': 'myservice',
                 'signatureVersion': 'v4',
                 'serviceFullName': 'AWS MyService',
-                'protocol': 'query'
+                'protocol': 'query',
+                'serviceId': 'MyService',
             },
             'operations': {
                 'SampleOperation': {


### PR DESCRIPTION
This add service-id to sample service models in the tests, so that
when serviceid starts being used for events there won't be test
failures.

Related to boto/botocore#1524