### PR TITLE
Fix docs typos

### DIFF
--- a/docs/source/guide/ses-rules.rst
+++ b/docs/source/guide/ses-rules.rst
@@ -98,8 +98,8 @@ Example
 
 
 
-Delete a Receipt Rule
-=====================
+Delete a Receipt Rule Set
+==========================
 
 Remove a specified receipt rule set that isn't currently disabled. This also deletes all of the receipt rules it contains. To delete a receipt rule set, provide the RuleSetName to the `DeleteReceiptRuleSet <https://docs.aws.amazon.com/ses/latest/APIReference/API_DeleteReceiptRuleSet.html>`_ operation.
 
@@ -121,8 +121,8 @@ Example
     print(response)
 
 
-Delete a Receipt Rule Set
-==========================
+Delete a Receipt Rule
+=====================
 
 To delete a specified receipt rule, provide the RuleName and RuleSetName to the `DeleteReceiptRule <https://docs.aws.amazon.com/ses/latest/APIReference/API_DeleteReceiptRule.html>`_ operation.
 

--- a/docs/source/guide/ses-rules.rst
+++ b/docs/source/guide/ses-rules.rst
@@ -98,8 +98,8 @@ Example
 
 
 
-Delete a Receipt Rule Set
-==========================
+Delete a Receipt Rule
+=====================
 
 Remove a specified receipt rule set that isn't currently disabled. This also deletes all of the receipt rules it contains. To delete a receipt rule set, provide the RuleSetName to the `DeleteReceiptRuleSet <https://docs.aws.amazon.com/ses/latest/APIReference/API_DeleteReceiptRuleSet.html>`_ operation.
 
@@ -121,8 +121,8 @@ Example
     print(response)
 
 
-Delete a Receipt Rule
-=====================
+Delete a Receipt Rule Set
+==========================
 
 To delete a specified receipt rule, provide the RuleName and RuleSetName to the `DeleteReceiptRule <https://docs.aws.amazon.com/ses/latest/APIReference/API_DeleteReceiptRule.html>`_ operation.
 

--- a/docs/source/guide/ses-template.rst
+++ b/docs/source/guide/ses-template.rst
@@ -52,7 +52,7 @@ Example
 
 .. code-block:: python
 
-   import boto3
+    import boto3
 
     # Create SES client
     ses = boto3.client('ses')
@@ -65,7 +65,6 @@ Example
         'HtmlPart'     : 'HTML_CONTENT'
       }
     )
-
 
     print(response)
 


### PR DESCRIPTION
Fix docs typos in SES tutorial [Working with Email Templates] and [Using Email Rules].