### PR TITLE
Fix datetime param/field descriptions

### DIFF
--- a/docs/source/reference/services/cloudwatch.rst
+++ b/docs/source/reference/services/cloudwatch.rst
@@ -1727,7 +1727,7 @@ Client
 
             - **LastModified** *(datetime) --* 
 
-              The time stamp of when the dashboard was last modified, either by an API call or through the console. This number is expressed as the number of milliseconds since Jan 1, 1970 00:00:00 UTC.
+              The time stamp of when the dashboard was last modified, either by an API call or through the console.
 
               
             
@@ -2498,7 +2498,7 @@ Client
       
         - **Timestamp** *(datetime) --* 
 
-          The time the metric data was received, expressed as the number of milliseconds since Jan 1, 1970 00:00:00 UTC.
+          The time the metric data was received.
 
           
 


### PR DESCRIPTION
Hello,

Descriptions of the `Timestamp` request param and the `LastModified` response field are confusing because `datetime` objects are described as numbers of milliseconds since Jan 1, 1970 00:00:00 UTC.
Using such number instead of `datetime` as the `Timestamp` param value leads to an error.

Corresponding documentation page:
 - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudwatch.html

Best regards!