### PR TITLE
Make BatchWriter._flush idempotent when batch_write_item raises an error

### DIFF
--- a/boto3/dynamodb/table.py
+++ b/boto3/dynamodb/table.py
@@ -132,17 +132,15 @@ class BatchWriter(object):
 
     def _flush(self):
         items_to_send = self._items_buffer[:self._flush_amount]
-        self._items_buffer = self._items_buffer[self._flush_amount:]
         response = self._client.batch_write_item(
             RequestItems={self._table_name: items_to_send})
+        self._items_buffer = self._items_buffer[self._flush_amount:]
         unprocessed_items = response['UnprocessedItems']
 
         if unprocessed_items and unprocessed_items[self._table_name]:
             # Any unprocessed_items are immediately added to the
             # next batch we send.
             self._items_buffer.extend(unprocessed_items[self._table_name])
-        else:
-            self._items_buffer = []
         logger.debug("Batch write sent %s, unprocessed: %s",
                      len(items_to_send), len(self._items_buffer))
 


### PR DESCRIPTION
Fixes issue #2088.