### PR TITLE
Issue #809 Adding get_template function to CloudFormation Stack resource

### DIFF
--- a/boto3/data/cloudformation/2010-05-15/resources-1.json
+++ b/boto3/data/cloudformation/2010-05-15/resources-1.json
@@ -93,6 +93,15 @@
               { "target": "StackName", "source": "identifier", "name": "Name" }
             ]
           }
+        },
+        "GetTemplate": {
+          "request": {
+            "operation": "GetTemplate",
+            "params": [
+              { "target": "StackName", "source": "identifier", "name": "Name" }
+            ]
+          },
+          "path": "TemplateBody"
         }
       },
       "has": {


### PR DESCRIPTION
Added the functionality to fetch the stack template for an AWS CloudFormation Stack resource as requested in #809. 

Tested the functionality with the following snippet:

```
import boto3
cloudformation = boto3.resource('cloudformation')
stack = cloudformation.Stack('test-stack')

stack.get_template()
stack.get_template(ChangeSetName='test-changeset')
stack.get_template(TemplateStage='Processed')
stack.get_template(ChangeSetName='test-changeset', TemplateStage='Original')

