### PR TITLE
Fix typo in Code Example docs

### DIFF
--- a/docs/source/guide/ses-verify.rst
+++ b/docs/source/guide/ses-verify.rst
@@ -77,7 +77,7 @@ Example
 
 .. code-block:: python
 
-    mport boto3
+    import boto3
 
     # Create SES client
     ses = boto3.client('ses')


### PR DESCRIPTION
There are typo in Boto 3 documentation.
This typo is in Example Code area.