### PR TITLE
Fix collections ABCs deprecation warning

### DIFF
--- a/boto3/compat.py
+++ b/boto3/compat.py
@@ -26,6 +26,11 @@ if six.PY3:
 else:
     SOCKET_ERROR = socket.error
 
+if six.PY3:
+    import collections.abc as collections_abc
+else:
+    import collections as collections_abc
+
 
 if sys.platform.startswith('win'):
     def rename_file(current_filename, new_filename):

--- a/boto3/dynamodb/transform.py
+++ b/boto3/dynamodb/transform.py
@@ -11,8 +11,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import copy
-from collections import Mapping, MutableSequence
 
+from boto3.compat import collections_abc
 from boto3.dynamodb.types import TypeSerializer, TypeDeserializer
 from boto3.dynamodb.conditions import ConditionBase
 from boto3.dynamodb.conditions import ConditionExpressionBuilder
@@ -262,7 +262,7 @@ class ParameterTransformer(object):
 
     def _transform_structure(self, model, params, transformation,
                              target_shape):
-        if not isinstance(params, Mapping):
+        if not isinstance(params, collections_abc.Mapping):
             return
         for param in params:
             if param in model.members:
@@ -276,7 +276,7 @@ class ParameterTransformer(object):
                         target_shape)
 
     def _transform_map(self, model, params, transformation, target_shape):
-        if not isinstance(params, Mapping):
+        if not isinstance(params, collections_abc.Mapping):
             return
         value_model = model.value
         value_shape = value_model.name
@@ -288,7 +288,7 @@ class ParameterTransformer(object):
                     value_model, params[key], transformation, target_shape)
 
     def _transform_list(self, model, params, transformation, target_shape):
-        if not isinstance(params, MutableSequence):
+        if not isinstance(params, collections_abc.MutableSequence):
             return
         member_model = model.member
         member_shape = member_model.name

--- a/boto3/dynamodb/types.py
+++ b/boto3/dynamodb/types.py
@@ -10,9 +10,10 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from collections import Mapping, Set
 from decimal import Decimal, Context, Clamped
 from decimal import Overflow, Inexact, Underflow, Rounded
+
+from boto3.compat import collections_abc
 
 from botocore.compat import six
 
@@ -174,7 +175,7 @@ class TypeSerializer(object):
         return False
 
     def _is_set(self, value):
-        if isinstance(value, Set):
+        if isinstance(value, collections_abc.Set):
             return True
         return False
 
@@ -185,7 +186,7 @@ class TypeSerializer(object):
         return False
 
     def _is_map(self, value):
-        if isinstance(value, Mapping):
+        if isinstance(value, collections_abc.Mapping):
             return True
         return False
 

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -10,10 +10,10 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import collections
 from decimal import Decimal
 
 import boto3.session
+from boto3.compat import collections_abc
 from boto3.dynamodb.types import Binary
 from boto3.dynamodb.conditions import Attr, Key
 from tests import unittest, unique_id
@@ -167,7 +167,7 @@ class TestDynamoDBConditions(BaseDynamoDBTest):
     def test_condition_attribute_type(self):
         r = self.scan(
             filter_expression=Attr('MyMap').attribute_type('M'))
-        self.assertIsInstance(r['Items'][0]['MyMap'], collections.Mapping)
+        self.assertIsInstance(r['Items'][0]['MyMap'], collections_abc.Mapping)
 
     def test_condition_and(self):
         r = self.scan(


### PR DESCRIPTION
in Python 3.7, importing ABCs from the 'collections' module is deprecated.

```
boto3/dynamodb/transform.py:14: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Mapping, MutableSequence

boto3/dynamodb/types.py:13: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Mapping, Set
```