### PR TITLE
Unregister handlers when session is garbage collected

### DIFF
--- a/boto3/compat.py
+++ b/boto3/compat.py
@@ -31,6 +31,13 @@ if six.PY3:
 else:
     import collections as collections_abc
 
+if six.PY2:
+    # weakref.finalize is not available in Python 2; replace with no-op.
+    def weakref_finalize(*args, **kwargs):
+        return None
+else:
+    from weakref import finalize as weakref_finalize
+
 
 if sys.platform.startswith('win'):
     def rename_file(current_filename, new_filename):


### PR DESCRIPTION
When `boto3.session.Session` registers a default handler, add a finalizer to unregister the handler when the session is garbage collected. This prevents excessive memory usage if the same `botocore.session.Session` instance is reused by many instances of `boto3.session.Session`.

Because `weakref.finalize` is not available in Python 2, this fix is implemented only for Python 3.

Fixes #2176