### PR TITLE
Add project_urls to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,4 +58,8 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],
+    project_urls={
+        'Documentation': 'https://boto3.amazonaws.com/v1/documentation/api/latest/index.html',
+        'Source': 'https://github.com/boto/boto3',
+    },
 )


### PR DESCRIPTION
Warehouse now uses the `project_urls` provided to display links in the sidebar on [this screen](https://pypi.org/project/boto3/), as well as including them in API responses to help automation tool find the source code for Boto 3. For example, see Django's [setup.py](https://github.com/django/django/blob/master/setup.py) and [PyPI listing](https://pypi.org/project/Django/).