### PR TITLE
Fix DeprecationWarning: invalid escape sequence in INDEX_RE

### DIFF
--- a/boto3/resources/params.py
+++ b/boto3/resources/params.py
@@ -19,7 +19,7 @@ from botocore import xform_name
 from ..exceptions import ResourceLoadException
 
 
-INDEX_RE = re.compile('\[(.*)\]$')
+INDEX_RE = re.compile(r'\[(.*)\]$')
 
 
 def get_data_member(parent, path):


### PR DESCRIPTION
A warning in logs for a project using `boto3` I am updating contains:

```
... boto3/resources/params.py:22: DeprecationWarning: invalid escape sequence \[
    INDEX_RE = re.compile('\[(.*)\]$')
```

I'm making a guess that declaring this match string as `r'\[(.*)\]$'` may get rid of the warning.

Tests I am running are using Python `3.6.8`.

If you have a different solution, by all means please do that instead.
