### PR TITLE
Fix for Python 4: replace unsafe six.PY3 with PY2

### DIFF
--- a/boto3/compat.py
+++ b/boto3/compat.py
@@ -17,19 +17,19 @@ import socket
 
 from botocore.vendored import six
 
-if six.PY3:
+if six.PY2:
+    SOCKET_ERROR = socket.error
+else:
     # In python3, socket.error is OSError, which is too general
     # for what we want (i.e FileNotFoundError is a subclass of OSError).
     # In py3 all the socket related errors are in a newly created
     # ConnectionError
     SOCKET_ERROR = ConnectionError
-else:
-    SOCKET_ERROR = socket.error
 
-if six.PY3:
-    import collections.abc as collections_abc
-else:
+if six.PY2:
     import collections as collections_abc
+else:
+    import collections.abc as collections_abc
 
 
 if sys.platform.startswith('win'):

--- a/boto3/docs/utils.py
+++ b/boto3/docs/utils.py
@@ -39,10 +39,10 @@ def get_resource_ignore_params(params):
 
 
 def is_resource_action(action_handle):
-    if six.PY3:
-        return inspect.isfunction(action_handle)
-    else:
+    if six.PY2:
         return inspect.ismethod(action_handle)
+    else:
+        return inspect.isfunction(action_handle)
 
 
 def get_resource_public_actions(resource_class):

--- a/boto3/dynamodb/types.py
+++ b/boto3/dynamodb/types.py
@@ -170,7 +170,7 @@ class TypeSerializer(object):
             return True
         elif isinstance(value, bytearray):
             return True
-        elif six.PY3 and isinstance(value, six.binary_type):
+        elif not six.PY2 and isinstance(value, six.binary_type):
             return True
         return False
 


### PR DESCRIPTION
We don't yet know if 3.10 or 4.0 will follow Python 3.9, but whichever it is, it will probably happen in [2020 when Python 3.9 reaches beta](https://www.python.org/dev/peps/pep-0596/#schedule) and work begins on Python 3.9+1.

There's some code which uses `six.PY3`:

```python
if six.PY3:
    print("Python 3+ code")
else:
    print "Python 2 code" 
```

Where:

```python
PY3 = sys.version_info[0] == 3
```

When run on Python 4, this will run the Python 2 code!

Instead, use `six.PY2`.

Found using https://github.com/asottile/flake8-2020.

---

See also:

* https://github.com/boto/boto/pull/3880
* https://github.com/boto/botocore/pull/1933
* https://github.com/boto/s3transfer/pull/152
