### PR TITLE
Correct full name of ECS

### DIFF
--- a/docs/source/reference/services/ecs.rst
+++ b/docs/source/reference/services/ecs.rst
@@ -19,7 +19,7 @@ Client
 
 .. py:class:: ECS.Client
 
-  A low-level client representing Amazon EC2 Container Service (ECS)::
+  A low-level client representing Amazon Elastic Container Service (ECS)::
 
     
     import boto3

--- a/docs/source/reference/services/events.rst
+++ b/docs/source/reference/services/events.rst
@@ -867,7 +867,7 @@ Client
 
             - **EcsParameters** *(dict) --* 
 
-              Contains the Amazon ECS task definition and task count to be used, if the event target is an Amazon ECS task. For more information about Amazon ECS tasks, see `Task Definitions <http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_defintions.html>`__ in the *Amazon EC2 Container Service Developer Guide* .
+              Contains the Amazon ECS task definition and task count to be used, if the event target is an Amazon ECS task. For more information about Amazon ECS tasks, see `Task Definitions <http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_defintions.html>`__ in the *Amazon Elastic Container Service Developer Guide* .
 
               
               
@@ -1497,7 +1497,7 @@ Client
         
         - **EcsParameters** *(dict) --* 
 
-          Contains the Amazon ECS task definition and task count to be used, if the event target is an Amazon ECS task. For more information about Amazon ECS tasks, see `Task Definitions <http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_defintions.html>`__ in the *Amazon EC2 Container Service Developer Guide* .
+          Contains the Amazon ECS task definition and task count to be used, if the event target is an Amazon ECS task. For more information about Amazon ECS tasks, see `Task Definitions <http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_defintions.html>`__ in the *Amazon Elastic Container Service Developer Guide* .
 
           
 


### PR DESCRIPTION
ECS's full name should be 'Elastic Container Service' rather than 'EC2 Container Service', especially given FARGATE can be used for ECS.