### PR TITLE
Use pyupgrade to use Python 2.7 syntax

### DIFF
--- a/boto3/dynamodb/types.py
+++ b/boto3/dynamodb/types.py
@@ -228,7 +228,7 @@ class TypeSerializer(object):
         return [self.serialize(v) for v in value]
 
     def _serialize_m(self, value):
-        return dict([(k, self.serialize(v)) for k, v in value.items()])
+        return {k: self.serialize(v) for k, v in value.items()}
 
 
 class TypeDeserializer(object):
@@ -295,4 +295,4 @@ class TypeDeserializer(object):
         return [self.deserialize(v) for v in value]
 
     def _deserialize_m(self, value):
-        return dict([(k, self.deserialize(v)) for k, v in value.items()])
+        return {k: self.deserialize(v) for k, v in value.items()}

--- a/boto3/resources/base.py
+++ b/boto3/resources/base.py
@@ -42,7 +42,7 @@ class ResourceMeta(object):
         self.resource_model = resource_model
 
     def __repr__(self):
-        return 'ResourceMeta(\'{0}\', identifiers={1})'.format(
+        return 'ResourceMeta(\'{}\', identifiers={})'.format(
             self.service_name, self.identifiers)
 
     def __eq__(self, other):
@@ -108,7 +108,7 @@ class ServiceResource(object):
                 continue
 
             if name not in self.meta.identifiers:
-                raise ValueError('Unknown keyword argument: {0}'.format(name))
+                raise ValueError('Unknown keyword argument: {}'.format(name))
 
             setattr(self, '_' + name, value)
 
@@ -116,14 +116,14 @@ class ServiceResource(object):
         for identifier in self.meta.identifiers:
             if getattr(self, identifier) is None:
                 raise ValueError(
-                    'Required parameter {0} not set'.format(identifier))
+                    'Required parameter {} not set'.format(identifier))
 
     def __repr__(self):
         identifiers = []
         for identifier in self.meta.identifiers:
-            identifiers.append('{0}={1}'.format(
+            identifiers.append('{}={}'.format(
                 identifier, repr(getattr(self, identifier))))
-        return "{0}({1})".format(
+        return "{}({})".format(
             self.__class__.__name__,
             ', '.join(identifiers),
         )

--- a/boto3/resources/collection.py
+++ b/boto3/resources/collection.py
@@ -52,10 +52,10 @@ class ResourceCollection(object):
         self._params = copy.deepcopy(kwargs)
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(
+        return '{}({}, {})'.format(
             self.__class__.__name__,
             self._parent,
-            '{0}.{1}'.format(
+            '{}.{}'.format(
                 self._parent.meta.service_name,
                 self._model.resource.type
             )
@@ -317,10 +317,10 @@ class CollectionManager(object):
         )
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(
+        return '{}({}, {})'.format(
             self.__class__.__name__,
             self._parent,
-            '{0}.{1}'.format(
+            '{}.{}'.format(
                 self._parent.meta.service_name,
                 self._model.resource.type
             )
@@ -404,10 +404,10 @@ class CollectionFactory(object):
             base_class=ResourceCollection)
 
         if service_context.service_name == resource_name:
-            cls_name = '{0}.{1}Collection'.format(
+            cls_name = '{}.{}Collection'.format(
                 service_context.service_name, collection_name)
         else:
-            cls_name = '{0}.{1}.{2}Collection'.format(
+            cls_name = '{}.{}.{}Collection'.format(
                 service_context.service_name, resource_name, collection_name)
 
         collection_cls = type(str(cls_name), (ResourceCollection,),

--- a/boto3/resources/factory.py
+++ b/boto3/resources/factory.py
@@ -181,9 +181,9 @@ class ResourceFactory(object):
         shape = service_context.service_model.shape_for(
             resource_model.shape)
 
-        identifiers = dict(
-            (i.member_name, i)
-            for i in resource_model.identifiers if i.member_name)
+        identifiers = {
+            i.member_name: i
+            for i in resource_model.identifiers if i.member_name}
         attributes = resource_model.get_attributes(shape)
         for name, (orig_name, member) in attributes.items():
             if name in identifiers:
@@ -339,7 +339,7 @@ class ResourceFactory(object):
                     self.load()
                 else:
                     raise ResourceLoadException(
-                        '{0} has no load method'.format(
+                        '{} has no load method'.format(
                             self.__class__.__name__))
 
             return self.meta.data.get(name)

--- a/boto3/resources/model.py
+++ b/boto3/resources/model.py
@@ -296,7 +296,7 @@ class ResourceModel(object):
         :param shape: The underlying shape for this resource.
         """
         # Meta is a reserved name for resources
-        names = set(['meta'])
+        names = {'meta'}
         self._renamed = {}
 
         if self._definition.get('load'):
@@ -362,7 +362,7 @@ class ResourceModel(object):
             if name in names:
                 # This isn't good, let's raise instead of trying to keep
                 # renaming this value.
-                raise ValueError('Problem renaming {0} {1} to {2}!'.format(
+                raise ValueError('Problem renaming {} {} to {}!'.format(
                     self.name, category, name))
 
         names.add(name)

--- a/boto3/resources/params.py
+++ b/boto3/resources/params.py
@@ -19,7 +19,7 @@ from botocore import xform_name
 from ..exceptions import ResourceLoadException
 
 
-INDEX_RE = re.compile('\[(.*)\]$')
+INDEX_RE = re.compile(r'\[(.*)\]$')
 
 
 def get_data_member(parent, path):
@@ -43,7 +43,7 @@ def get_data_member(parent, path):
             parent.load()
         else:
             raise ResourceLoadException(
-                '{0} has no load method!'.format(parent.__class__.__name__))
+                '{} has no load method!'.format(parent.__class__.__name__))
 
     return jmespath.search(path, parent.meta.data)
 
@@ -91,7 +91,7 @@ def create_request_parameters(parent, request_model, params=None, index=None):
             continue
         else:
             raise NotImplementedError(
-                'Unsupported source type: {0}'.format(source))
+                'Unsupported source type: {}'.format(source))
 
         build_param_structure(params, target, value, index)
 

--- a/boto3/resources/response.py
+++ b/boto3/resources/response.py
@@ -69,7 +69,7 @@ def build_identifiers(identifiers, parent, params=None, raw_response=None):
             continue
         else:
             raise NotImplementedError(
-                'Unsupported source type: {0}'.format(source))
+                'Unsupported source type: {}'.format(source))
 
         results.append((xform_name(target), value))
 
@@ -111,7 +111,7 @@ def build_empty_response(search_path, operation_name, service_model):
                 shape = shape.member
             else:
                 raise NotImplementedError(
-                    'Search path hits shape type {0} from {1}'.format(
+                    'Search path hits shape type {} from {}'.format(
                         shape.type_name, item))
 
     # Anything not handled here is set to None

--- a/boto3/session.py
+++ b/boto3/session.py
@@ -56,7 +56,7 @@ class Session(object):
 
         # Setup custom user-agent string if it isn't already customized
         if self._session.user_agent_name == 'Botocore':
-            botocore_info = 'Botocore/{0}'.format(
+            botocore_info = 'Botocore/{}'.format(
                 self._session.user_agent_version)
             if self._session.user_agent_extra:
                 self._session.user_agent_extra += ' ' + botocore_info
@@ -81,7 +81,7 @@ class Session(object):
         self._register_default_handlers()
 
     def __repr__(self):
-        return '{0}(region_name={1})'.format(
+        return '{}(region_name={})'.format(
             self.__class__.__name__,
             repr(self._session.get_config_variable('region')))
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -43,8 +43,8 @@ def unique_id(name):
     integration tests in parallel that must create remote
     resources.
     """
-    return '{0}-{1}-{2}'.format(name, int(time.time()),
-                                random.randint(0, 10000))
+    return '{}-{}-{}'.format(name, int(time.time()),
+                             random.randint(0, 10000))
 
 
 class BaseTestCase(unittest.TestCase):

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -32,9 +32,9 @@ class BaseDynamoDBTest(unittest.TestCase):
             'MyString': 'mystring',
             'MyNumber': Decimal('1.25'),
             'MyBinary': Binary(b'\x01'),
-            'MyStringSet': set(['foo']),
-            'MyNumberSet': set([Decimal('1.25')]),
-            'MyBinarySet': set([Binary(b'\x01')]),
+            'MyStringSet': {'foo'},
+            'MyNumberSet': {Decimal('1.25')},
+            'MyBinarySet': {Binary(b'\x01')},
             'MyList': ['foo'],
             'MyMap': {'foo': 'bar'}
         }

--- a/tests/unit/dynamodb/test_types.py
+++ b/tests/unit/dynamodb/test_types.py
@@ -103,20 +103,20 @@ class TestSerializer(unittest.TestCase):
         self.assertEqual(self.serializer.serialize(b'\x01'), {'B': b'\x01'})
 
     def test_serialize_number_set(self):
-        serialized_value = self.serializer.serialize(set([1, 2, 3]))
+        serialized_value = self.serializer.serialize({1, 2, 3})
         self.assertEqual(len(serialized_value), 1)
         self.assertIn('NS', serialized_value)
         self.assertCountEqual(serialized_value['NS'], ['1', '2', '3'])
 
     def test_serialize_string_set(self):
-        serialized_value = self.serializer.serialize(set(['foo', 'bar']))
+        serialized_value = self.serializer.serialize({'foo', 'bar'})
         self.assertEqual(len(serialized_value), 1)
         self.assertIn('SS', serialized_value)
         self.assertCountEqual(serialized_value['SS'], ['foo', 'bar'])
 
     def test_serialize_binary_set(self):
         serialized_value = self.serializer.serialize(
-            set([Binary(b'\x01'), Binary(b'\x02')]))
+            {Binary(b'\x01'), Binary(b'\x02')})
         self.assertEqual(len(serialized_value), 1)
         self.assertIn('BS', serialized_value)
         self.assertCountEqual(serialized_value['BS'], [b'\x01', b'\x02'])
@@ -175,18 +175,18 @@ class TestDeserializer(unittest.TestCase):
     def test_deserialize_number_set(self):
         self.assertEqual(
             self.deserializer.deserialize(
-                {'NS': ['1', '1.25']}), set([Decimal('1'), Decimal('1.25')]))
+                {'NS': ['1', '1.25']}), {Decimal('1'), Decimal('1.25')})
 
     def test_deserialize_string_set(self):
         self.assertEqual(
             self.deserializer.deserialize(
-                {'SS': ['foo', 'bar']}), set(['foo', 'bar']))
+                {'SS': ['foo', 'bar']}), {'foo', 'bar'})
 
     def test_deserialize_binary_set(self):
         self.assertEqual(
             self.deserializer.deserialize(
                 {'BS': [b'\x00', b'\x01']}),
-            set([Binary(b'\x00'), Binary(b'\x01')]))
+            {Binary(b'\x00'), Binary(b'\x01')})
 
     def test_deserialize_list(self):
         self.assertEqual(


### PR DESCRIPTION
Python 2.6 support was removed in
0d4c8abbff7bb0e45e466b4dbf16d33f319c7414.

Use pyupgrade to use more modern Python features and syntax.

- Set literals
- Dictionary comprehension
- Omit unnecessary formatting indexes
- Avoid invalid escape sequences

For details on the pyupgrade tool, see:

https://github.com/asottile/pyupgrade