### PR TITLE
Simplify Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,10 @@
 language: python
-
-matrix:
-  include:
-    - python: 2.7
-      dist: trusty
-      sudo: false
-    - python: 3.4
-      dist: trusty
-      sudo: false
-    - python: 3.5
-      dist: trusty
-      sudo: false
-    - python: 3.6
-      dist: trusty
-      sudo: false
-    - python: 3.7
-      dist: xenial
-      sudo: true
+python:
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
+  - 3.7
 
 before_install:
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then


### PR DESCRIPTION
Specifying 'sudo' and 'dist' is no longer required. All Pythons are
available on the default test images.