### PR TITLE
Changes to boto3 and botocore to implement AWS rate limiting client side

### DIFF
--- a/boto3/session.py
+++ b/boto3/session.py
@@ -79,6 +79,7 @@ class Session(object):
             self._session.get_component('event_emitter'))
         self._setup_loader()
         self._register_default_handlers()
+        self.api_rate_mgr = None
 
     def __repr__(self):
         return '{0}(region_name={1})'.format(
@@ -185,7 +186,7 @@ class Session(object):
     def client(self, service_name, region_name=None, api_version=None,
                use_ssl=True, verify=None, endpoint_url=None,
                aws_access_key_id=None, aws_secret_access_key=None,
-               aws_session_token=None, config=None):
+               aws_session_token=None, config=None, api_rate=0):
         """
         Create a low-level service client by name.
 
@@ -252,15 +253,19 @@ class Session(object):
             <https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html>`_
             for more details.
 
+        :type api_rate: int
+        :param api_rate: Request interval if using the ApiRateManager
+
         :return: Service client instance
 
         """
+
         return self._session.create_client(
             service_name, region_name=region_name, api_version=api_version,
             use_ssl=use_ssl, verify=verify, endpoint_url=endpoint_url,
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
-            aws_session_token=aws_session_token, config=config)
+            aws_session_token=aws_session_token, config=config, api_rate=api_rate)
 
     def resource(self, service_name, region_name=None, api_version=None,
                  use_ssl=True, verify=None, endpoint_url=None,

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -217,6 +217,8 @@ class TestSession(BaseTestCase):
         self.assertTrue(client,
                         'No low-level client was returned')
 
+    # TODO This test for specific args means breaking compatibility
+    # with previous versions when new args are added.
     def test_create_client_with_args(self):
         bc_session = self.bc_session_cls.return_value
 
@@ -224,7 +226,7 @@ class TestSession(BaseTestCase):
         session.client('sqs', region_name='us-west-2')
 
         bc_session.create_client.assert_called_with(
-            'sqs', aws_secret_access_key=None, aws_access_key_id=None,
+            'sqs', api_rate=0, aws_secret_access_key=None, aws_access_key_id=None,
             endpoint_url=None, use_ssl=True, aws_session_token=None,
             verify=None, region_name='us-west-2', api_version=None,
             config=None)


### PR DESCRIPTION
Hello

This PR is for changes to both boto3 and botocore. The changes are explained in detail on the README of master project I've created to test them together here - https://github.com/museadmin/botorate/tree/master

Your contributing guidelines suggest that I should be supporting some deprecated versions of Python. I'm not clear if this is a real requirement or if your docs are just a little out of date. I raised an issue asking the question, but have decided to submit the PR to see what other specific issues you might want resolving.

If accepted, I think you would need to coordinate the merge with botocore, whom I'm also raising a PR with.

Bradley