### PR TITLE
Adding link to newly added Simple Email Service Examples

### DIFF
--- a/docs/source/guide/examples.rst
+++ b/docs/source/guide/examples.rst
@@ -24,4 +24,5 @@ Amazon Web Services (AWS) SDK for Python.
    ec2-examples
    iam-examples
    s3-examples
+   ses-examples
    sqs-examples


### PR DESCRIPTION
Adding a link to [SES examples](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/ses-examples.html)