### PR TITLE
Fix event system typo

### DIFF
--- a/docs/source/guide/events.rst
+++ b/docs/source/guide/events.rst
@@ -372,7 +372,7 @@ provide-client-params
 ~~~~~~~~~~~~~~~~~~~~~
 
 :Full Event Name:
-  ``'provide-client.service-name.operation-name'``
+  ``'provide-client-params.service-name.operation-name'``
 
   Note: ``service-name`` refers to the value used to instantiate a client i.e.
   ``boto3.client('service-name')``. ``operation-name`` refers to the


### PR DESCRIPTION
I verified the correct event name in the `botocore` code: https://github.com/boto/botocore/blob/develop/botocore/client.py#L674