### PR TITLE
Remove docutils from requirements

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,3 @@
-docutils>=0.10,<0.15
 Sphinx>=1.1.3,<1.3
 guzzle_sphinx_theme>=0.7.10,<0.8
 -rrequirements.txt


### PR DESCRIPTION
Boto3 does not use docutils directly. Botocore does, and it is included
in the requirements in botocore.