### PR TITLE
Fix User Guide typos

### DIFF
--- a/docs/source/guide/cw-example-subscription-filters.rst
+++ b/docs/source/guide/cw-example-subscription-filters.rst
@@ -68,7 +68,7 @@ Prerequisite Tasks
                  "Effect": "Allow",
                  "Action": [
                     "logs:CreateLogGroup",
-                    "logs:CrateLogStream",
+                    "logs:CreateLogStream",
                     "logs:PutLogEvents"
                  ],
                  "Resource": "arn:aws:logs:*:*:*"

--- a/docs/source/guide/cw-examples.rst
+++ b/docs/source/guide/cw-examples.rst
@@ -15,7 +15,7 @@ Amazon CloudWatch Examples
 ##########################
 
 You can use the following examples to access Amazon Cloudwatch (CloudWatch) by using Amazon Boto. For more
-information about ClodWatch, see the `CloudWatch Developer Guide <http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide>`_.
+information about CloudWatch, see the `CloudWatch Developer Guide <http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide>`_.
 
 **Examples**
 

--- a/docs/source/guide/resources.rst
+++ b/docs/source/guide/resources.rst
@@ -186,7 +186,7 @@ Waiters
 -------
 A waiter is similiar to an action. A waiter will poll the status of a
 resource and suspend execution until the resource reaches the state that is
-being polling for or a failure occurs while polling.
+being polled for or a failure occurs while polling.
 Waiters automatically set the resource
 identifiers as parameters, but allow you to pass additional parameters via
 keyword arguments. Examples of waiters include::

--- a/docs/source/guide/ses-template.rst
+++ b/docs/source/guide/ses-template.rst
@@ -52,7 +52,7 @@ Example
 
 .. code-block:: python
 
-   import boto3
+    import boto3
 
     # Create SES client
     ses = boto3.client('ses')

--- a/docs/source/guide/sqs-example-long-polling.rst
+++ b/docs/source/guide/sqs-example-long-polling.rst
@@ -94,7 +94,7 @@ The example below shows how to:
 Example
 -------
 
-.. code:: python
+.. code-block:: python
 
     import boto3
 
@@ -126,7 +126,7 @@ The example below shows how to:
 Example
 -------
 
-.. code-block:: python/example_code
+.. code-block:: python
 
     import boto3
 


### PR DESCRIPTION
Fixes several SDK User Guide typos, including long-standing typos submitted in PRs #1255 , #1465 , #1582 , and #1874 