### PR TITLE
Do not pack requirements.txt to sdist (#2111)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include CONTRIBUTING.rst
 include README.rst
 include LICENSE
-include requirements.txt
 recursive-include boto3/data *.json


### PR DESCRIPTION
This may fix missing dependencies info on PyPI