### PR TITLE
Increase S3 integ test reliablity

### DIFF
--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -187,6 +187,9 @@ class TestS3Resource(unittest.TestCase):
             }
         bucket = self.s3.create_bucket(**kwargs)
         self.addCleanup(bucket.delete)
+
+        for _ in range(3):
+            bucket.wait_until_exists()
         return bucket
 
     def test_s3(self):


### PR DESCRIPTION
This adds a call to the waiter to make sure the bucket exists before
moving on with the test. Confirmed three times to be sure.