### PR TITLE
Retry guide sentence casing

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -31,7 +31,7 @@ ideal report includes:
 -  If relevant, including the versions of your:
 
    -  Python interpreter
-   -  Boto 3
+   -  Boto3
    -  Optionally of the other dependencies involved (e.g. Botocore)
 
 -  If possible, create a pull request with a (failing) test case

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ===============================
-Boto 3 - The AWS SDK for Python
+Boto3 - The AWS SDK for Python
 ===============================
 
 |Build Status| |Version| |Gitter|

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,7 +50,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = 'Boto 3 Docs'
+project = 'Boto3 Docs'
 copyright = '2020, Amazon Web Services, Inc'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/source/guide/clients.rst
+++ b/docs/source/guide/clients.rst
@@ -1,12 +1,12 @@
 .. _guide_clients:
 
-Low-level Clients
+Low-level clients
 =================
 Clients provide a low-level interface to AWS whose methods map close to 1:1
 with service APIs. All service operations are supported by clients. Clients
 are generated from a JSON service definition file.
 
-Creating Clients
+Creating clients
 ----------------
 Clients are created in a similar fashion to resources::
 
@@ -24,7 +24,7 @@ resource::
     # Get the client from the resource
     sqs = sqs_resource.meta.client
 
-Service Operations
+Service operations
 ------------------
 Service operations map to client methods of the same name and provide
 access to the same operation parameters via keyword arguments::
@@ -42,7 +42,7 @@ As can be seen above, the method arguments map directly to the associated
    Parameters **must** be sent as keyword arguments. They will not work
    as positional arguments.
 
-Handling Responses
+Handling responses
 ------------------
 Responses are returned as python dictionaries. It is up to you to traverse
 or otherwise process the response for the data you need, keeping in mind

--- a/docs/source/guide/cloud9.rst
+++ b/docs/source/guide/cloud9.rst
@@ -2,7 +2,7 @@
 
 Cloud9
 ======
-You can use AWS Cloud9 with Boto 3 to write, run, and debug your Python code 
+You can use AWS Cloud9 with Boto3 to write, run, and debug your Python code 
 using just a browser. AWS Cloud9 provides an integrated development 
 environment (IDE) that includes tools such as a code editor, 
 debugger, and terminal. Because the AWS Cloud9 IDE is cloud based, 
@@ -57,10 +57,10 @@ To set up these credentials, see
 `Call AWS Services from an Environment <https://docs.aws.amazon.com/cloud9/latest/user-guide/credentials.html>`_ 
 in the *AWS Cloud9 User Guide*.
 
-Step 4: Install Boto 3
+Step 4: Install Boto3
 ----------------------
 After AWS Cloud9 opens the IDE for your development environment, use the IDE 
-to set up Boto 3. To do this, use the terminal in the IDE to 
+to set up Boto3. To do this, use the terminal in the IDE to 
 run this command:
 
     sudo pip install boto3
@@ -80,7 +80,7 @@ You can also install a specific version:
 Step 5: Download example code
 -----------------------------
 Use the terminal that you opened in the previous step, download example code 
-for Boto 3 into your AWS Cloud9 development environment. To do this, 
+for Boto3 into your AWS Cloud9 development environment. To do this, 
 use the terminal in the IDE to run this command: 
 
     git clone https://github.com/awsdocs/aws-doc-sdk-examples.git
@@ -89,7 +89,7 @@ This command downloads
 a copy of many of the code examples used across the official AWS SDK 
 documentation into your environment's root directory.
 
-To find the code examples for Boto 3, use the **Environment** window to open 
+To find the code examples for Boto3, use the **Environment** window to open 
 the :code:`your-environment-name/aws-doc-sdk-examples/python/example_code` 
 directory, where :code:`your-environment-name` is the name of your 
 development environment.

--- a/docs/source/guide/cloud9.rst
+++ b/docs/source/guide/cloud9.rst
@@ -20,7 +20,7 @@ to create it:
 #. Choose **Create a new AWS account**. 
 #. Follow the on-screen instructions to finish creating the account.
 
-Step 1: Set Up Your AWS Account
+Step 1: Set up your AWS account
 -------------------------------
 Start to use AWS Cloud9 by signing in to the AWS Cloud9 console as 
 an AWS Identity and Access Management (IAM) entity (for example, 
@@ -31,7 +31,7 @@ and to sign in to the AWS Cloud9 console, see
 `Team Setup <https://docs.aws.amazon.com/cloud9/latest/user-guide/setup.html>`_ 
 in the *AWS Cloud9 User Guide*.
 
-Step 2: Create an Environment
+Step 2: Create an environment
 -----------------------------
 After you sign in to the AWS Cloud9 console, use the console to 
 create an AWS Cloud9 development environment. (A *development environment* is 
@@ -43,7 +43,7 @@ To create an AWS Cloud9 development environment, see
 `Creating an Environment <https://docs.aws.amazon.com/cloud9/latest/user-guide/create-environment.html>`_ 
 in the *AWS Cloud9 User Guide*.
 
-Step 3: Set Up Credentials
+Step 3: Set up credentials
 --------------------------
 To call AWS services from Python code in your environment, you must provide a 
 set of AWS authentication credentials along with each call that your 
@@ -77,7 +77,7 @@ You can also install a specific version:
    The latest development version can always be found on
    `GitHub <https://github.com/boto/boto3>`_.
 
-Step 5: Download Example Code
+Step 5: Download example code
 -----------------------------
 Use the terminal that you opened in the previous step, download example code 
 for Boto 3 into your AWS Cloud9 development environment. To do this, 
@@ -97,7 +97,7 @@ development environment.
 To learn how to work with these and other code examples, see 
 :ref:`Code Examples <aws-boto3-examples>`.
 
-Step 6: Run and Debug Code
+Step 6: Run and debug code
 --------------------------
 To run your Python code in your AWS Cloud9 development environment, see 
 `Run Your Code <https://docs.aws.amazon.com/cloud9/latest/user-guide/build-run-debug.html#build-run-debug-run>`_ 
@@ -107,7 +107,7 @@ To debug your Python code, see
 `Debug Your Code <https://docs.aws.amazon.com/cloud9/latest/user-guide/build-run-debug.html#build-run-debug-debug>`_ 
 in the *AWS Cloud9 User Guide*. 
 
-Next Steps
+Next steps
 ----------
 Explore these resources to learn more about AWS Cloud9:
 

--- a/docs/source/guide/collections.rst
+++ b/docs/source/guide/collections.rst
@@ -17,7 +17,7 @@ data. Example of a collection::
     for queue in sqs.queues.all():
         print(queue.url)
 
-When Collections Make Requests
+When collections make requests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Collections can be created and manipulated without any request being made
 to the underlying service. A collection makes a remote service request under
@@ -89,7 +89,7 @@ in common::
     for instance in filtered2:
         print(instance.id)
 
-Limiting Results
+Limiting results
 ----------------
 It is possible to limit the number of items returned from a collection
 by using either the
@@ -102,7 +102,7 @@ by using either the
 In both cases, up to 10 items total will be returned. If you do not
 have 10 buckets, then all of your buckets will be returned.
 
-Controlling Page Size
+Controlling page size
 ---------------------
 Collections automatically handle paging through results, but you may want
 to control the number of items returned from a single service operation
@@ -118,7 +118,7 @@ By default, S3 will return 1000 objects at a time, so the above code
 would let you process the items in smaller batches, which could be
 beneficial for slow or unreliable internet connections.
 
-Batch Actions
+Batch bctions
 -------------
 Some collections support batch actions, which are actions that operate
 on an entire page of results at a time. They will automatically handle

--- a/docs/source/guide/collections.rst
+++ b/docs/source/guide/collections.rst
@@ -118,7 +118,7 @@ By default, S3 will return 1000 objects at a time, so the above code
 would let you process the items in smaller batches, which could be
 beneficial for slow or unreliable internet connections.
 
-Batch bctions
+Batch actions
 -------------
 Some collections support batch actions, which are actions that operate
 on an entire page of results at a time. They will automatically handle

--- a/docs/source/guide/configuration.rst
+++ b/docs/source/guide/configuration.rst
@@ -8,7 +8,7 @@ that you choose, you **must** have AWS credentials and a region set in
 order to make requests.
 
 
-Interactive Configuration
+Interactive configuration
 -------------------------
 
 If you have the `AWS CLI <http://aws.amazon.com/cli/>`_, then you can use
@@ -20,7 +20,7 @@ default region::
 Follow the prompts and it will generate configuration files in the
 correct locations for you.
 
-Configuring Credentials
+Configuring credentials
 -----------------------
 
 There are two types of configuration data in boto3: credentials and
@@ -50,7 +50,7 @@ The order in which Boto3 searches for credentials is:
 Each of those locations is discussed in more detail below.
 
 
-Method Parameters
+Method parameters
 ~~~~~~~~~~~~~~~~~
 
 The first option for providing credentials to boto3 is passing them
@@ -93,7 +93,7 @@ and ``Session`` objects include:
 * Loading credentials from some external location, e.g the OS keychain.
 
 
-Environment Variables
+Environment variables
 ~~~~~~~~~~~~~~~~~~~~~
 
 Boto3 will check these environment variables for credentials:
@@ -112,7 +112,7 @@ Boto3 will check these environment variables for credentials:
     supported by multiple AWS SDKs besides python.
 
 
-Shared Credentials File
+Shared credentials file
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 The shared credentials file has a default location of
@@ -158,7 +158,7 @@ variable or the ``profile_name`` argument when creating a Session::
     dev_s3_client = session.client('s3')
 
 
-AWS Config File
+AWS config file
 ~~~~~~~~~~~~~~~
 
 Boto3 can also load credentials from ``~/.aws/config``.  You can change
@@ -186,7 +186,7 @@ The reason that section names must start with ``profile`` in the
 that are permitted that aren't profile configurations.
 
 
-Assume Role Provider
+Assume role provider
 ~~~~~~~~~~~~~~~~~~~~
 
 .. note::
@@ -203,7 +203,7 @@ refreshing credentials as needed.
 
 You can specify the following configuration values for configuring an
 IAM role in boto3. For more information about a particular setting, see
-the section `Configuration File`_.
+the section `Configuration file`_.
 
 * ``role_arn`` - The ARN of the role you want to assume.
 * ``source_profile`` - The boto3 profile that contains credentials we should
@@ -314,7 +314,7 @@ This provider can also be configured via the environment:
     configuration.
 
 
-Boto2 Config
+Boto 2 config
 ~~~~~~~~~~~~
 
 Boto3 will attempt to load credentials from the Boto2 config file.
@@ -333,7 +333,7 @@ This credential provider is primarily for backwards compatibility purposes
 with boto2.
 
 
-IAM Role
+IAM roles
 ~~~~~~~~
 
 If you are running on Amazon EC2 and no credentials have been found
@@ -349,7 +349,7 @@ credentials.  Boto3 will automatically use IAM role credentials if it does
 not find credentials in any of the other places listed above.
 
 
-Best Practices for Configuring Credentials
+Best practices for configuring credentials
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you're running on an EC2 instance, use AWS IAM roles.  See the
@@ -373,7 +373,7 @@ locations until a value is found.  Boto3 uses these sources for configuration:
 * Environment variables
 * The ``~/.aws/config`` file.
 
-Environment Variable Configuration
+Environment variable configuration
 ----------------------------------
 
 ``AWS_ACCESS_KEY_ID``
@@ -455,7 +455,7 @@ Environment Variable Configuration
     Specifies the types of retries the SDK will use.  For more information,
     see the ``retry_mode`` configuration file section.
 
-Configuration File
+Configuration file
 ~~~~~~~~~~~~~~~~~~
 
 Boto3 will also search the ``~/.aws/config`` file when looking for
@@ -516,7 +516,7 @@ in the ``~/.aws/config`` file:
             Use the IAM role attached to the Amazon EC2 instance profile.
 
         ``EcsContainer``
-            Use the IAM role attached to the Amazon ESC container.
+            Use the IAM role attached to the Amazon ECS container.
 
         ``Environment``
             Retrieve the credentials from environment variables.

--- a/docs/source/guide/cw-example-creating-alarms.rst
+++ b/docs/source/guide/cw-example-creating-alarms.rst
@@ -11,7 +11,7 @@
 .. _aws-boto3-cw-creating-alarms:   
 
 ####################################
-Creating Alarms in Amazon CloudWatch
+Creating alarms in Amazon CloudWatch
 ####################################
 
 This Python example shows you how to:
@@ -20,7 +20,7 @@ This Python example shows you how to:
 
 * Create and delete a CloudWatch alarm
 
-The Scenario
+The scenario
 ============
 
 An alarm watches a single metric over a time period you specify, and performs one or more actions 
@@ -40,12 +40,12 @@ in the *Amazon CloudWatch User Guide*.
 
 All the example code for the Amazon Web Services (AWS) SDK for Python is available `here on GitHub <https://github.com/awsdocs/aws-doc-sdk-examples/tree/master/python/example_code>`_.
 
-Prerequisite Task
+Prerequisite tasks
 =================
 
 To set up and run this example, you must first configure your AWS credentials, as described in :doc:`quickstart`.
 
-Describe Alarms
+Describe alarms
 ===============
 
 The example below shows how to:
@@ -70,7 +70,7 @@ Example
     for response in paginator.paginate(StateValue='INSUFFICIENT_DATA'):
         print(response['MetricAlarms'])
  
-Create an Alarm for a CloudWatch Metric Alarm
+Create an alarm for a CloudWatch Metric alarm
 =============================================
 
 Create or update an alarm and associate it with the specified metric alarm. Optionally, this operation 
@@ -120,7 +120,7 @@ Example
     )
 
  
-Delete an Alarm
+Delete an alarm
 ===============
 
 Delete the specified alarms. In the event of an error, no alarms are deleted.

--- a/docs/source/guide/cw-example-events.rst
+++ b/docs/source/guide/cw-example-events.rst
@@ -11,7 +11,7 @@
 .. _aws-boto3-cw-events:   
 
 ##########################################
-Sending Events to Amazon CloudWatch Events
+Sending events to Amazon CloudWatch Events
 ##########################################
 
 This Python example shows you how to:
@@ -22,7 +22,7 @@ This Python example shows you how to:
 
 * Send events that are matched to targets for handling
 
-The Scenario
+The scenario
 ============
 
 CloudWatch Events delivers a near real-time stream of system events that describe changes in 
@@ -44,7 +44,7 @@ in the *Amazon CloudWatch Events User Guide*.
 
 All the example code for the Amazon Web Services (AWS) SDK for Python is available `here on GitHub <https://github.com/awsdocs/aws-doc-sdk-examples/tree/master/python/example_code>`_.
 
-Prerequisite Task
+Prerequisite tasks
 =================
 
 * Configure your AWS credentials, as described in :doc:`quickstart`.
@@ -98,7 +98,7 @@ Use the following trust relationship when creating the IAM role.
         }
 
 
-Create a Scheduled Rule
+Create a scheduled rule
 =======================
 
 Create or update the specified rule. Rules are enabled by default, or based on value of the state. 
@@ -131,8 +131,8 @@ Example
     print(response['RuleArn'])
 
  
-Add a Lambda Function Target
-============================
+Add an AWS Lambda function target
+=================================
 
 Add the specified targets to the specified rule, or update the targets if they are already 
 associated with the rule.
@@ -166,7 +166,7 @@ Example
     print(response)
 
  
-Send Events
+Send events
 ===========
 
 Send custom events to Amazon CloudWatch Events so that they can be matched to rules.

--- a/docs/source/guide/cw-example-metrics.rst
+++ b/docs/source/guide/cw-example-metrics.rst
@@ -11,7 +11,7 @@
 .. _aws-boto3-cw-metrics:   
 
 ######################################
-Getting Metrics from Amazon CloudWatch
+Getting metrics from Amazon CloudWatch
 ######################################
 
 This Python example shows you how to:
@@ -20,7 +20,7 @@ This Python example shows you how to:
 
 * Publish data points to CloudWatch metrics
 
-The Scenario
+The scenario
 ============
 
 Metrics are data about the performance of your systems. You can enable detailed monitoring of some 
@@ -39,13 +39,13 @@ For more information about CloudWatch metrics, see `Using Amazon CloudWatch Metr
 
 All the example code for the Amazon Web Services (AWS) SDK for Python is available `here on GitHub <https://github.com/awsdocs/aws-doc-sdk-examples/tree/master/python/example_code>`_.
 
-Prerequisite Task
+Prerequisite tasks
 =================
 
 To set up and run this example, you must first configure your AWS credentials, as described in :doc:`quickstart`.
 
 
-List Metrics
+List metrics
 ===============
 
 List the metric alarm events uploaded to CloudWatch Logs. 
@@ -75,7 +75,7 @@ Example
         print(response['Metrics'])
 
  
-Publish Custom Metrics
+Publish custom metrics
 ======================
 
 Publish metric data points to Amazon CloudWatch. Amazon CloudWatch associates the data points with 

--- a/docs/source/guide/cw-example-subscription-filters.rst
+++ b/docs/source/guide/cw-example-subscription-filters.rst
@@ -11,12 +11,12 @@
 .. _aws-boto3-cw-subscription-filters:   
 
 ####################################################
-Using Subscription Filters in Amazon CloudWatch Logs
+Using subscription filters in Amazon CloudWatch Logs
 ####################################################
 
 This Python example shows you how to create and delete filters for log events in CloudWatch Logs.
 
-The Scenario
+The scenario
 ============
 
 Subscriptions provide access to a real-time feed of log events from CloudWatch Logs and deliver that 
@@ -41,7 +41,7 @@ in the Amazon CloudWatch Logs User Guide.
 
 All the example code for the Amazon Web Services (AWS) SDK for Python is available `here on GitHub <https://github.com/awsdocs/aws-doc-sdk-examples/tree/master/python/example_code>`_.
 
-Prerequisite Tasks
+Prerequisite tasks
 ==================
 
 * Configure your AWS credentials, as described in :doc:`quickstart`.
@@ -85,7 +85,7 @@ Prerequisite Tasks
            ]
         }
  
-List Existing Subscription Filters
+List existing subscription filters
 ==================================
 
 List the subscription filters for the specified log group.
@@ -115,7 +115,7 @@ Example
 
 
  
-Create a Subscription Filter
+Create a subscription filter
 ============================
 
 Create or update a subscription filter and associates it with the specified log group.
@@ -144,7 +144,7 @@ Example
     )
 
  
-Delete a Subscription Filter
+Delete a subscription filter
 ============================
 
 The example below shows how to:

--- a/docs/source/guide/cw-example-using-alarms.rst
+++ b/docs/source/guide/cw-example-using-alarms.rst
@@ -11,7 +11,7 @@
 .. _aws-boto3-cw-using-alarms:   
 
 ########################################
-Using Alarm Actions in Amazon CloudWatch
+Using alarm actions in Amazon CloudWatch
 ########################################
 
 This Python example shows you how to:
@@ -20,7 +20,7 @@ This Python example shows you how to:
 
 * Disable a CloudWatch alarm action
 
-The Scenario
+The scenario
 ============
 
 Using alarm actions, you can create alarms that automatically stop, terminate, reboot, or recover 
@@ -42,7 +42,7 @@ in the *Amazon CloudWatch User Guide*.
 
 All the example code for the Amazon Web Services (AWS) SDK for Python is available `here on GitHub <https://github.com/awsdocs/aws-doc-sdk-examples/tree/master/python/example_code>`_.
 
-Prerequisite Task
+Prerequisite tasks
 =================
 
 * Configure your AWS credentials, as described in :doc:`quickstart`.
@@ -75,7 +75,7 @@ Prerequisite Task
            ]
         }
  
-Create and Enable Actions on an Alarm
+Create and enable actions on an alarm
 =====================================
 
 Create or update an alarm and associate it with the specified metric. Optionally, this operation 
@@ -127,7 +127,7 @@ Example
         Unit='Seconds'
     )
 
-Disable Actions on an Alarm
+Disable actions on an alarm
 ===========================
 
 Disable the actions for the specified alarms. When an alarm's actions are disabled, the alarm actions 

--- a/docs/source/guide/cw-examples.rst
+++ b/docs/source/guide/cw-examples.rst
@@ -11,7 +11,7 @@
 .. _aws-boto3-cw-examples:
 
 ##########################
-Amazon CloudWatch Examples
+Amazon CloudWatch examples
 ##########################
 
 You can use the following examples to access Amazon Cloudwatch (CloudWatch) by using Amazon Boto. For more

--- a/docs/source/guide/dynamodb.rst
+++ b/docs/source/guide/dynamodb.rst
@@ -8,7 +8,7 @@ resources in order to create tables, write items to tables, modify existing
 items, retrieve items, and query/filter the items in the table.
 
 
-Creating a New Table
+Creating a new table
 --------------------
 
 In order to create a new table, use the
@@ -54,7 +54,7 @@ In order to create a new table, use the
     # Print out some data about the table.
     print(table.item_count)
 
-Expected Output::
+Expected output::
 
     0
 
@@ -64,7 +64,7 @@ This method will return a :py:class:`DynamoDB.Table` resource to call
 additional methods on the created table.
 
 
-Using an Existing Table
+Using an existing table
 -----------------------
 It is also possible to create a :py:class:`DynamoDB.Table` resource from
 an existing table::
@@ -86,12 +86,12 @@ an existing table::
     # values will be set based on the response.
     print(table.creation_date_time)
 
-Expected Output (Please note that the actual times will probably not match up)::
+Expected output (Please note that the actual times will probably not match up)::
 
     2015-06-26 12:42:45.149000-07:00
 
 
-Creating a New Item
+Creating a new item
 -------------------
 
 Once you have a :py:class:`DynamoDB.Table` resource you can add new items
@@ -111,7 +111,7 @@ For all of the valid types that can be used for an item, refer to
 :ref:`ref_valid_dynamodb_types`.
 
 
-Getting an Item
+Getting an item
 ---------------
 You can then retrieve the object using :py:meth:`DynamoDB.Table.get_item`::
 
@@ -125,7 +125,7 @@ You can then retrieve the object using :py:meth:`DynamoDB.Table.get_item`::
     print(item)
 
 
-Expected Output::
+Expected output::
 
     {u'username': u'janedoe',
      u'first_name': u'Jane',
@@ -134,8 +134,8 @@ Expected Output::
      u'age': Decimal('25')}
 
 
-Updating Item
--------------
+Updating an item
+----------------
 
 You can then update attributes of the item in the table::
 
@@ -162,7 +162,7 @@ Then if you retrieve the item again, it will be updated appropriately::
     print(item)
 
 
-Expected Output::
+Expected output::
 
     {u'username': u'janedoe',
      u'first_name': u'Jane',
@@ -171,8 +171,8 @@ Expected Output::
      u'age': Decimal('26')}
 
 
-Deleting Item
--------------
+Deleting an item
+----------------
 You can also delete the item using :py:meth:`DynamoDB.Table.delete_item`::
     
     table.delete_item(
@@ -183,7 +183,7 @@ You can also delete the item using :py:meth:`DynamoDB.Table.delete_item`::
     )
 
 
-Batch Writing
+Batch writing
 -------------
 If you are loading a lot of data at a time, you can make use of
 :py:meth:`DynamoDB.Table.batch_writer` so you can both speed up the process and
@@ -332,7 +332,7 @@ after de-duplicate:
     )
 
 
-Querying and Scanning
+Querying and scanning
 ---------------------
 
 With the table full of items, you can then query or scan the items in the table
@@ -357,7 +357,7 @@ This queries for all of the users whose ``username`` key equals ``johndoe``::
     print(items)
 
 
-Expected Output::
+Expected output::
 
     [{u'username': u'johndoe',
       u'first_name': u'John',
@@ -380,7 +380,7 @@ example, this scans for all the users whose ``age`` is less than ``27``::
     print(items)
 
 
-Expected Output::
+Expected output::
 
     [{u'username': u'johndoe',
       u'first_name': u'John',
@@ -414,7 +414,7 @@ users whose ``first_name`` starts with ``J`` and whose ``account_type`` is
     print(items)
 
 
-Expected Output::
+Expected output::
 
     [{u'username': u'janedoering',
       u'first_name': u'Jane',
@@ -437,7 +437,7 @@ scans for all users whose ``state`` in their ``address`` is ``CA``::
     print(items)
 
 
-Expected Output::
+Expected output::
 
     [{u'username': u'johndoe',
       u'first_name': u'John',
@@ -463,7 +463,7 @@ For more information on the various conditions you can use for queries and
 scans, refer to :ref:`ref_dynamodb_conditions`.
 
 
-Deleting a Table
+Deleting a table
 ----------------
 Finally, if you want to delete your table call
 :py:meth:`DynamoDB.Table.delete`::

--- a/docs/source/guide/ec2-example-elastic-ip-addresses.rst
+++ b/docs/source/guide/ec2-example-elastic-ip-addresses.rst
@@ -11,7 +11,7 @@
 .. _aws-boto-ec2-example-elastic-ip-addresses:
 
 ########################################
-Using Elastic IP Addresses in Amazon EC2
+Using Elastic IP addresses in Amazon EC2
 ########################################
 
 This Python example shows you how to:
@@ -22,7 +22,7 @@ This Python example shows you how to:
 
 * Release an Elastic IP address
 
-The Scenario
+The scenario
 ============
 
 An Elastic IP address is a static IP address designed for dynamic cloud computing. An Elastic IP 
@@ -48,12 +48,12 @@ Prerequisite Tasks
 
 All the example code for the Amazon Web Services (AWS) SDK for Python is available `here on GitHub <https://github.com/awsdocs/aws-doc-sdk-examples/tree/master/python/example_code>`_.
 
-Prerequisite Task
+Prerequisite tasks
 =================
 
 To set up and run this example, you must first configure your AWS credentials, as described in :doc:`quickstart`.
 
-Describe Elastic IP Addresses
+Describe Elastic IP addresses
 =============================
 
 An Elastic IP address is a static IPv4 address designed for dynamic cloud computing. An Elastic IP 
@@ -80,7 +80,7 @@ Example
     response = ec2.describe_addresses(Filters=filters)
     print(response)
 
-Allocate and Associate an Elastic IP Address with an Amazon EC2 Instance
+Allocate and associate an Elastic IP address with an Amazon EC2 instance
 ========================================================================
 
 An *Elastic IP address* is a static IPv4 address designed for dynamic cloud computing. An Elastic IP 
@@ -112,7 +112,7 @@ Example
 
 
  
-Release an Elastic IP Address
+Release an Elastic IP address
 =============================
 
 After releasing an Elastic IP address, it is released to the IP address pool and might be unavailable 

--- a/docs/source/guide/ec2-example-key-pairs.rst
+++ b/docs/source/guide/ec2-example-key-pairs.rst
@@ -11,7 +11,7 @@
 .. _aws-boto-ec2-example-key-pairs:
 
 #################################
-Working with Amazon EC2 Key Pairs
+Working with Amazon EC2 key pairs
 #################################
 
 This Python example shows you how to:
@@ -22,7 +22,7 @@ This Python example shows you how to:
 
 * Delete an existing key pair
 
-The Scenario
+The scenario
 ============
 
 Amazon EC2 uses public–key cryptography to encrypt and decrypt login information. Public–key cryptography 
@@ -45,12 +45,12 @@ in the *Amazon EC2 User Guide for Windows Instances*.
 
 All the example code for the Amazon Web Services (AWS) SDK for Python is available `here on GitHub <https://github.com/awsdocs/aws-doc-sdk-examples/tree/master/python/example_code>`_.
 
-Prerequisite Task
+Prerequisite tasks
 =================
 
 To set up and run this example, you must first configure your AWS credentials, as described in :doc:`quickstart`.
     
-Describe Key Pairs
+Describe key pairs
 ==================
 
 Describe one or more of your key pairs.
@@ -72,7 +72,7 @@ Example
     print(response)
 
 
-Create a Key Pair
+Create a key pair
 =================
 
 Create a 2048-bit RSA key pair with the specified name. Amazon EC2 stores the public key and displays 
@@ -96,7 +96,7 @@ Example
     print(response)
 
 
-Delete a Key Pair
+Delete a key pair
 =================
 
 Delete the specified key pair, by removing the public key from Amazon EC2.

--- a/docs/source/guide/ec2-example-managing-instances.rst
+++ b/docs/source/guide/ec2-example-managing-instances.rst
@@ -11,7 +11,7 @@
 .. _aws-boto3-ec2-managing-instances:   
 
 #############################
-Managing Amazon EC2 Instances
+Managing Amazon EC2 instances
 #############################
 
 This Python example shows you how to:
@@ -24,7 +24,7 @@ This Python example shows you how to:
 
 * Reboot an Amazon EC2 instance
 
-The Scenario
+The scenario
 ============
 
 In this example, Python code is used perform several basic instance management operations. The code uses the 
@@ -49,12 +49,12 @@ in the *Amazon EC2 User Guide for Windows Instances*.
 
 All the example code for the Amazon Web Services (AWS) SDK for Python is available `here on GitHub <https://github.com/awsdocs/aws-doc-sdk-examples/tree/master/python/example_code>`_.
 
-Prerequisite Task
+Prerequisite tasks
 =================
 
 To set up and run this example, you must first configure your AWS credentials, as described in :doc:`quickstart`.
     
-Describe Instances
+Describe instances
 ==================
 
 An EC2 instance is a virtual server in Amazon's Elastic Compute Cloud (EC2) for running applications 
@@ -79,7 +79,7 @@ Example
     print(response)
 
 
-Monitor and Unmonitor Instances
+Monitor and unmonitor instances
 ===============================
 
 Enable or disable detailed monitoring for a running instance. If detailed monitoring is not enabled, 
@@ -112,7 +112,7 @@ Example
     print(response)
 
 
-Start and Stop Instances
+Start and stop instances
 ========================
 
 Instances that use Amazon EBS volumes as their root devices can be quickly stopped and started. When 
@@ -175,7 +175,7 @@ Example
             print(e)
 
 
-Reboot Instances
+Reboot instances
 ================
 Request a reboot of one or more instances. This operation is asynchronous; it only queues a request 
 to reboot the specified instances. The operation succeeds if the instances are valid and belong to 

--- a/docs/source/guide/ec2-example-regions-avail-zones.rst
+++ b/docs/source/guide/ec2-example-regions-avail-zones.rst
@@ -19,7 +19,7 @@ Availability Zones. Each region is a separate geographic area. Each region has m
 locations known as Availability Zones. Amazon EC2 provides the ability to place instances and data 
 in multiple locations.
 
-The Scenario
+The scenario
 ============
 
 In this example, Python code is used to get details about regions and Availability Zones. The code uses the 
@@ -37,7 +37,7 @@ in the *Amazon EC2 User Guide for Windows Instances*.
 
 All the example code for the Amazon Web Services (AWS) SDK for Python is available `here on GitHub <https://github.com/awsdocs/aws-doc-sdk-examples/tree/master/python/example_code>`_.
 
-Prerequisite Task
+Prerequisite tasks
 =================
 
 To set up and run this example, you must first configure your AWS credentials, as described in :doc:`quickstart`.
@@ -45,7 +45,7 @@ To set up and run this example, you must first configure your AWS credentials, a
 Describe Regions and Availability Zones
 =======================================
 
-* Describe one or more regions that are currently available to you. 
+* Describe one or more Regions that are currently available to you. 
 
 * Describe one or more of the Availability Zones that are available to you. The results include zones 
   only for the region you're currently using. If there is an event impacting an Availability Zone, 

--- a/docs/source/guide/ec2-example-regions-avail-zones.rst
+++ b/docs/source/guide/ec2-example-regions-avail-zones.rst
@@ -53,10 +53,10 @@ Describe Regions and Availability Zones
 
 The example below shows how to:
  
-* Describe regions using 
+* Describe Regions using 
   `describe_regions <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_regions>`_.
 
-* Describe AvailabilityZones using 
+* Describe Availability Zones using 
   `describe_availability_zones <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_availability_zones>`_.
  
 Example

--- a/docs/source/guide/ec2-example-security-group.rst
+++ b/docs/source/guide/ec2-example-security-group.rst
@@ -11,7 +11,7 @@
 .. _aws-boto-ec2-example-security-group:
 
 ##########################################
-Working with Security Groups in Amazon EC2
+Working with security groups in Amazon EC2
 ##########################################
 
 This Python example shows you how to:
@@ -22,7 +22,7 @@ This Python example shows you how to:
 
 * Delete an existing security group
 
-The Scenario
+The scenario
 ============
 
 An Amazon EC2 security group acts as a virtual firewall that controls the traffic for one or more instances. 
@@ -50,12 +50,12 @@ in the *Amazon EC2 User Guide for Windows Instances*.
 
 All the example code for the Amazon Web Services (AWS) SDK for Python is available `here on GitHub <https://github.com/awsdocs/aws-doc-sdk-examples/tree/master/python/example_code>`_.
 
-Prerequisite Tasks
+Prerequisite tasks
 ==================
 
 To set up and run this example, you must first configure your AWS credentials, as described in :doc:`quickstart`.
 
-Describe Security Groups
+Describe security groups
 =======================
 Describe one or more of your security groups.
 
@@ -86,7 +86,7 @@ Example
     except ClientError as e:
         print(e)
 
-Create a Security Group and Rules
+Create a security group and rules
 =================================
 
 * Create a security group.
@@ -140,7 +140,7 @@ Example
     except ClientError as e:
         print(e)
 
-Delete a Security Group
+Delete a security group
 =======================
 
 If you attempt to delete a security group that is associated with an instance, or is referenced by 

--- a/docs/source/guide/ec2-examples.rst
+++ b/docs/source/guide/ec2-examples.rst
@@ -11,7 +11,7 @@
 .. _aws-boto-ec2-examples:
 
 ###################
-Amazon EC2 Examples
+Amazon EC2 examples
 ###################
 
 .. meta::

--- a/docs/source/guide/error-handling.rst
+++ b/docs/source/guide/error-handling.rst
@@ -6,12 +6,12 @@ Error handling
 Overview
 --------
 AWS services require clients to use a variety of parameters, behaviors, or limits when interacting with their APIs.
-Boto 3 provides many features to assist in navigating the errors and exceptions that you might encounter when interacting with AWS services.
+Boto3 provides many features to assist in navigating the errors and exceptions that you might encounter when interacting with AWS services.
 
 Specifically, this guide provides details on the following:
 
-* How to find what exceptions there are to catch when using Boto 3 and interacting with AWS services
-* How to catch/handle exceptions thrown by both Boto 3 and AWS services
+* How to find what exceptions there are to catch when using Boto3 and interacting with AWS services
+* How to catch/handle exceptions thrown by both Boto3 and AWS services
 * How to parse error responses from AWS services
 
 Why catch exceptions from AWS and Boto
@@ -22,11 +22,11 @@ Why catch exceptions from AWS and Boto
 
 Determining what exceptions to catch
 ------------------------------------
-Exceptions that you might encounter when using Boto 3 will come from one of two sources: botocore or the AWS services your client is interacting with.
+Exceptions that you might encounter when using Boto3 will come from one of two sources: botocore or the AWS services your client is interacting with.
 
 Botocore exceptions
 ~~~~~~~~~~~~~~~~~~~
-These exceptions are statically defined within the botocore package, a dependency of Boto 3. The exceptions are related to issues with client-side behaviors, configurations, or validations. You can generate a list of the statically defined botocore exceptions using the following code:
+These exceptions are statically defined within the botocore package, a dependency of Boto3. The exceptions are related to issues with client-side behaviors, configurations, or validations. You can generate a list of the statically defined botocore exceptions using the following code:
 
 .. code-block:: python
 
@@ -109,7 +109,7 @@ This produces a list of statically defined botocore exceptions::
 
 AWS service exceptions
 ~~~~~~~~~~~~~~~~~~~~~~
-AWS service exceptions are caught with the underlying botocore exception, ``ClientError``. After you catch this exception, you can parse through the response for specifics around that error, including the service-specific exception. Exceptions and errors from AWS services vary widely. You can quickly get a list of an AWS service’s exceptions using Boto 3.
+AWS service exceptions are caught with the underlying botocore exception, ``ClientError``. After you catch this exception, you can parse through the response for specifics around that error, including the service-specific exception. Exceptions and errors from AWS services vary widely. You can quickly get a list of an AWS service’s exceptions using Boto3.
 
 For a complete list of error responses from the services you’re using, consult the individual service’s `AWS documentation <https://docs.aws.amazon.com/>`_, specifically the error response section of the AWS service’s API reference. These references also provide context around the exceptions and errors.
 
@@ -118,7 +118,7 @@ Catching exceptions when using a low-level client
 
 Catching botocore exceptions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Botocore exceptions are statically defined in the botocore package. Any Boto 3 clients you create will use these same statically defined exception classes. The most common botocore exception you’ll encounter is ``ClientError``. This is a general exception when an error response is provided by an AWS service to your Boto 3 client’s request.
+Botocore exceptions are statically defined in the botocore package. Any Boto3 clients you create will use these same statically defined exception classes. The most common botocore exception you’ll encounter is ``ClientError``. This is a general exception when an error response is provided by an AWS service to your Boto3 client’s request.
 
 Additional client-side issues with SSL negotiation, client misconfiguration, or AWS service validation errors will also throw botocore exceptions. Here’s a generic example of how you might catch botocore exceptions.
 
@@ -141,9 +141,9 @@ Additional client-side issues with SSL negotiation, client misconfiguration, or 
 
 Parsing error responses and catching exceptions from AWS services
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Unlike botocore exceptions, AWS service exceptions aren't statically defined in Boto 3. This is due to errors and exceptions from AWS services varying widely and being subject to change. To properly catch an exception from an AWS service, you must parse the error response from the service. The error response provided to your client from the AWS service follows a common structure and is minimally processed and not obfuscated by Boto 3.
+Unlike botocore exceptions, AWS service exceptions aren't statically defined in Boto3. This is due to errors and exceptions from AWS services varying widely and being subject to change. To properly catch an exception from an AWS service, you must parse the error response from the service. The error response provided to your client from the AWS service follows a common structure and is minimally processed and not obfuscated by Boto3.
 
-Using Boto 3, the error response from an AWS service will look similar to a success response, except that an ``Error`` nested dictionary will appear with the ``ResponseMetadata`` nested dictionary. Here is an example of what an error response might look like::
+Using Boto3, the error response from an AWS service will look similar to a success response, except that an ``Error`` nested dictionary will appear with the ``ResponseMetadata`` nested dictionary. Here is an example of what an error response might look like::
 
     {
         'Error': {
@@ -159,9 +159,9 @@ Using Boto 3, the error response from an AWS service will look similar to a succ
         }
     }
 
-Boto 3 classifies all AWS service errors and exceptions as ``ClientError`` exceptions. When attempting to catch AWS service exceptions, one way is to catch ``ClientError`` and then parse the error response for the AWS service-specific exception.
+Boto3 classifies all AWS service errors and exceptions as ``ClientError`` exceptions. When attempting to catch AWS service exceptions, one way is to catch ``ClientError`` and then parse the error response for the AWS service-specific exception.
 
-Using Amazon Kinesis as an example service, you can use Boto 3 to catch the exception ``LimitExceededException`` and insert your own logging message when your code experiences request throttling from the AWS service.
+Using Amazon Kinesis as an example service, you can use Boto3 to catch the exception ``LimitExceededException`` and insert your own logging message when your code experiences request throttling from the AWS service.
 
 .. code-block:: python
 
@@ -187,7 +187,7 @@ Using Amazon Kinesis as an example service, you can use Boto 3 to catch the exce
 
 .. note::
 
-    The Boto 3 ``standard`` retry mode will catch throttling errors and exceptions, and will back off and retry them for you.
+    The Boto3 ``standard`` retry mode will catch throttling errors and exceptions, and will back off and retry them for you.
 
 Additionally, you can also access some of the dynamic service-side exceptions from the client’s exception property. Using the previous example, you would need to modify only the ``except`` clause.
 

--- a/docs/source/guide/events.rst
+++ b/docs/source/guide/events.rst
@@ -1,4 +1,4 @@
-Extensibility Guide
+Extensibility guide
 ===================
 
 All of Boto3's resource and client classes are generated at runtime.
@@ -11,7 +11,7 @@ However it is still possible to extend the functionality of classes through
 Boto3's event system.
 
 
-An Introduction to the Event System
+An introduction to the event system
 -----------------------------------
 
 Boto3's event system allows users to register a function to
@@ -74,7 +74,7 @@ Here are the takeaways from this example:
   `provide-client-params`_
 
 
-A Hierarchical Structure
+A hierarchical structure
 ------------------------
 
 The event system also provides a hierarchy for registering events such that
@@ -131,7 +131,7 @@ method is called via its registration to ``'provide-client-params.s3'``. The
 registered ``add_my_specific_bucket`` function is never called.
 
 
-Wildcard Matching
+Wildcard matching
 -----------------
 
 Another aspect of Boto3's event system is that it has the capability
@@ -169,7 +169,7 @@ to ``'provide-client-params.s3.*'`` which is more specific than the event
 ``'provide-client.s3'``.
 
 
-Isolation of Event Systems
+Isolation of event systems
 --------------------------
 
 The event system in Boto3 has the notion of isolation:
@@ -206,7 +206,7 @@ inject ``'myotherbucket'`` for its ``list_objects`` method call because
 was registered to ``client2``.
 
 
-Boto3 Specific Events
+Boto3 specific events
 ---------------------
 
 Boto3 emits a set of events that users can register to
@@ -219,7 +219,7 @@ Here is the list of events that users of boto3 can register handlers to:
 * ``'provide-client-params'``
 
 
-creating-client-class
+`creating-client-class`
 ~~~~~~~~~~~~~~~~~~~~~
 
 :Full Event Name:
@@ -292,7 +292,7 @@ creating-client-class
     Client instantiated!
 
 
-creating-resource-class
+`creating-resource-class`
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 :Full Event Name:
@@ -368,7 +368,7 @@ creating-resource-class
     Resource instantiated!
 
 
-provide-client-params
+`provide-client-params`
 ~~~~~~~~~~~~~~~~~~~~~
 
 :Full Event Name:

--- a/docs/source/guide/events.rst
+++ b/docs/source/guide/events.rst
@@ -1,24 +1,24 @@
 Extensibility guide
 ===================
 
-All of Boto 3's resource and client classes are generated at runtime.
+All of Boto3's resource and client classes are generated at runtime.
 This means that you cannot directly inherit and then extend the
 functionality of these classes because they do not exist until the
 program actually starts running.
 
 
 However it is still possible to extend the functionality of classes through
-Boto 3's event system.
+Boto3's event system.
 
 
 An introduction to the event system
 -----------------------------------
 
-Boto 3's event system allows users to register a function to
+Boto3's event system allows users to register a function to
 a specific event. Then once the running program reaches a line that
-emits that specific event, Boto 3 will call every function
+emits that specific event, Boto3 will call every function
 registered to the event in the order in which they were registered.
-When Boto 3 calls each of these registered functions,
+When Boto3 calls each of these registered functions,
 it will call each of them with a specific set of
 keyword arguments that are associated with that event.
 Then once the registered function
@@ -134,7 +134,7 @@ registered ``add_my_specific_bucket`` function is never called.
 Wildcard matching
 -----------------
 
-Another aspect of Boto 3's event system is that it has the capability
+Another aspect of Boto3's event system is that it has the capability
 to do wildcard matching using the ``'*'`` notation. Here is an example
 of using wildcards in the event system::
 
@@ -172,7 +172,7 @@ to ``'provide-client-params.s3.*'`` which is more specific than the event
 Isolation of event systems
 --------------------------
 
-The event system in Boto 3 has the notion of isolation:
+The event system in Boto3 has the notion of isolation:
 all clients maintain their own set of registered handlers. For example if a
 handler is registered to one client's event system, it will not be registered
 to another client's event system::
@@ -206,13 +206,13 @@ inject ``'myotherbucket'`` for its ``list_objects`` method call because
 was registered to ``client2``.
 
 
-Boto 3 specific events
+Boto3 specific events
 ---------------------
 
-Boto 3 emits a set of events that users can register to
+Boto3 emits a set of events that users can register to
 customize clients or resources and modify the behavior of method calls.
 
-Here is the list of events that users of Boto 3 can register handlers to:
+Here is the list of events that users of Boto3 can register handlers to:
 
 * ``'creating-client-class``
 * ``'creating-resource-class``

--- a/docs/source/guide/events.rst
+++ b/docs/source/guide/events.rst
@@ -1,24 +1,24 @@
 Extensibility guide
 ===================
 
-All of Boto3's resource and client classes are generated at runtime.
+All of Boto 3's resource and client classes are generated at runtime.
 This means that you cannot directly inherit and then extend the
 functionality of these classes because they do not exist until the
 program actually starts running.
 
 
 However it is still possible to extend the functionality of classes through
-Boto3's event system.
+Boto 3's event system.
 
 
 An introduction to the event system
 -----------------------------------
 
-Boto3's event system allows users to register a function to
+Boto 3's event system allows users to register a function to
 a specific event. Then once the running program reaches a line that
-emits that specific event, Boto3 will call every function
+emits that specific event, Boto 3 will call every function
 registered to the event in the order in which they were registered.
-When Boto3 calls each of these registered functions,
+When Boto 3 calls each of these registered functions,
 it will call each of them with a specific set of
 keyword arguments that are associated with that event.
 Then once the registered function
@@ -134,7 +134,7 @@ registered ``add_my_specific_bucket`` function is never called.
 Wildcard matching
 -----------------
 
-Another aspect of Boto3's event system is that it has the capability
+Another aspect of Boto 3's event system is that it has the capability
 to do wildcard matching using the ``'*'`` notation. Here is an example
 of using wildcards in the event system::
 
@@ -172,7 +172,7 @@ to ``'provide-client-params.s3.*'`` which is more specific than the event
 Isolation of event systems
 --------------------------
 
-The event system in Boto3 has the notion of isolation:
+The event system in Boto 3 has the notion of isolation:
 all clients maintain their own set of registered handlers. For example if a
 handler is registered to one client's event system, it will not be registered
 to another client's event system::
@@ -206,13 +206,13 @@ inject ``'myotherbucket'`` for its ``list_objects`` method call because
 was registered to ``client2``.
 
 
-Boto3 specific events
+Boto 3 specific events
 ---------------------
 
-Boto3 emits a set of events that users can register to
+Boto 3 emits a set of events that users can register to
 customize clients or resources and modify the behavior of method calls.
 
-Here is the list of events that users of boto3 can register handlers to:
+Here is the list of events that users of Boto 3 can register handlers to:
 
 * ``'creating-client-class``
 * ``'creating-resource-class``

--- a/docs/source/guide/examples.rst
+++ b/docs/source/guide/examples.rst
@@ -11,7 +11,7 @@
 .. _aws-boto3-examples:
 
 #############
-Code Examples
+Code examples
 #############
 
 This section describes code examples that demonstrate how to use the AWS SDK

--- a/docs/source/guide/iam-example-managing-access-keys.rst
+++ b/docs/source/guide/iam-example-managing-access-keys.rst
@@ -11,12 +11,12 @@
 .. _aws-boto3-iam-managing-access-keys:   
 
 ########################
-Managing IAM Access Keys
+Managing IAM access keys
 ########################
 
 This Python example shows you how to manage the access keys of your users.
 
-The Scenario
+The scenario
 ============
 
 Users need their own access keys to make programmatic calls to AWS from the Amazon Web Services (AWS) 
@@ -43,12 +43,12 @@ in the *IAM User Guide*.
 
 All the example code for the Amazon Web Services (AWS) SDK for Python is available `here on GitHub <https://github.com/awsdocs/aws-doc-sdk-examples/tree/master/python/example_code>`_.
 
-Prerequisite Task
+Prerequisite tasks
 =================
 
 To set up and run this example, you must first configure your AWS credentials, as described in :doc:`quickstart`.
 
-Create Access Keys for a User
+Create access keys for a user
 =============================
 
 Create a new AWS secret access key and corresponding AWS access key ID for the specified user. The 
@@ -76,7 +76,7 @@ Example
 
     print(response['AccessKey'])
 
-List a User's Access Keys
+List a user's access keys
 =========================
 
 List information about the access key IDs associated with the specified IAM user. If there are none, 
@@ -109,7 +109,7 @@ Example
         print(response)
 
 
-Get the Access Key Last Used
+Get the access key last used
 ============================
 
 Get information about when the specified access key was last used. The information includes the 
@@ -141,7 +141,7 @@ Example
 
 
  
-Update Access Key Status
+Update access key status
 ========================
 
 Change the status of the specified access key from Active to Inactive, or vice versa. This action 
@@ -170,7 +170,7 @@ Example
     )
 
     
-Delete an Access Key
+Delete an access key
 ====================
 
 Delete the access key pair associated with the specified IAM user.

--- a/docs/source/guide/iam-example-managing-account-aliases.rst
+++ b/docs/source/guide/iam-example-managing-account-aliases.rst
@@ -11,12 +11,12 @@
 .. _aws-boto3-iam-managing-account-aliases:   
 
 ############################
-Managing IAM Account Aliases
+Managing IAM account aliases
 ############################
 
 This Python example shows you how to manage aliases for your AWS account ID.
 
-The Scenario
+The scenario
 ============
 
 If you want the URL for your sign-in page to contain your company name or other friendly identifier 
@@ -37,12 +37,12 @@ in the *IAM User Guide*.
 
 All the example code for the Amazon Web Services (AWS) SDK for Python is available `here on GitHub <https://github.com/awsdocs/aws-doc-sdk-examples/tree/master/python/example_code>`_.
 
-Prerequisite Task
+Prerequisite tasks
 =================
 
 To set up and run this example, you must first configure your AWS credentials, as described in :doc:`quickstart`.
 
-Create an Account Alias
+Create an account alias
 =======================
 
 Create an alias for your AWS account. For information about using an AWS account alias, see 
@@ -69,7 +69,7 @@ Example
         AccountAlias='ALIAS'
     )
 
-List an Account Alias
+List an account alias
 =====================
 
 List the account alias associated with the AWS account (Note: you can have only one). For information 
@@ -98,7 +98,7 @@ Example
     for response in paginator.paginate():
         print(response['AccountAliases'])
 
-Delete an Account Alias
+Delete an account alias
 =========================
 
 Delete the specified AWS account alias. For information about using an AWS account alias, see 

--- a/docs/source/guide/iam-example-managing-users.rst
+++ b/docs/source/guide/iam-example-managing-users.rst
@@ -11,12 +11,12 @@
 .. _aws-boto3-iam-examples-managing-users:   
 
 ******************
-Managing IAM Users
+Managing IAM users
 ******************
 
 This Python example shows you how to create a user, list users, update a user name and delete a user.
 
-The Scenario
+The scenario
 ============
 
 In this example Python code is used to create and manage users in IAM. The code uses the 
@@ -36,12 +36,12 @@ All the example code for the Amazon Web Services (AWS) SDK for Python is availab
 For more information about IAM users, see `IAM Users <http://docs.aws.amazon.com/IAM/latest/UserGuide/id_users.html>`_ 
 in the *IAM User Guide*.
 
-Prerequisite Task
+Prerequisite tasks
 =================
 
 To set up and run this example, you must first configure your AWS credentials, as described in :doc:`quickstart`.
     
-Create a User
+Create a user
 =============
 
 Create a new IAM user for your AWS account.
@@ -72,7 +72,7 @@ Example
 
     print(response)
 
-List Users in Your Account
+List users in your account
 ==========================
 
 List the IAM users.
@@ -99,7 +99,7 @@ Example
     for response in paginator.paginate():
         print(response)
 
-Update a User's Name
+Update a user's name
 ====================
 
 Update the name and/or the path of the specified IAM user.
@@ -132,7 +132,7 @@ Example
     )
 
  
-Delete a User
+Delete a user
 =============
 
 Delete the specified IAM user. The user must not belong to any groups or have any access keys, signing 

--- a/docs/source/guide/iam-example-policies.rst
+++ b/docs/source/guide/iam-example-policies.rst
@@ -11,12 +11,12 @@
 .. _aws-boto3-iam-examples-policies:
 
 #########################
-Working with IAM Policies
+Working with IAM policies
 #########################
 
 This Python example shows you how to create and get IAM policies and attach and detach IAM policies from roles.
 
-The Scenario
+The scenario
 ============
 
 You grant permissions to a user by creating a policy, which is a document that lists the actions 
@@ -41,12 +41,12 @@ All the example code for the Amazon Web Services (AWS) SDK for Python is availab
 For more information about IAM policies, see `Overview of Access Management: Permissions and Policies <http://docs.aws.amazon.com/IAM/latest/UserGuide/introduction_access-management.html>`_ 
 in the IAM User Guide.
 
-Prerequisite Task
+Prerequisite tasks
 =================
 
 To set up and run this example, you must first configure your AWS credentials, as described in :doc:`quickstart`.
 
-Create an IAM Policy
+Create an IAM policy
 ====================
 
 Create a new managed policy for your AWS account.
@@ -103,7 +103,7 @@ Example
     )
     print(response)
 
-Get an IAM Policy
+Get an IAM policy
 =================
 
 Get information about the specified managed policy, including the policy's default version and 
@@ -140,7 +140,7 @@ Example
 
 
 
-Attach a Managed Role Policy
+Attach a managed role policy
 ============================
 
 When you attach a managed policy to a role, the managed policy becomes part of the role's permission 
@@ -173,7 +173,7 @@ Example
 
 
 
-Detach a Managed Role Policy
+Detach a managed role policy
 ============================
 
 Detach the specified managed policy from the specified role.

--- a/docs/source/guide/iam-example-server-certificates.rst
+++ b/docs/source/guide/iam-example-server-certificates.rst
@@ -12,12 +12,12 @@
 
 
 ####################################
-Working with IAM Server Certificates
+Working with IAM server certificates
 ####################################
 
 This Python example shows you how to carry out basic tasks in managing server certificates for HTTPS connections.
 
-The Scenario
+The scenario
 ============
 
 To enable HTTPS connections to your website or application on AWS, you need an SSL/TLS server certificate. 
@@ -41,12 +41,12 @@ All the example code for the Amazon Web Services (AWS) SDK for Python is availab
 For more information about server certificates, see `Working with Server Certificates <http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html>`_ 
 in the *IAM User Guide*.
 
-Prerequisite Task
+Prerequisite tasks
 =================
 
 To set up and run this example, you must first configure your AWS credentials, as described in :doc:`quickstart`.
 
-List Your Server Certificates
+List your server certificates
 =============================
 
 List the server certificates stored in IAM. If none exist, the action returns an empty list.
@@ -73,7 +73,7 @@ Example
     for response in paginator.paginate():
         print(response['ServerCertificateMetadataList'])
 
-Get a Server Certificate
+Get a server certificate
 ========================
 
 Get information about the specified server certificate stored in IAM.
@@ -98,7 +98,7 @@ Example
     response = iam.get_server_certificate(ServerCertificateName='CERTIFICATE_NAME')
     print(response['ServerCertificate'])
 
-Update a Server Certificate
+Update a server certificate
 ===========================
 
 Update the name and/or the path of the specified server certificate stored in IAM.
@@ -124,7 +124,7 @@ Example
         NewServerCertificateName='NEW_CERTIFICATE_NAME'
     )
 
-Delete a Server Certificate
+Delete a server certificate
 ===========================
 
 Delete the specified server certificate.

--- a/docs/source/guide/iam-examples.rst
+++ b/docs/source/guide/iam-examples.rst
@@ -11,7 +11,7 @@
 .. _aws-boto-iam-examples:
 
 ###########################################
-AWS Identity and Access Management Examples
+AWS Identity and Access Management examples
 ###########################################
 
 .. meta::

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -27,6 +27,7 @@ General feature guide
    paginators
    session
    error-handling
+   retries
    configuration
    events
 

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -11,11 +11,11 @@
 .. _user_guides:
 
 +++++++++++
-User Guides
+User guides
 +++++++++++
 
 
-General Feature Guide
+General feature guide
 =====================
 
 .. toctree::
@@ -31,7 +31,7 @@ General Feature Guide
    events
 
 
-Tool Guide
+Tool guide
 ==========
 
 .. toctree::
@@ -41,7 +41,7 @@ Tool Guide
    sdk-metrics
 
 
-Migration Guide
+Migration guide
 ===============
 
 .. toctree::

--- a/docs/source/guide/kms-example-encrypt-decrypt-file.rst
+++ b/docs/source/guide/kms-example-encrypt-decrypt-file.rst
@@ -11,7 +11,7 @@
 .. _aws-boto3-kms-examples-encrypt-decrypt-file:
 
 **************************
-Encrypt and Decrypt a File
+Encrypt and decrypt a file
 **************************
 
 The example program uses AWS KMS keys to encrypt and decrypt a file.
@@ -33,7 +33,7 @@ Each section describes a single function from the example's `entire
 source file <https://github.com/awsdocs/aws-doc-sdk-examples/tree/master/python/example_code/kms/encrypt_decrypt_file.py>`_.
 
 
-Retrieve an Existing Master Key
+Retrieve an existing master key
 ===============================
 
 Master keys are created, managed, and stored within AWS KMS. A KMS master key is also referred to 
@@ -102,7 +102,7 @@ to AWS KMS methods.
         return None, None
 
 
-Create a Customer Master Key
+Create a customer master key
 ============================
 
 If the example does not find an existing CMK, it creates a new one and returns its ID and ARN.
@@ -133,7 +133,7 @@ If the example does not find an existing CMK, it creates a new one and returns i
         return response['KeyMetadata']['KeyId'], response['KeyMetadata']['Arn']
 
 
-Create a Data Key
+Create a data key
 =================
 
 To encrypt a file, the example ``create_data_key`` function creates a data key. The data key is 
@@ -174,7 +174,7 @@ when necessary.
         return response['CiphertextBlob'], base64.b64encode(response['Plaintext'])
 
 
-Encrypt a File
+Encrypt a file
 ==============
 
 The ``encrypt_file`` function creates a data key and uses it to encrypt the contents of a disk file.
@@ -242,7 +242,7 @@ decrypt the encrypted data key.
         return True
 
 
-Decrypt a Data Key
+Decrypt a data key
 ==================
 
 To decrypt an encrypted file, the encrypted data key used to perform the encryption must first
@@ -271,7 +271,7 @@ the plaintext form of the key.
         return base64.b64encode((response['Plaintext']))
 
 
-Decrypt a File
+Decrypt a file
 ==============
 
 The example ``decrypt_file`` function first extracts the encrypted data key from the encrypted file. It 

--- a/docs/source/guide/kms-examples.rst
+++ b/docs/source/guide/kms-examples.rst
@@ -11,7 +11,7 @@
 .. _aws-boto3-kms-examples:
 
 #############################################
-AWS Key Management Service (AWS KMS) Examples
+AWS Key Management Service (AWS KMS) examples
 #############################################
 
 .. meta::

--- a/docs/source/guide/migration.rst
+++ b/docs/source/guide/migration.rst
@@ -7,19 +7,19 @@ live side-by-side in the same project, which means that a piecemeal
 approach can be used. New features can be written in Boto 3, or existing
 code can be migrated over as needed, piece by piece.
 
-High Level Concepts
+High level concepts
 -------------------
 Boto 2.x modules are typically split into two categories, those which include a high-level object-oriented interface and those which include only a low-level interface which matches the underlying Amazon Web Services API. Some modules are completely high-level (like Amazon S3 or EC2), some include high-level code on top of a low-level connection (like Amazon DynamoDB), and others are 100% low-level (like Amazon Elastic Transcoder).
 
 In Boto 3 this general low-level and high-level concept hasn't changed much, but there are two important points to understand.
 
-Data Driven
+Data driven
 ~~~~~~~~~~~
 First, in Boto 3 classes are created at runtime from JSON data files that describe AWS APIs and organizational structures built atop of them. These data files are loaded at runtime and can be modified and updated without the need of installing an entirely new SDK release.
 
 A side effect of having all the services generated from JSON files is that there is now consistency between all AWS service modules. One important change is that *all* API call parameters must now be passed as **keyword arguments**, and these keyword arguments take the form defined by the upstream service. Though there are exceptions, this typically means ``UpperCamelCasing`` parameter names. You will see this in the service-specific migration guides linked to below.
 
-Resource Objects
+Resource objects
 ~~~~~~~~~~~~~~~~
 Second, while every service now uses the runtime-generated low-level client, some services additionally have high-level generated objects that we refer to as ``Resources``. The lower-level is comparable to Boto 2.x layer 1 connection objects in that they provide a one to one mapping of API operations and return low-level responses. The higher level is comparable to the high-level customizations from Boto 2.x: an S3 ``Key``, an EC2 ``Instance``, and a DynamoDB ``Table`` are all considered resources in Boto 3. Just like a Boto 2.x ``S3Connection``'s ``list_buckets`` will return ``Bucket`` objects, the Boto 3 resource interface provides actions and collections that return resources. Some services may also have hand-written customizations built on top of the runtime-generated high-level resources (such as utilities for working with S3 multipart uploads).
 
@@ -39,7 +39,7 @@ Second, while every service now uses the runtime-generated low-level client, som
     s3 = boto3.resource('s3')
     boto3_bucket = s3.Bucket('mybucket')
 
-Installation & Configuration
+Installation & configuration
 ----------------------------
 The :ref:`guide_quickstart` guide provides instructions for installing Boto 3. You can also follow the instructions there to set up new credential files, or you can continue to use your existing Boto 2.x credentials. Please note that Boto 3, the AWS CLI, and several other SDKs all use the shared credentials file (usually at ``~/.aws/credentials``).
 

--- a/docs/source/guide/migration.rst
+++ b/docs/source/guide/migration.rst
@@ -7,7 +7,7 @@ live side-by-side in the same project, which means that a piecemeal
 approach can be used. New features can be written in Boto 3, or existing
 code can be migrated over as needed, piece by piece.
 
-High level concepts
+High-level concepts
 -------------------
 Boto 2.x modules are typically split into two categories, those which include a high-level object-oriented interface and those which include only a low-level interface which matches the underlying Amazon Web Services API. Some modules are completely high-level (like Amazon S3 or EC2), some include high-level code on top of a low-level connection (like Amazon DynamoDB), and others are 100% low-level (like Amazon Elastic Transcoder).
 
@@ -39,7 +39,7 @@ Second, while every service now uses the runtime-generated low-level client, som
     s3 = boto3.resource('s3')
     boto3_bucket = s3.Bucket('mybucket')
 
-Installation & configuration
+Installation and configuration
 ----------------------------
 The :ref:`guide_quickstart` guide provides instructions for installing Boto 3. You can also follow the instructions there to set up new credential files, or you can continue to use your existing Boto 2.x credentials. Please note that Boto 3, the AWS CLI, and several other SDKs all use the shared credentials file (usually at ``~/.aws/credentials``).
 

--- a/docs/source/guide/migration.rst
+++ b/docs/source/guide/migration.rst
@@ -2,26 +2,26 @@
 
 Migrating from Boto 2.x
 =======================
-Current Boto users can begin using Boto 3 right away. The two modules can
+Current Boto users can begin using Boto3 right away. The two modules can
 live side-by-side in the same project, which means that a piecemeal
-approach can be used. New features can be written in Boto 3, or existing
+approach can be used. New features can be written in Boto3, or existing
 code can be migrated over as needed, piece by piece.
 
 High-level concepts
 -------------------
 Boto 2.x modules are typically split into two categories, those which include a high-level object-oriented interface and those which include only a low-level interface which matches the underlying Amazon Web Services API. Some modules are completely high-level (like Amazon S3 or EC2), some include high-level code on top of a low-level connection (like Amazon DynamoDB), and others are 100% low-level (like Amazon Elastic Transcoder).
 
-In Boto 3 this general low-level and high-level concept hasn't changed much, but there are two important points to understand.
+In Boto3 this general low-level and high-level concept hasn't changed much, but there are two important points to understand.
 
 Data driven
 ~~~~~~~~~~~
-First, in Boto 3 classes are created at runtime from JSON data files that describe AWS APIs and organizational structures built atop of them. These data files are loaded at runtime and can be modified and updated without the need of installing an entirely new SDK release.
+First, in Boto3 classes are created at runtime from JSON data files that describe AWS APIs and organizational structures built atop of them. These data files are loaded at runtime and can be modified and updated without the need of installing an entirely new SDK release.
 
 A side effect of having all the services generated from JSON files is that there is now consistency between all AWS service modules. One important change is that *all* API call parameters must now be passed as **keyword arguments**, and these keyword arguments take the form defined by the upstream service. Though there are exceptions, this typically means ``UpperCamelCasing`` parameter names. You will see this in the service-specific migration guides linked to below.
 
 Resource objects
 ~~~~~~~~~~~~~~~~
-Second, while every service now uses the runtime-generated low-level client, some services additionally have high-level generated objects that we refer to as ``Resources``. The lower-level is comparable to Boto 2.x layer 1 connection objects in that they provide a one to one mapping of API operations and return low-level responses. The higher level is comparable to the high-level customizations from Boto 2.x: an S3 ``Key``, an EC2 ``Instance``, and a DynamoDB ``Table`` are all considered resources in Boto 3. Just like a Boto 2.x ``S3Connection``'s ``list_buckets`` will return ``Bucket`` objects, the Boto 3 resource interface provides actions and collections that return resources. Some services may also have hand-written customizations built on top of the runtime-generated high-level resources (such as utilities for working with S3 multipart uploads).
+Second, while every service now uses the runtime-generated low-level client, some services additionally have high-level generated objects that we refer to as ``Resources``. The lower-level is comparable to Boto 2.x layer 1 connection objects in that they provide a one to one mapping of API operations and return low-level responses. The higher level is comparable to the high-level customizations from Boto 2.x: an S3 ``Key``, an EC2 ``Instance``, and a DynamoDB ``Table`` are all considered resources in Boto3. Just like a Boto 2.x ``S3Connection``'s ``list_buckets`` will return ``Bucket`` objects, the Boto3 resource interface provides actions and collections that return resources. Some services may also have hand-written customizations built on top of the runtime-generated high-level resources (such as utilities for working with S3 multipart uploads).
 
 ::
 
@@ -41,18 +41,18 @@ Second, while every service now uses the runtime-generated low-level client, som
 
 Installation and configuration
 ----------------------------
-The :ref:`guide_quickstart` guide provides instructions for installing Boto 3. You can also follow the instructions there to set up new credential files, or you can continue to use your existing Boto 2.x credentials. Please note that Boto 3, the AWS CLI, and several other SDKs all use the shared credentials file (usually at ``~/.aws/credentials``).
+The :ref:`guide_quickstart` guide provides instructions for installing Boto3. You can also follow the instructions there to set up new credential files, or you can continue to use your existing Boto 2.x credentials. Please note that Boto3, the AWS CLI, and several other SDKs all use the shared credentials file (usually at ``~/.aws/credentials``).
 
-Once configured, you may begin using Boto 3::
+Once configured, you may begin using Boto3::
 
     import boto3
 
     for bucket in boto3.resource('s3').buckets.all():
         print(bucket.name)
 
-See the :ref:`Code Examples <aws-boto3-examples>` and `Boto 3 Documentation <https://boto3.amazonaws.com/v1/documentation/api/latest/index.html>`__ for more information.
+See the :ref:`Code Examples <aws-boto3-examples>` and `Boto3 Documentation <https://boto3.amazonaws.com/v1/documentation/api/latest/index.html>`__ for more information.
 
-The rest of this document will describe specific common usage scenarios of Boto 2 code and how to accomplish the same tasks with Boto 3.
+The rest of this document will describe specific common usage scenarios of Boto 2 code and how to accomplish the same tasks with Boto3.
 
 Services
 --------

--- a/docs/source/guide/migrationec2.rst
+++ b/docs/source/guide/migrationec2.rst
@@ -4,7 +4,7 @@ Amazon EC2
 ==========
 Boto 2.x contains a number of customizations to make working with Amazon EC2 instances, storage and networks easy. Boto 3 exposes these same objects through its resources interface in a unified and consistent way.
 
-Creating the Connection
+Creating the connection
 -----------------------
 Boto 3 has both low-level clients and higher-level resources. For Amazon EC2, the higher-level resources are the most similar to Boto 2.x's ``ec2`` and ``vpc`` modules::
 
@@ -17,7 +17,7 @@ Boto 3 has both low-level clients and higher-level resources. For Amazon EC2, th
     import boto3
     ec2 = boto3.resource('ec2')
 
-Launching New Instances
+Launching new instances
 -----------------------
 Launching new instances requires an image ID and the number of instances to launch. It can also take several optional parameters, such as the instance type and security group::
 
@@ -27,7 +27,7 @@ Launching new instances requires an image ID and the number of instances to laun
     # Boto 3
     ec2.create_instances(ImageId='<ami-image-id>', MinCount=1, MaxCount=5)
 
-Stopping & Terminating Instances
+Stopping & terminating instances
 --------------------------------
 Stopping and terminating multiple instances given a list of instance IDs uses Boto 3 collection filtering::
 
@@ -41,7 +41,7 @@ Stopping and terminating multiple instances given a list of instance IDs uses Bo
     ec2.instances.filter(InstanceIds=ids).stop()
     ec2.instances.filter(InstanceIds=ids).terminate()
 
-Checking What Instances Are Running
+Checking what instances are running
 -----------------------------------
 Boto 3 collections come in handy when listing all your running instances as well. Every collection exposes a ``filter`` method that allows you to pass additional parameters to the underlying service API operation. The EC2 instances collection takes a parameter called ``Filters`` which is a list of names and values, for example::
 
@@ -60,7 +60,7 @@ Boto 3 collections come in handy when listing all your running instances as well
     for instance in instances:
         print(instance.id, instance.instance_type)
 
-Checking Health Status Of Instances
+Checking health status of instances
 -----------------------------------
 It is possible to get scheduled maintenance information for your running instances. At the time of this writing Boto 3 does not have a status resource, so you must drop down to the low-level client via ``ec2.meta.client``::
 
@@ -72,7 +72,7 @@ It is possible to get scheduled maintenance information for your running instanc
     for status in ec2.meta.client.describe_instance_status()['InstanceStatuses']:
         print(status)
 
-Working with EBS Snapshots
+Working with EBS snapshots
 --------------------------
 Snapshots provide a way to create a copy of an EBS volume, as well as make new volumes from the snapshot which can be attached to an instance::
 
@@ -88,7 +88,7 @@ Snapshots provide a way to create a copy of an EBS volume, as well as make new v
     ec2.Instance('instance-id').attach_volume(VolumeId=volume.id, Device='/dev/sdy')
     snapshot.delete()
 
-Creating a VPC, Subnet, and Gateway
+Creating a VPC, subnet, and gateway
 -----------------------------------
 Creating VPC resources in Boto 3 is very similar to Boto 2.x::
 
@@ -102,7 +102,7 @@ Creating VPC resources in Boto 3 is very similar to Boto 2.x::
     subnet = vpc.create_subnet(CidrBlock='10.0.0.0/25')
     gateway = ec2.create_internet_gateway()
 
-Attaching and Detaching an Elastic IP and Gateway
+Attaching and detaching an elastic IP and gateway
 -------------------------------------------------
 Elastic IPs and gateways provide a way for instances inside of a VPC to communicate with the outside world::
 

--- a/docs/source/guide/migrationec2.rst
+++ b/docs/source/guide/migrationec2.rst
@@ -27,7 +27,7 @@ Launching new instances requires an image ID and the number of instances to laun
     # Boto 3
     ec2.create_instances(ImageId='<ami-image-id>', MinCount=1, MaxCount=5)
 
-Stopping & terminating instances
+Stopping and terminating instances
 --------------------------------
 Stopping and terminating multiple instances given a list of instance IDs uses Boto 3 collection filtering::
 

--- a/docs/source/guide/migrationec2.rst
+++ b/docs/source/guide/migrationec2.rst
@@ -2,18 +2,18 @@
 
 Amazon EC2
 ==========
-Boto 2.x contains a number of customizations to make working with Amazon EC2 instances, storage and networks easy. Boto 3 exposes these same objects through its resources interface in a unified and consistent way.
+Boto 2.x contains a number of customizations to make working with Amazon EC2 instances, storage and networks easy. Boto3 exposes these same objects through its resources interface in a unified and consistent way.
 
 Creating the connection
 -----------------------
-Boto 3 has both low-level clients and higher-level resources. For Amazon EC2, the higher-level resources are the most similar to Boto 2.x's ``ec2`` and ``vpc`` modules::
+Boto3 has both low-level clients and higher-level resources. For Amazon EC2, the higher-level resources are the most similar to Boto 2.x's ``ec2`` and ``vpc`` modules::
 
     # Boto 2.x
     import boto
     ec2_connection = boto.connect_ec2()
     vpc_connection = boto.connect_vpc()
 
-    # Boto 3
+    # Boto3
     import boto3
     ec2 = boto3.resource('ec2')
 
@@ -24,12 +24,12 @@ Launching new instances requires an image ID and the number of instances to laun
     # Boto 2.x
     ec2_connection.run_instances('<ami-image-id>')
 
-    # Boto 3
+    # Boto3
     ec2.create_instances(ImageId='<ami-image-id>', MinCount=1, MaxCount=5)
 
 Stopping and terminating instances
 --------------------------------
-Stopping and terminating multiple instances given a list of instance IDs uses Boto 3 collection filtering::
+Stopping and terminating multiple instances given a list of instance IDs uses Boto3 collection filtering::
 
     ids = ['instance-id-1', 'instance-id-2', ...]
 
@@ -37,13 +37,13 @@ Stopping and terminating multiple instances given a list of instance IDs uses Bo
     ec2_connection.stop_instances(instance_ids=ids)
     ec2_connection.terminate_instances(instance_ids=ids)
 
-    # Boto 3
+    # Boto3
     ec2.instances.filter(InstanceIds=ids).stop()
     ec2.instances.filter(InstanceIds=ids).terminate()
 
 Checking what instances are running
 -----------------------------------
-Boto 3 collections come in handy when listing all your running instances as well. Every collection exposes a ``filter`` method that allows you to pass additional parameters to the underlying service API operation. The EC2 instances collection takes a parameter called ``Filters`` which is a list of names and values, for example::
+Boto3 collections come in handy when listing all your running instances as well. Every collection exposes a ``filter`` method that allows you to pass additional parameters to the underlying service API operation. The EC2 instances collection takes a parameter called ``Filters`` which is a list of names and values, for example::
 
     # Boto 2.x
     reservations = ec2_connection.get_all_reservations(
@@ -52,7 +52,7 @@ Boto 3 collections come in handy when listing all your running instances as well
         for instance in reservation.instances:
             print(instance.instance_id, instance.instance_type)
 
-    # Boto 3
+    # Boto3
     # Use the filter() method of the instances collection to retrieve
     # all running EC2 instances.
     instances = ec2.instances.filter(
@@ -62,13 +62,13 @@ Boto 3 collections come in handy when listing all your running instances as well
 
 Checking health status of instances
 -----------------------------------
-It is possible to get scheduled maintenance information for your running instances. At the time of this writing Boto 3 does not have a status resource, so you must drop down to the low-level client via ``ec2.meta.client``::
+It is possible to get scheduled maintenance information for your running instances. At the time of this writing Boto3 does not have a status resource, so you must drop down to the low-level client via ``ec2.meta.client``::
 
     # Boto 2.x
     for status in ec2_connection.get_all_instance_statuses():
         print(status)
 
-    # Boto 3
+    # Boto3
     for status in ec2.meta.client.describe_instance_status()['InstanceStatuses']:
         print(status)
 
@@ -82,7 +82,7 @@ Snapshots provide a way to create a copy of an EBS volume, as well as make new v
     ec2_connection.attach_volume(volume.id, 'instance-id', '/dev/sdy')
     ec2_connection.delete_snapshot(snapshot.id)
 
-    # Boto 3
+    # Boto3
     snapshot = ec2.create_snapshot(VolumeId='volume-id', Description='description')
     volume = ec2.create_volume(SnapshotId=snapshot.id, AvailabilityZone='us-west-2a')
     ec2.Instance('instance-id').attach_volume(VolumeId=volume.id, Device='/dev/sdy')
@@ -90,14 +90,14 @@ Snapshots provide a way to create a copy of an EBS volume, as well as make new v
 
 Creating a VPC, subnet, and gateway
 -----------------------------------
-Creating VPC resources in Boto 3 is very similar to Boto 2.x::
+Creating VPC resources in Boto3 is very similar to Boto 2.x::
 
     # Boto 2.x
     vpc = vpc_connection.create_vpc('10.0.0.0/24')
     subnet = vpc_connection.create_subnet(vpc.id, '10.0.0.0/25')
     gateway = vpc_connection.create_internet_gateway()
 
-    # Boto 3
+    # Boto3
     vpc = ec2.create_vpc(CidrBlock='10.0.0.0/24')
     subnet = vpc.create_subnet(CidrBlock='10.0.0.0/25')
     gateway = ec2.create_internet_gateway()
@@ -116,7 +116,7 @@ Elastic IPs and gateways provide a way for instances inside of a VPC to communic
     address.associate('i-71b2f60b')
     address.disassociate()
 
-    # Boto 3
+    # Boto3
     gateway.attach_to_vpc(VpcId=vpc.id)
     gateway.detach_from_vpc(VpcId=vpc.id)
 

--- a/docs/source/guide/migrations3.rst
+++ b/docs/source/guide/migrations3.rst
@@ -2,29 +2,29 @@
 
 Amazon S3
 =========
-Boto 2.x contains a number of customizations to make working with Amazon S3 buckets and keys easy. Boto 3 exposes these same objects through its resources interface in a unified and consistent way.
+Boto 2.x contains a number of customizations to make working with Amazon S3 buckets and keys easy. Boto3 exposes these same objects through its resources interface in a unified and consistent way.
 
 Creating the connection
 -----------------------
-Boto 3 has both low-level clients and higher-level resources. For Amazon S3, the higher-level resources are the most similar to Boto 2.x's ``s3`` module::
+Boto3 has both low-level clients and higher-level resources. For Amazon S3, the higher-level resources are the most similar to Boto 2.x's ``s3`` module::
 
     # Boto 2.x
     import boto
     s3_connection = boto.connect_s3()
 
-    # Boto 3
+    # Boto3
     import boto3
     s3 = boto3.resource('s3')
 
 Creating a bucket
 -----------------
-Creating a bucket in Boto 2 and Boto 3 is very similar, except that in Boto 3 all action parameters must be passed via keyword arguments and a bucket configuration must be specified manually::
+Creating a bucket in Boto 2 and Boto3 is very similar, except that in Boto3 all action parameters must be passed via keyword arguments and a bucket configuration must be specified manually::
 
     # Boto 2.x
     s3_connection.create_bucket('mybucket')
     s3_connection.create_bucket('mybucket', location=Location.USWest)
 
-    # Boto 3
+    # Boto3
     s3.create_bucket(Bucket='mybucket')
     s3.create_bucket(Bucket='mybucket', CreateBucketConfiguration={
         'LocationConstraint': 'us-west-1'})
@@ -38,19 +38,19 @@ Storing data from a file, stream, or string is easy::
     key = Key('hello.txt')
     key.set_contents_from_file('/tmp/hello.txt')
 
-    # Boto 3
+    # Boto3
     s3.Object('mybucket', 'hello.txt').put(Body=open('/tmp/hello.txt', 'rb'))
 
 
 Accessing a bucket
 ------------------
-Getting a bucket is easy with Boto 3's resources, however these do not automatically validate whether a bucket exists::
+Getting a bucket is easy with Boto3's resources, however these do not automatically validate whether a bucket exists::
 
     # Boto 2.x
     bucket = s3_connection.get_bucket('mybucket', validate=False)
     exists = s3_connection.lookup('mybucket')
 
-    # Boto 3
+    # Boto3
     import botocore
     bucket = s3.Bucket('mybucket')
     exists = True
@@ -72,7 +72,7 @@ All of the keys in a bucket must be deleted before the bucket itself can be dele
         key.delete()
     bucket.delete()
 
-    # Boto 3
+    # Boto3
     for key in bucket.objects.all():
         key.delete()
     bucket.delete()
@@ -86,20 +86,20 @@ Bucket and key objects are no longer iterable, but now provide collection attrib
         for key in bucket:
             print(key.name)
 
-    # Boto 3
+    # Boto3
     for bucket in s3.buckets.all():
         for key in bucket.objects.all():
             print(key.key)
 
 Access controls
 ---------------
-Getting and setting canned access control values in Boto 3 operates on an ``ACL`` resource object::
+Getting and setting canned access control values in Boto3 operates on an ``ACL`` resource object::
 
     # Boto 2.x
     bucket.set_acl('public-read')
     key.set_acl('public-read')
 
-    # Boto 3
+    # Boto3
     bucket.Acl().put(ACL='public-read')
     obj.Acl().put(ACL='public-read')
 
@@ -110,17 +110,17 @@ It's also possible to retrieve the policy grant information::
     for grant in acp.acl.grants:
         print(grant.display_name, grant.permission)
 
-    # Boto 3
+    # Boto3
     acl = bucket.Acl()
     for grant in acl.grants:
         print(grant['Grantee']['DisplayName'], grant['Permission'])
 
-Boto 3 lacks the grant shortcut methods present in Boto 2.x, but it is still fairly simple to add grantees::
+Boto3 lacks the grant shortcut methods present in Boto 2.x, but it is still fairly simple to add grantees::
 
     # Boto 2.x
     bucket.add_email_grant('READ', 'user@domain.tld')
 
-    # Boto 3
+    # Boto3
     bucket.Acl.put(GrantRead='emailAddress=user@domain.tld')
 
 Key metadata
@@ -131,7 +131,7 @@ It's possible to set arbitrary metadata on keys::
     key.set_metadata('meta1', 'This is my metadata value')
     print(key.get_metadata('meta1'))
 
-    # Boto 3
+    # Boto3
     key.put(Metadata={'meta1': 'This is my metadata value'})
     print(key.metadata['meta1'])
 
@@ -148,7 +148,7 @@ Allows you to manage the cross-origin resource sharing configuration for S3 buck
 
     bucket.delete_cors()
 
-    # Boto 3
+    # Boto3
     cors = bucket.Cors()
 
     config = {

--- a/docs/source/guide/migrations3.rst
+++ b/docs/source/guide/migrations3.rst
@@ -4,7 +4,7 @@ Amazon S3
 =========
 Boto 2.x contains a number of customizations to make working with Amazon S3 buckets and keys easy. Boto 3 exposes these same objects through its resources interface in a unified and consistent way.
 
-Creating the Connection
+Creating the connection
 -----------------------
 Boto 3 has both low-level clients and higher-level resources. For Amazon S3, the higher-level resources are the most similar to Boto 2.x's ``s3`` module::
 
@@ -16,7 +16,7 @@ Boto 3 has both low-level clients and higher-level resources. For Amazon S3, the
     import boto3
     s3 = boto3.resource('s3')
 
-Creating a Bucket
+Creating a bucket
 -----------------
 Creating a bucket in Boto 2 and Boto 3 is very similar, except that in Boto 3 all action parameters must be passed via keyword arguments and a bucket configuration must be specified manually::
 
@@ -29,7 +29,7 @@ Creating a bucket in Boto 2 and Boto 3 is very similar, except that in Boto 3 al
     s3.create_bucket(Bucket='mybucket', CreateBucketConfiguration={
         'LocationConstraint': 'us-west-1'})
 
-Storing Data
+Storing data
 ------------
 Storing data from a file, stream, or string is easy::
 
@@ -42,7 +42,7 @@ Storing data from a file, stream, or string is easy::
     s3.Object('mybucket', 'hello.txt').put(Body=open('/tmp/hello.txt', 'rb'))
 
 
-Accessing a Bucket
+Accessing a bucket
 ------------------
 Getting a bucket is easy with Boto 3's resources, however these do not automatically validate whether a bucket exists::
 
@@ -63,7 +63,7 @@ Getting a bucket is easy with Boto 3's resources, however these do not automatic
         if error_code == '404':
             exists = False
 
-Deleting a Bucket
+Deleting a bucket
 -----------------
 All of the keys in a bucket must be deleted before the bucket itself can be deleted::
 
@@ -77,7 +77,7 @@ All of the keys in a bucket must be deleted before the bucket itself can be dele
         key.delete()
     bucket.delete()
 
-Iteration of Buckets and Keys
+Iteration of buckets and keys
 -----------------------------
 Bucket and key objects are no longer iterable, but now provide collection attributes which can be iterated::
 
@@ -91,7 +91,7 @@ Bucket and key objects are no longer iterable, but now provide collection attrib
         for key in bucket.objects.all():
             print(key.key)
 
-Access Controls
+Access controls
 ---------------
 Getting and setting canned access control values in Boto 3 operates on an ``ACL`` resource object::
 
@@ -123,7 +123,7 @@ Boto 3 lacks the grant shortcut methods present in Boto 2.x, but it is still fai
     # Boto 3
     bucket.Acl.put(GrantRead='emailAddress=user@domain.tld')
 
-Key Metadata
+Key metadata
 ------------
 It's possible to set arbitrary metadata on keys::
 
@@ -135,7 +135,7 @@ It's possible to set arbitrary metadata on keys::
     key.put(Metadata={'meta1': 'This is my metadata value'})
     print(key.metadata['meta1'])
 
-Managing CORS Configuration
+Managing CORS configurations
 ---------------------------
 Allows you to manage the cross-origin resource sharing configuration for S3 buckets::
 

--- a/docs/source/guide/new.rst
+++ b/docs/source/guide/new.rst
@@ -2,21 +2,21 @@
 
 What's new
 ==========
-Boto 3 is a ground-up rewrite of Boto. It uses a data-driven approach to
+Boto3 is a ground-up rewrite of Boto. It uses a data-driven approach to
 generate classes at runtime from JSON description files that are shared
 between SDKs in various languages. This includes descriptions for a
 high level, object oriented interface similar to those available in
 previous versions of Boto.
 
-Because Boto 3 is generated from these shared JSON files, we get
+Because Boto3 is generated from these shared JSON files, we get
 fast updates to the latest services and features and a consistent
 API across services. Community contributions to JSON description
-files in other SDKs also benefit Boto 3, just as contributions to
-Boto 3 benefit the other SDKs.
+files in other SDKs also benefit Boto3, just as contributions to
+Boto3 benefit the other SDKs.
 
 Major features
 --------------
-Boto 3 consists of the following major features:
+Boto3 consists of the following major features:
 
 * **Resources**: a high level, object oriented interface
 * **Collections**: a tool to iterate and manipulate groups of resources
@@ -24,7 +24,7 @@ Boto 3 consists of the following major features:
 * **Paginators**: automatic paging of responses
 * **Waiters**: a way to block until a certain state has been reached
 
-Along with these major features, Boto 3 also provides *sessions* and
+Along with these major features, Boto3 also provides *sessions* and
 per-session *credentials* & *configuration*, as well as basic
 components like *authentication*, *parameter* & *response* handling,
 an *event system* for customizations and logic to *retry* failed
@@ -32,8 +32,8 @@ requests.
 
 Botocore
 ~~~~~~~~
-Boto 3 is built atop of a library called
+Boto3 is built atop of a library called
 `Botocore <https://pypi.python.org/pypi/botocore>`_, which is shared by the
 `AWS CLI <http://aws.amazon.com/cli/>`_. Botocore provides the low level
-clients, session, and credential & configuration data. Boto 3 builds on top
+clients, session, and credential & configuration data. Boto3 builds on top
 of Botocore by providing its own session, resources and collections.

--- a/docs/source/guide/new.rst
+++ b/docs/source/guide/new.rst
@@ -1,6 +1,6 @@
 .. _guide_new:
 
-What's New
+What's new
 ==========
 Boto 3 is a ground-up rewrite of Boto. It uses a data-driven approach to
 generate classes at runtime from JSON description files that are shared
@@ -14,7 +14,7 @@ API across services. Community contributions to JSON description
 files in other SDKs also benefit Boto 3, just as contributions to
 Boto 3 benefit the other SDKs.
 
-Major Features
+Major features
 --------------
 Boto 3 consists of the following major features:
 

--- a/docs/source/guide/paginators.rst
+++ b/docs/source/guide/paginators.rst
@@ -13,7 +13,7 @@ results.
 process of iterating over an entire result set of a truncated API operation.
 
 
-Creating Paginators
+Creating paginators
 -------------------
 
 Paginators are created via the ``get_paginator()`` method of a boto3
@@ -38,7 +38,7 @@ underlying API operation. The ``paginate`` method then returns an iterable
         print(page['Contents'])
 
 
-Customizing Page Iterators
+Customizing page iterators
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You must call the ``paginate`` method of a Paginator in order to iterate over
@@ -89,7 +89,7 @@ to the client::
         print(page['Contents'])
 
 
-Filtering Results with JMESPath
+Filtering results with JMESPath
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `JMESPath <http://jmespath.org>`_ is a query language for JSON that can be used
@@ -99,6 +99,9 @@ JMESPath expressions that are applied to each page of results through the
 
 .. code-block:: python
 
+    import boto3
+    
+    client = boto3.client('s3', region_name='us-west-2')
     paginator = client.get_paginator('list_objects')
     page_iterator = paginator.paginate(Bucket='my-bucket')
     filtered_iterator = page_iterator.search("Contents[?Size > `100`][]")

--- a/docs/source/guide/quickstart.rst
+++ b/docs/source/guide/quickstart.rst
@@ -2,11 +2,11 @@
 
 Quickstart
 ==========
-Getting started with Boto 3 is easy, but requires a few steps.
+Getting started with Boto3 is easy, but requires a few steps.
 
 Installation
 ------------
-Install the latest Boto 3 release via :command:`pip`::
+Install the latest Boto3 release via :command:`pip`::
 
     pip install boto3
 
@@ -21,7 +21,7 @@ You may also install a specific version::
 
 Configuration
 -------------
-Before you can begin using Boto 3, you should set up authentication
+Before you can begin using Boto3, you should set up authentication
 credentials. Credentials for your AWS account can be found in the
 `IAM Console <https://console.aws.amazon.com/iam/home>`_. You can
 create or use an existing user. Go to manage access keys and
@@ -53,9 +53,9 @@ region to use when creating connections. See
 :ref:`guide_configuration` for in-depth configuration sources and
 options.
 
-Using Boto 3
+Using Boto3
 ------------
-To use Boto 3, you must first import it and tell it what service you are
+To use Boto3, you must first import it and tell it what service you are
 going to use::
 
     import boto3

--- a/docs/source/guide/resources.rst
+++ b/docs/source/guide/resources.rst
@@ -28,7 +28,7 @@ identifiers or attributes. The two share the same components otherwise.
 
 .. _identifiers_attributes_intro:
 
-Identifiers & Attributes
+Identifiers & attributes
 ------------------------
 An identifier is a unique value that is used to call actions on the resource.
 Resources **must** have at least one identifier, except for the top-level
@@ -198,7 +198,7 @@ keyword arguments. Examples of waiters include::
     instance.wait_until_running()
 
 
-Multithreading / Multiprocessing
+Multithreading & multiprocessing
 --------------------------------
 It is recommended to create a resource instance for each thread / process in a multithreaded or multiprocess application rather than sharing a single instance among the threads / processes. For example::
 

--- a/docs/source/guide/resources.rst
+++ b/docs/source/guide/resources.rst
@@ -28,7 +28,7 @@ identifiers or attributes. The two share the same components otherwise.
 
 .. _identifiers_attributes_intro:
 
-Identifiers & attributes
+Identifiers and attributes
 ------------------------
 An identifier is a unique value that is used to call actions on the resource.
 Resources **must** have at least one identifier, except for the top-level
@@ -198,7 +198,7 @@ keyword arguments. Examples of waiters include::
     instance.wait_until_running()
 
 
-Multithreading & multiprocessing
+Multithreading and multiprocessing
 --------------------------------
 It is recommended to create a resource instance for each thread / process in a multithreaded or multiprocess application rather than sharing a single instance among the threads / processes. For example::
 
@@ -213,3 +213,8 @@ It is recommended to create a resource instance for each thread / process in a m
             # ... do some work with S3 ...
 
 In the example above, each thread would have its own Boto 3 session and its own instance of the S3 resource. This is a good idea because resources contain shared data when loaded and calling actions, accessing properties, or manually loading or reloading the resource can modify this data.
+
+.. note::
+    Resources are **not** thread safe. These special classes contain additional meta data that cannot be shared between threads. When using a Resource, it is recommended to instantiate a new Resource for each thread, as is shown in the example above. 
+    
+    Low-level clients **are** thread safe. When using a low-level client, it is recommended to instantiate your client then pass that client object to each of your threads. 

--- a/docs/source/guide/resources.rst
+++ b/docs/source/guide/resources.rst
@@ -212,7 +212,7 @@ It is recommended to create a resource instance for each thread / process in a m
             s3 = session.resource('s3')
             # ... do some work with S3 ...
 
-In the example above, each thread would have its own Boto 3 session and its own instance of the S3 resource. This is a good idea because resources contain shared data when loaded and calling actions, accessing properties, or manually loading or reloading the resource can modify this data.
+In the example above, each thread would have its own Boto3 session and its own instance of the S3 resource. This is a good idea because resources contain shared data when loaded and calling actions, accessing properties, or manually loading or reloading the resource can modify this data.
 
 .. note::
     Resources are **not** thread safe. These special classes contain additional meta data that cannot be shared between threads. When using a Resource, it is recommended to instantiate a new Resource for each thread, as is shown in the example above. 

--- a/docs/source/guide/retries.rst
+++ b/docs/source/guide/retries.rst
@@ -1,0 +1,201 @@
+.. _guide_retries:
+
+Retries
+=======
+
+Overview
+--------
+
+Your AWS client might see calls to AWS services fail due to unexpected issues on the client side. Or calls might fail due to rate limiting from the AWS service you're attempting to call. In either case, these kinds of failures often don’t require special handling and the call should be made again, often after a brief waiting period. Boto 3 provides many features to assist in retrying client calls to AWS services when these kinds of errors or exceptions are experienced.
+
+This guide provides you with details on the following:
+
+* How to find the available retry modes and the differences between each mode
+* How to configure your client to use each retry mode and other retry configurations
+* How to validate if your client performs a retry attempt
+
+Available retry modes
+---------------------
+
+Legacy retry mode
+~~~~~~~~~~~~~~~~~~
+
+Legacy mode is the default mode used by any Boto3 client you create. As its name implies, ``legacy mode`` uses an older (v1) retry handler that has limited functionality.
+
+**Legacy mode’s functionality includes:**
+
+* A default value of 5 for maximum retry attempts. This value can be overwritten through the ``max_attempts`` configuration parameter.
+* Retry attempts for a limited number of errors/exceptions::
+
+   # General socket/connection errors
+   ConnectionError
+   ConnectionClosedError
+   ReadTimeoutError
+   EndpointConnectionError
+
+   # Service-side throttling/limit errors and exceptions
+   Throttling
+   ThrottlingException
+   ThrottledException
+   RequestThrottledException
+   ProvisionedThroughputExceededException
+
+* Retry attempts on several HTTP status codes, including 429, 500, 502, 503, 504, and 509.
+* Any retry attempt will include an exponential backoff by a base factor of 2.
+
+
+.. note::
+   For more information about additional service-specific retry policies, see the following `botocore references in GitHub <https://github.com/boto/botocore/blob/develop/botocore/data/_retry.json>`_.
+
+
+Standard retry mode
+~~~~~~~~~~~~~~~~~~~~
+
+Standard mode is a retry mode that was introduced with the updated retry handler (v2). This mode is a standardization of retry logic and behavior that is consistent with other AWS SDKs. In addition to this standardization, this mode also extends the functionality of retries over that found in legacy mode.
+
+**Standard mode’s functionality includes:**
+
+* A default value of 3 for maximum retry attempts. This value can be overwritten through the ``max_attempts`` configuration parameter.
+* Retry attempts for an expanded list of errors/exceptions::
+
+   # Transient errors/exceptions
+   RequestTimeout
+   RequestTimeoutException
+   PriorRequestNotComplete
+   ConnectionError
+   HTTPClientError
+
+   # Service-side throttling/limit errors and exceptions
+   Throttling
+   ThrottlingException
+   ThrottledException
+   RequestThrottledException
+   TooManyRequestsException
+   ProvisionedThroughputExceededException
+   TransactionInProgressException
+   RequestLimitExceeded
+   BandwidthLimitExceeded
+   LimitExceededException
+   RequestThrottled
+   SlowDown
+   EC2ThrottledException
+
+* Retry attempts on nondescriptive, transient error codes. Specifically, these HTTP status codes: 500, 502, 503, 504.
+* Any retry attempt will include an exponential backoff by a base factor of 2 for a maximum backoff time of 20 seconds.
+
+Adaptive retry mode
+~~~~~~~~~~~~~~~~~~~~
+
+Adaptive retry mode is an experimental retry mode that includes all the features of standard mode. In addition to the standard mode features, adaptive mode also introduces client-side rate limiting through the use of a token bucket and rate-limit variables that are dynamically updated with each retry attempt. This mode offers flexibility in client-side retries that adapts to the error/exception state response from an AWS service.
+
+With each new retry attempt, adaptive mode modifies the rate-limit variables based on the error, exception, or HTTP status code presented in the response from the AWS service. These rate-limit variables are then used to calculate a new call rate for the client. Each exception/error or non-success HTTP response (provided in the list above) from an AWS service updates the rate-limit variables as retries occur until success is reached, the token bucket is exhausted, or the configured maximum attempts value is reached.
+
+.. note::
+   Adaptive mode is an experimental mode and is subject to change, both in features and behavior.
+
+
+Configuring a retry mode
+-------------------------
+
+Boto 3 includes a variety of both retry configurations as well as configuration methods to consider when creating your client object.
+
+Available configuration options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In Boto 3, users can customize two retry configurations:
+
+* ``retry_mode`` - This tells Boto 3 which retry mode to use. As described previously, there are three retry modes available: legacy (default), standard, and adaptive.
+* ``max_attempts`` - This provides Boto 3’s retry handler with a value of maximum retry attempts, where the initial call counts toward the ``max_attempts`` value that you provide.
+
+Defining a retry configuration in your AWS configuration file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This first way to define your retry configuration is to update your global AWS configuration file. The default location for your AWS config file is ``~/.aws/config``. Here’s an example of an AWS config file with the retry configuration options used::
+
+   [myConfigProfile]
+   region = us-east-1
+   max_attempts = 10
+   retry_mode = standard
+
+Any Boto 3 script or code that uses your AWS config file inherits these configurations when using your profile, unless otherwise explicitly overwritten by a ``Config`` object when instantiating your client object at runtime. If no configuration options are set, the default retry mode value is ``legacy``, and the default ``max_attempts`` value is 5.
+
+Defining a retry configuration in a Config object for your Boto 3 client
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The second way to define your retry configuration is to use botocore to enable more flexibility for you to specify your retry configuration using a ``Config`` object that you can pass to your client at runtime. This method is useful if you don't want to configure retry behavior globally with your AWS config file 
+
+Additionally, if your AWS configuration file is configured with retry behavior, but you want to override those global settings, you can use the ``Config`` object to override an individual client object at runtime.
+
+As shown in the following example, the ``Config`` object takes a ``retries`` dictionary where you can supply your two configuration options, ``max_attempts`` and ``mode``, and the values for each.
+
+.. code-block:: python
+
+   config = Config(
+      retries = {
+         'max_attempts': 10,
+         'mode': 'standard'
+      }
+   )
+
+.. note::
+   The AWS configuration file uses ``retry_mode`` and the ``Config`` object uses ``mode``. Although named differently, they both refer to the same retry configuration whose options are legacy (default), standard, and adaptive.
+
+The following is an example of instantiating a ``Config`` object and passing it into an Amazon EC2 client to use at runtime.
+
+.. code-block:: python
+
+   import boto3
+   from botocore.config import Config
+
+   config = Config(
+      retries = {
+         'max_attempts': 10,
+         'mode': 'standard'
+      }
+   )
+
+   ec2 = boto3.client('ec2', config=config)
+
+.. note::
+   As mentioned previously, if no configuration options are set, the default mode is ``legacy`` and the default ``max_attempts`` is 5.
+
+
+Validating retry attempts
+--------------------------
+
+To ensure that your retry configuration is correct and working properly, there are a number of ways you can validate that your client's retries are occurring. 
+
+Checking retry attempts in your client logs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you enable Boto 3’s logging, you can validate and check your client’s retry attempts in your client’s logs. Notice, however, that you need to enable ``DEBUG`` mode in your logger to see any retry attempts. The client log entries for retry attempts will appear differently, depending on which retry mode you’ve configured.
+
+**If legacy mode is enabled:**
+
+Retry messages are generated by ``botocore.retryhandler``. You’ll see one of three messages:
+
+* *No retry needed*
+* *Retry needed, action of: <action_value>*
+* *Reached the maximum number of retry attempts: <attempt_num>*
+
+
+**If standard or adaptive mode is enabled:**
+
+Retry messages are generated by ``botocore.retries.standard``. You’ll see one of three messages:
+
+* *Not retrying request*
+* *Retry needed, retrying request after delay of: <delay_value>*
+* *Retry needed but retry quota reached, not retrying request*
+
+Checking retry attempts in an AWS service response
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can check the number of retry attempts your client has made by parsing the response botocore provides when making a call to an AWS service API. Responses are handled by an underlying botocore module, and formatted into a dictionary that's part of the JSON response object. You can access the number of retry attempts your client has taken by calling the ``RetryAttempts`` key in the ``ResponseMetaData`` dictionary::
+
+   'ResponseMetadata': {
+      'RequestId': '1234567890ABCDEF',
+      'HostId': 'host ID data will appear here as a hash',
+      'HTTPStatusCode': 400,
+      'HTTPHeaders': {'header metadata key/values will appear here'},
+      'RetryAttempts': 4
+   }

--- a/docs/source/guide/retries.rst
+++ b/docs/source/guide/retries.rst
@@ -6,7 +6,7 @@ Retries
 Overview
 --------
 
-Your AWS client might see calls to AWS services fail due to unexpected issues on the client side. Or calls might fail due to rate limiting from the AWS service you're attempting to call. In either case, these kinds of failures often don’t require special handling and the call should be made again, often after a brief waiting period. Boto 3 provides many features to assist in retrying client calls to AWS services when these kinds of errors or exceptions are experienced.
+Your AWS client might see calls to AWS services fail due to unexpected issues on the client side. Or calls might fail due to rate limiting from the AWS service you're attempting to call. In either case, these kinds of failures often don’t require special handling and the call should be made again, often after a brief waiting period. Boto3 provides many features to assist in retrying client calls to AWS services when these kinds of errors or exceptions are experienced.
 
 This guide provides you with details on the following:
 
@@ -97,15 +97,15 @@ With each new retry attempt, adaptive mode modifies the rate-limit variables bas
 Configuring a retry mode
 -------------------------
 
-Boto 3 includes a variety of both retry configurations as well as configuration methods to consider when creating your client object.
+Boto3 includes a variety of both retry configurations as well as configuration methods to consider when creating your client object.
 
 Available configuration options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In Boto 3, users can customize two retry configurations:
+In Boto3, users can customize two retry configurations:
 
-* ``retry_mode`` - This tells Boto 3 which retry mode to use. As described previously, there are three retry modes available: legacy (default), standard, and adaptive.
-* ``max_attempts`` - This provides Boto 3’s retry handler with a value of maximum retry attempts, where the initial call counts toward the ``max_attempts`` value that you provide.
+* ``retry_mode`` - This tells Boto3 which retry mode to use. As described previously, there are three retry modes available: legacy (default), standard, and adaptive.
+* ``max_attempts`` - This provides Boto3’s retry handler with a value of maximum retry attempts, where the initial call counts toward the ``max_attempts`` value that you provide.
 
 Defining a retry configuration in your AWS configuration file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -117,9 +117,9 @@ This first way to define your retry configuration is to update your global AWS c
    max_attempts = 10
    retry_mode = standard
 
-Any Boto 3 script or code that uses your AWS config file inherits these configurations when using your profile, unless otherwise explicitly overwritten by a ``Config`` object when instantiating your client object at runtime. If no configuration options are set, the default retry mode value is ``legacy``, and the default ``max_attempts`` value is 5.
+Any Boto3 script or code that uses your AWS config file inherits these configurations when using your profile, unless otherwise explicitly overwritten by a ``Config`` object when instantiating your client object at runtime. If no configuration options are set, the default retry mode value is ``legacy``, and the default ``max_attempts`` value is 5.
 
-Defining a retry configuration in a Config object for your Boto 3 client
+Defining a retry configuration in a Config object for your Boto3 client
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The second way to define your retry configuration is to use botocore to enable more flexibility for you to specify your retry configuration using a ``Config`` object that you can pass to your client at runtime. This method is useful if you don't want to configure retry behavior globally with your AWS config file 
@@ -168,7 +168,7 @@ To ensure that your retry configuration is correct and working properly, there a
 Checking retry attempts in your client logs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you enable Boto 3’s logging, you can validate and check your client’s retry attempts in your client’s logs. Notice, however, that you need to enable ``DEBUG`` mode in your logger to see any retry attempts. The client log entries for retry attempts will appear differently, depending on which retry mode you’ve configured.
+If you enable Boto3’s logging, you can validate and check your client’s retry attempts in your client’s logs. Notice, however, that you need to enable ``DEBUG`` mode in your logger to see any retry attempts. The client log entries for retry attempts will appear differently, depending on which retry mode you’ve configured.
 
 **If legacy mode is enabled:**
 

--- a/docs/source/guide/s3-example-access-permissions.rst
+++ b/docs/source/guide/s3-example-access-permissions.rst
@@ -9,14 +9,14 @@
    limitations under the License.
    
 ##################
-Access Permissions
+Access permissions
 ##################
 
 This section demonstrates how to manage the access permissions for an S3 
 bucket or object by using an access control list (ACL).
 
 
-Get a Bucket Access Control List
+Get a bucket access control list
 ================================
 
 The example retrieves the current access control list of an S3 bucket.

--- a/docs/source/guide/s3-example-bucket-policies.rst
+++ b/docs/source/guide/s3-example-bucket-policies.rst
@@ -10,7 +10,7 @@
 
 
 ###############
-Bucket Policies
+Bucket policies
 ###############
 
 An S3 bucket can have an optional policy that grants access permissions to 
@@ -18,7 +18,7 @@ other AWS accounts or AWS Identity and Access Management (IAM) users. Bucket
 policies are defined using the same JSON format as a resource-based IAM policy.
 
 
-Retrieve a Bucket Policy
+Retrieve a bucket policy
 ========================
 
 Retrieve a bucket's policy by calling the AWS SDK for Python 
@@ -35,7 +35,7 @@ the bucket name.
     print(result['Policy'])
 
 
-Set a Bucket Policy
+Set a bucket policy
 ===================
 
 A bucket's policy can be set by calling the ``put_bucket_policy`` method.
@@ -70,7 +70,7 @@ stored in the bucket identified by the ``bucket_name`` variable.
     s3.put_bucket_policy(Bucket=bucket_name, Policy=bucket_policy)
 
 
-Delete a Bucket Policy
+Delete a bucket policy
 ======================
 
 A bucket's policy can be deleted by calling the ``delete_bucket_policy`` method.

--- a/docs/source/guide/s3-example-configuring-buckets.rst
+++ b/docs/source/guide/s3-example-configuring-buckets.rst
@@ -10,7 +10,7 @@
 
 
 #########################
-Bucket CORS Configuration
+Bucket CORS configuration
 #########################
 
 Cross Origin Resource Sharing (CORS) enables client web applications in one 
@@ -19,7 +19,7 @@ to enable cross-origin requests. The configuration defines rules that specify
 the allowed origins, HTTP methods (GET, PUT, etc.), and other elements.
 
 
-Retrieve a Bucket CORS Configuration
+Retrieve a bucket CORS configuration
 ====================================
 
 Retrieve a bucket's CORS configuration by calling the AWS SDK for Python 
@@ -54,7 +54,7 @@ Retrieve a bucket's CORS configuration by calling the AWS SDK for Python
         return response['CORSRules']
 
 
-Set a Bucket CORS Configuration
+Set a bucket CORS configuration
 ===============================
 
 A bucket's CORS configuration can be set by calling the ``put_bucket_cors`` 

--- a/docs/source/guide/s3-example-creating-buckets.rst
+++ b/docs/source/guide/s3-example-creating-buckets.rst
@@ -10,7 +10,7 @@
 
 
 #################
-Amazon S3 Buckets
+Amazon S3 buckets
 #################
 
 An Amazon S3 bucket is a storage location to hold files. S3 files are referred 
@@ -20,7 +20,7 @@ This section describes how to use the AWS SDK for Python to perform common
 operations on S3 buckets.
 
 
-Create an Amazon S3 Bucket
+Create an Amazon S3 bucket
 ==========================
 
 The name of an Amazon S3 bucket must be unique across all regions of the AWS 
@@ -61,7 +61,7 @@ or to address regulatory requirements.
         return True
 
 
-List Existing Buckets
+List existing buckets
 =====================
 
 List all the existing buckets for the AWS account.

--- a/docs/source/guide/s3-example-download-file.rst
+++ b/docs/source/guide/s3-example-download-file.rst
@@ -10,7 +10,7 @@
 
 
 #################
-Downloading Files
+Downloading files
 #################
 
 The methods provided by the AWS SDK for Python to download files are similar 

--- a/docs/source/guide/s3-example-static-web-host.rst
+++ b/docs/source/guide/s3-example-static-web-host.rst
@@ -10,13 +10,13 @@
 
 
 ##############################################
-Using an Amazon S3 Bucket as a Static Web Host
+Using an Amazon S3 bucket as a static web host
 ##############################################
 
 An S3 bucket can be configured to host a static website.
 
 
-Retrieve a Website Configuration
+Retrieve a website configuration
 ================================
 
 Retrieve a bucket's website configuration by calling the AWS SDK for Python 
@@ -31,7 +31,7 @@ Retrieve a bucket's website configuration by calling the AWS SDK for Python
     result = s3.get_bucket_website(Bucket='BUCKET_NAME')
  
 
-Set a Website Configuration
+Set a website configuration
 ===========================
 
 A bucket's website configuration can be set by calling the 
@@ -52,7 +52,7 @@ A bucket's website configuration can be set by calling the
                           WebsiteConfiguration=website_configuration)
 
 
-Delete a Website Configuration
+Delete a website configuration
 ==============================
 
 A bucket's website configuration can be deleted by calling the 

--- a/docs/source/guide/s3-examples.rst
+++ b/docs/source/guide/s3-examples.rst
@@ -11,7 +11,7 @@
 .. _aws-boto3-s3-examples:
 
 ##################
-Amazon S3 Examples
+Amazon S3 examples
 ##################
 
 .. meta::

--- a/docs/source/guide/s3-presigned-urls.rst
+++ b/docs/source/guide/s3-presigned-urls.rst
@@ -70,7 +70,7 @@ perform a GET request.
         response = requests.get(url)
 
 
-Using Presigned URLs to Perform Other S3 Operations
+Using presigned URLs to perform other S3 operations
 ===================================================
 
 The main purpose of presigned URLs is to grant a user temporary access to an 
@@ -120,7 +120,7 @@ the appropriate method so this argument is not normally required.
         return response
 
 
-Generating a Presigned URL to Upload a File
+Generating a presigned URL to upload a file
 ===========================================
 
 A user who does not have AWS credentials to upload a file can use a 

--- a/docs/source/guide/s3-uploading-files.rst
+++ b/docs/source/guide/s3-uploading-files.rst
@@ -10,7 +10,7 @@
 
 
 ###############
-Uploading Files
+Uploading files
 ###############
 
 The AWS SDK for Python provides a pair of methods to upload a file to an S3
@@ -66,7 +66,7 @@ provided by each class is identical. No benefits are gained by calling one
 class's method over another's. Use whichever class is most convenient.
 
 
-The ExtraArgs Parameter
+The ExtraArgs parameter
 ===========================
 
 Both ``upload_file`` and ``upload_fileobj`` accept an optional ``ExtraArgs`` 
@@ -110,7 +110,7 @@ The ``ExtraArgs`` parameter can also be used to set custom or multiple ACLs.
     )
 
 
-The Callback Parameter
+The Callback parameter
 ==========================
 
 Both ``upload_file`` and ``upload_fileobj`` accept an optional ``Callback`` 

--- a/docs/source/guide/s3.rst
+++ b/docs/source/guide/s3.rst
@@ -10,7 +10,7 @@
 
 
 ###########################
-File Transfer Configuration
+File transfer configuration
 ###########################
 
 When uploading, downloading, or copying a file or S3 object, the AWS SDK for 
@@ -29,7 +29,7 @@ The remaining sections demonstrate how to configure various transfer operations
 with the ``TransferConfig`` object.
 
 
-Multipart Transfers
+Multipart transfers
 ===================
 
 Multipart transfers occur when the file size exceeds the value of the 
@@ -53,7 +53,7 @@ if the file size is larger than the threshold specified in the
     s3.upload_file('FILE_NAME', 'BUCKET_NAME', 'OBJECT_NAME', Config=config)
 
 
-Concurrent Transfer Operations
+Concurrent transfer operations
 ==============================
 
 The maximum number of concurrent S3 API transfer operations can be tuned to 

--- a/docs/source/guide/sdk-metrics.rst
+++ b/docs/source/guide/sdk-metrics.rst
@@ -1,6 +1,6 @@
 .. _guide_sdk-metrics:
 
-SDK Metrics 
+SDK metrics 
 ===========
 
 AWS SDK Metrics for Enterprise Support (SDK Metrics) enables Enterprise customers to collect metrics from AWS SDKs on their hosts and clients shared with 
@@ -34,7 +34,7 @@ For more information, see the following:
 
 .. _csm-enable-agent:
 
-Enable SDK Metrics
+Enable SDK metrics
 ------------------
 
 By default, SDK Metrics is turned off, and the port is set to 31000. The following are the default parameters.
@@ -43,7 +43,7 @@ Enabling SDK Metrics is independent of configuring your credentials to use an AW
 
 You can enable SDK Metrics by setting environment variables or by using the AWS Shared config file.
 
-Option 1: Set Environment Variables
+Option 1: Set environment variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If :code:`AWS_CSM_ENABLED` is not set, the SDK checks the :code:`AWS_DEFAULT_PROFILE` profile to determine if SDK Metrics is enabled. By default this is set to ``false``.
@@ -59,7 +59,7 @@ To turn on SDK Metrics, add the following to your environmental variables.
 Note: Enabling SDK Metrics does not configure your credentials to use an AWS service. 
 
 
-Option 2: AWS Shared Config File
+Option 2: AWS shared config file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If no CSM configuration is found in the environment variables, the SDK looks for your default AWS profile field. If :code:`AWS_DEFAULT_PROFILE` is set to something other than default, update that profile. To enable SDK Metrics, add :code:`csm_enabled` to the shared config file located at :file:`~/.aws/config`.
@@ -78,12 +78,12 @@ Note: Enabling SDK Metrics is independent from configuring your credentials to u
 
 .. _csm-update-agent:
 
-Update a CloudWatch Agent
+Update a CloudWatch agent
 -------------------------
 
 To make changes to the port, you need to set the values and then restart any AWS jobs that are currently active.
 
-Option 1: Set Environment Variables
+Option 1: Set environment variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Most services use the default port. But if your service requires a unique port ID, add ``AWS_CSM_PORT=[port_number]``, to the host's environment variables.
@@ -94,7 +94,7 @@ Most services use the default port. But if your service requires a unique port I
     export AWS_CSM_PORT=1234
 
 
-Option 2: AWS Shared Config File
+Option 2: AWS shared config file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Most services use the default port. But if your service requires a
@@ -110,7 +110,7 @@ unique port ID, add ``csm_port = [port_number]`` to ``~/.aws/config``.
     csm_enabled = false
     csm_port = 1234
 
-Restart SDK Metrics
+Restart SDK metrics
 ~~~~~~~~~~~~~~~~~~~
 
 To restart a job, run the following commands.
@@ -123,7 +123,7 @@ To restart a job, run the following commands.
 
 .. _csm-disable-agent:
 
-Disable SDK Metrics
+Disable SDK metrics
 --------------------
 
 To turn off SDK Metrics, remove ``csm_enabled`` from your environment variables, or in your AWS Shared config file located at :file:`~/.aws/config`.
@@ -168,7 +168,7 @@ If you are using other CloudWatch features, restart CloudWatch Agent with the fo
     amazon-cloudwatch-agent-ctl –a start;
     
 
-Restart SDK Metrics
+Restart SDK metrics
 ~~~~~~~~~~~~~~~~~~~
 
 To restart a SDK Metrics job, run the following commands.
@@ -178,7 +178,7 @@ To restart a SDK Metrics job, run the following commands.
     amazon-cloudwatch-agent-ctl –a stop;
     amazon-cloudwatch-agent-ctl –a start;
 
-Definitions for SDK Metrics
+Definitions for SDK metrics
 ---------------------------
 
 You can use the following descriptions of SDK Metrics to interpret your results. In general, these metrics are available for review

--- a/docs/source/guide/secrets-manager.rst
+++ b/docs/source/guide/secrets-manager.rst
@@ -24,7 +24,7 @@ in the *AWS Secrets Manager Developer Guide*.
 
 All the example code for the Amazon Web Services (AWS) SDK for Python is available `here on GitHub <https://github.com/awsdocs/aws-doc-sdk-examples/tree/master/python/example_code>`_.
 
-Prerequisite Tasks
+Prerequisite tasks
 ==================
 
 To set up and run this example, you must first set up the following:
@@ -32,7 +32,7 @@ To set up and run this example, you must first set up the following:
 * Configure your AWS credentials, as described in :doc:`quickstart`.
 * Create a secret with the AWS Secrets Manager, as described in the `AWS Secrets Manager Developer Guide <https://docs.aws.amazon.com/secretsmanager/latest/userguide/manage_create-basic-secret.html>`_
 
-Retrieve the Secret Value
+Retrieve the secret value
 =============================================
 
 The following example shows how to:

--- a/docs/source/guide/security.rst
+++ b/docs/source/guide/security.rst
@@ -26,7 +26,7 @@ and `AWS services that are in scope of AWS compliance efforts by compliance prog
 
 .. _data_protection_intro:
 
-Data Protection
+Data protection
 ---------------
 
 For data protection purposes, we recommend that you protect AWS account credentials and set up individual user accounts with
@@ -52,7 +52,7 @@ blog post on the *AWS Security Blog*.
 
 .. _identity_and_access_management_intro:
 
-Identity and Access Management
+Identity and access management
 ------------------------------
 
 AWS Identity and Access Management (IAM) is an AWS service that helps an administrator securely control access to AWS resources.
@@ -70,7 +70,7 @@ in the `Amazon Web Services General Reference <https://docs.aws.amazon.com/gener
 
 .. _compliance_validation_intro:
 
-Compliance Validation
+Compliance validation
 ---------------------
 
 The security and compliance of AWS services is assessed by third-party auditors as part
@@ -112,7 +112,7 @@ For more information about AWS Regions and Availability Zones, see `AWS Global I
 
 .. _infrastructure_security_intro:
 
-Infrastructure Security
+Infrastructure security
 -----------------------
 
 For information about AWS security processes, see the `AWS: Overview of Security Processes <https://d0.awsstatic.com/whitepapers/Security/AWS_Security_Whitepaper.pdf>`_ whitepaper.
@@ -124,7 +124,7 @@ Enforcing TLS 1.2
 
 To ensure the AWS SDK for Python uses no TLS version earlier than TLS 1.2, you might need to recompile OpenSSL to enforce this minimum and then recompile Python to use the recompiled OpenSSL.
 
-Determining Supported Protocols
+Determining supported protocols
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 First, create a self-signed certificate to use for the test server and the SDK using OpenSSL::

--- a/docs/source/guide/security.rst
+++ b/docs/source/guide/security.rst
@@ -19,7 +19,7 @@ verified by third-party auditors as part of the `AWS Compliance Programs <https:
 determined by the AWS service you are using, and other factors including the sensitivity of
 your data, your organization’s requirements, and applicable laws and regulations.
 
-Boto 3 follows the `shared responsibility model <https://aws.amazon.com/compliance/shared-responsibility-model>`_
+Boto3 follows the `shared responsibility model <https://aws.amazon.com/compliance/shared-responsibility-model>`_
 through the specific AWS services it supports. For AWS service security information, see the
 `AWS service security documentation page <https://aws.amazon.com/security/?id=docs_gateway#aws-security>`_
 and `AWS services that are in scope of AWS compliance efforts by compliance program <https://aws.amazon.com/compliance/services-in-scope/>`_.
@@ -41,8 +41,8 @@ you secure your data in the following ways:
   is stored in Amazon S3.
 
 We strongly recommend that you never put sensitive identifying information, such as your customers' account numbers, into
-free-form fields such as a **Name** field. This includes when you work with Boto 3 or other AWS services
-using the console, API, AWS CLI, or AWS SDKs. Any data that you enter into Boto 3 or other services might get picked up
+free-form fields such as a **Name** field. This includes when you work with Boto3 or other AWS services
+using the console, API, AWS CLI, or AWS SDKs. Any data that you enter into Boto3 or other services might get picked up
 for inclusion in diagnostic logs. When you provide a URL to an external server, don't include credentials information in the URL
 to validate your request to that server.
 
@@ -58,7 +58,7 @@ Identity and access management
 AWS Identity and Access Management (IAM) is an AWS service that helps an administrator securely control access to AWS resources.
 IAM administrators control who can be *authenticated* (signed in) and *authorized* (have permissions) to use AWS resources. IAM is an AWS service that you can use with no additional charge.
 
-To use Boto 3 to access AWS, you need an AWS account and AWS credentials. To increase the security of your
+To use Boto3 to access AWS, you need an AWS account and AWS credentials. To increase the security of your
 AWS account, we recommend that you use an *IAM user* to provide access credentials instead of using your AWS
 account credentials.
 
@@ -83,7 +83,7 @@ Third-party audit reports are available for you to download using AWS Artifact. 
 
 For more information about AWS compliance programs, see `AWS Compliance Programs <https://aws.amazon.com/compliance/programs/>`_.
 
-Your compliance responsibility when using Boto 3 to access an AWS service is determined by the sensitivity of your data, your organization’s compliance objectives,
+Your compliance responsibility when using Boto3 to access an AWS service is determined by the sensitivity of your data, your organization’s compliance objectives,
 and applicable laws and regulations. If your use of an AWS service is subject to compliance with standards such as HIPAA, PCI, or FedRAMP, AWS provides resources to help:
 
 * `Security and Compliance Quick Start Guides <https://aws.amazon.com/quickstart/?quickstart-all.sort-by=item.additionalFields.updateDate&quickstart-all.sort-order=desc&awsf.quickstart-homepage-filter=categories%23security-identity-compliance>`_ –

--- a/docs/source/guide/ses-examples.rst
+++ b/docs/source/guide/ses-examples.rst
@@ -12,7 +12,7 @@
 
 
 ###################
-Amazon SES Examples
+Amazon SES examples
 ###################
 
 .. meta::
@@ -29,9 +29,9 @@ addresses and domains. For more information about Amazon SES, see the
 .. toctree::
    :maxdepth: 1
 
-   Verifying Email Addresses <ses-verify>
-   Working with Email Templates <ses-template>
-   Managing Email Filters <ses-filters>
-   Using Email Rules <ses-rules>
+   Verifying email addresses <ses-verify>
+   Working with email templates <ses-template>
+   Managing email filters <ses-filters>
+   Using email rules <ses-rules>
 
    

--- a/docs/source/guide/ses-filters.rst
+++ b/docs/source/guide/ses-filters.rst
@@ -12,7 +12,7 @@
 
 
 ###################################
-Managing Email Filters with SES API 
+Managing email filters with SES API 
 ###################################
 
 .. meta::
@@ -36,7 +36,7 @@ The following examples show how to:
   `delete_receipt_filter() <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ses.html#SES.Client.delete_receipt_filter>`__.
 
 
-Prerequisite Tasks
+Prerequisite tasks
 ==================
 
 To set up and run this example, you must first complete these tasks:
@@ -44,7 +44,7 @@ To set up and run this example, you must first complete these tasks:
 * Configure your AWS credentials, as described in :doc:`quickstart`.
 
 
-Create an Email Filter
+Create an email filter
 ======================
 
 To allow or block emails from a specific IP address, use the 
@@ -76,7 +76,7 @@ Example
     print(response)
 
 
-List All Email Filters
+List all email filters
 ======================
 
 To list the IP address filters associated with your AWS account in the current 
@@ -99,7 +99,7 @@ Example
     print(response)
 
 
-Delete an Email Filter
+Delete an email filter
 ======================
 
 To remove an existing filter for a specific IP address use the 

--- a/docs/source/guide/ses-rules.rst
+++ b/docs/source/guide/ses-rules.rst
@@ -12,7 +12,7 @@
 
 
 ####################################################
-Creating and Managing Email Rules with the SES API 
+Creating and managing email rules with the SES API 
 ####################################################
 
 .. meta::
@@ -38,7 +38,7 @@ The following examples show how to:
 * Remove a receipt rule set using `delete_receipt_rule_set() <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ses.html#SES.Client.delete_receipt_rule_set>`_.
 
 
-Prerequisite Tasks
+Prerequisite tasks
 ==================
 
 To set up and run this example, you must first complete these tasks:
@@ -46,7 +46,7 @@ To set up and run this example, you must first complete these tasks:
 * Configure your AWS credentials, as described in :doc:`quickstart`.
 
 
-Create a Receipt Rule Set
+Create a receipt rule set
 ==========================
 
 A receipt rule set contains a collection of receipt rules. You must have at 
@@ -73,7 +73,7 @@ Example
     print(response)
 
 
-Create a Receipt Rule
+Create a receipt rule
 =====================
 
 Control your incoming email by adding a receipt rule to an existing 
@@ -117,7 +117,7 @@ Example
     print(response)
 
 
-Delete a Receipt Rule Set
+Delete a receipt rule set
 ==========================
 
 Remove a specified receipt rule set that isn't currently disabled. This also 
@@ -144,7 +144,7 @@ Example
     print(response)
 
 
-Delete a Receipt Rule
+Delete a receipt rule
 =====================
 
 To delete a specified receipt rule, provide the RuleName and RuleSetName to the 

--- a/docs/source/guide/ses-template.rst
+++ b/docs/source/guide/ses-template.rst
@@ -11,7 +11,7 @@
 .. _aws-boto3-ses-template:   
 
 ###############################################
-Creating Custom Email Templates with Amazon SES
+Creating custom email templates with Amazon SES
 ###############################################
 
 .. meta::
@@ -36,14 +36,14 @@ The following examples show how to:
 * Remove an email template using `delete_template() <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ses.html#SES.Client.delete_template>`_.
 * Send a templated email using `send_templated_email() <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ses.html#SES.Client.send_templated_email>`_.
 
-Prerequisite Tasks
+Prerequisite tasks
 ==================
 
 To set up and run this example, you must first complete these tasks:
 
 * Configure your AWS credentials, as described in :doc:`quickstart`.
 
-Create an Email Template
+Create an email template
 ========================
 
 To create a template to send personalized email messages, use the 
@@ -77,7 +77,7 @@ Example
 
     print(response)
 
-Get an Email Template
+Get an email template
 =====================
 
 To view the content for an existing email template including the subject line, HTML body, and plain text, use the `GetTemplate <https://docs.aws.amazon.com/ses/latest/APIReference/API_GetTemplate.html>`_ operation. Only TemplateName is required.
@@ -98,7 +98,7 @@ Example
 
     print(response)
 
-List All Email Templates
+List all email templates
 ========================
 
 To retrieve a list of all email templates that are associated with your AWS account in the current AWS Region, use the `ListTemplates <https://docs.aws.amazon.com/ses/latest/APIReference/API_ListTemplates.html>`_ operation.
@@ -120,7 +120,7 @@ Example
     print(response)
 
 
-Update an Email Template
+Update an email template
 ========================
 
 To change the content for a specific email template including the subject line, HTML body, and plain text, use the `UpdateTemplate <https://docs.aws.amazon.com/ses/latest/APIReference/API_UpdateTemplate.html>`_ operation.
@@ -146,7 +146,7 @@ Example
     
     print(response)
    
-Send an Email with a Template
+Send an email with a template
 =============================
 
 To use a template to send an email to recipients, use the `SendTemplatedEmail <https://docs.aws.amazon.com/ses/latest/APIReference/API_SendTemplatedEmail.html>`__ operation.

--- a/docs/source/guide/ses-verify.rst
+++ b/docs/source/guide/ses-verify.rst
@@ -12,7 +12,7 @@
 
 
 ############################################
-Verifying Email Identities in Amazon SES
+Verifying email identities in Amazon SES
 ############################################
 
 .. meta::
@@ -32,7 +32,7 @@ The following examples show how to:
 * List all email addresses or domains using `list_identities() <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ses.html#SES.Client.list_identities>`__.
 * Remove an email address or domain using `delete_identity() <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ses.html#SES.Client.delete_identity>`__.
 
-Prerequisite Tasks
+Prerequisite tasks
 ==================
 
 To set up and run this example, you must first complete these tasks:
@@ -40,7 +40,7 @@ To set up and run this example, you must first complete these tasks:
 * Configure your AWS credentials, as described in :doc:`quickstart`.
 
 
-Verify an Email Address
+Verify an email address
 =======================
 SES can send email only from verified email addresses or domains. By 
 verifying an email address, you demonstrate that you're the owner of that 
@@ -71,7 +71,7 @@ Example
     print(response)
 
 
-Verify an Email Domain
+Verify an email domain
 ======================
 
 SES can send email only from verified email addresses or domains. By verifying 
@@ -104,7 +104,7 @@ Example
     print(response)
 
 
-List Email Addresses
+List email addresses
 ====================
 
 To retrieve a list of email addresses submitted in the current AWS Region, 
@@ -130,7 +130,7 @@ Example
     print(response)
 
 
-List Email Domains
+List email domains
 ==================
 
 To retrieve a list of email domains submitted in the current AWS Region, 
@@ -156,7 +156,7 @@ Example
     print(response)
 
 
-Delete an Email Address
+Delete an email address
 =======================
 
 To delete a verified email address from the list of verified identities, use 
@@ -180,7 +180,7 @@ Example
     print(response)
 
 
-Delete an Email Domain
+Delete an email domain
 ======================
 
 To delete a verified email domain from the list of verified identities, use the 

--- a/docs/source/guide/session.rst
+++ b/docs/source/guide/session.rst
@@ -11,7 +11,7 @@ typically store:
 * Region
 * Other configurations
 
-Default Session
+Default session
 ---------------
 The ``boto3`` module acts as a proxy to the default session, which is
 created automatically when needed. Example default session use::
@@ -20,7 +20,7 @@ created automatically when needed. Example default session use::
     sqs = boto3.client('sqs')
     s3 = boto3.resource('s3')
 
-Custom Session
+Custom session
 --------------
 It is also possible to manage your own session and create clients or
 resources from it::

--- a/docs/source/guide/sqs-example-dead-letter-queue.rst
+++ b/docs/source/guide/sqs-example-dead-letter-queue.rst
@@ -11,13 +11,13 @@
 .. _aws-boto3-sqs-dead-letter-queue:   
 
 ######################################
-Using Dead Letter Queues in Amazon SQS
+Using dead-letter queues in Amazon SQS
 ######################################
 
 This Python example shows you how to use a queue to receive and hold messages from other queues that 
 the queues can't process.
 
-The Scenario
+The scenario
 ============
 
 A dead letter queue is one that other (source) queues can target for messages that can't be processed
@@ -34,7 +34,7 @@ For more information about Amazon SQS dead letter queues, see
 `Using Amazon SQS Dead Letter Queues <http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html>`_ 
 in the *Amazon Simple Queue Service Developer Guide*.
 
-Prerequisite Tasks
+Prerequisite tasks
 ==================
 
 To set up and run this example, you must first complete these tasks:
@@ -42,7 +42,7 @@ To set up and run this example, you must first complete these tasks:
 * Create an Amazon SQS queue to serve as a dead letter queue. For an example 
   of creating an Amazon SQS queue, see :ref:`aws-boto3-sqs-create-queue`.
 
-Configure Source Queues
+Configure source queues
 =======================
 
 After you create a queue to act as a dead letter queue, you must configure the other queues that route 

--- a/docs/source/guide/sqs-example-long-polling.rst
+++ b/docs/source/guide/sqs-example-long-polling.rst
@@ -11,7 +11,7 @@
 .. _aws-boto3-sqs-long-polling:   
 
 ###################################
-Enabling Long Polling in Amazon SQS
+Enabling long polling in Amazon SQS
 ###################################
 
 This Python example shows you how to enable long polling in Amazon SQS in one of these ways:
@@ -22,7 +22,7 @@ This Python example shows you how to enable long polling in Amazon SQS in one of
 
 * Upon receipt of a message
 
-The Scenario
+The scenario
 ============
 
 Long polling reduces the number of empty responses by allowing Amazon SQS to wait a specified time 
@@ -45,7 +45,7 @@ For more information, see
 `Amazon SQS Long Polling <http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html>`_ 
 in the *Amazon Simple Queue Service Developer Guide*.
 
-Enable Long Polling When Creating a Queue
+Enable long polling when creating a queue
 =========================================
 
 The example below shows how to:
@@ -71,7 +71,7 @@ Example
 
     print(response['QueueUrl'])
 
-Enable Long Polling on an Existing Queue
+Enable long polling on an existing queue
 ========================================
 
 The example below shows how to:
@@ -97,7 +97,7 @@ Example
         Attributes={'ReceiveMessageWaitTimeSeconds': '20'}
     )
 
-Enable Long Polling on Message Receipt
+Enable long polling on message receipt
 ======================================
 
 The example below shows how to:

--- a/docs/source/guide/sqs-example-sending-receiving-msgs.rst
+++ b/docs/source/guide/sqs-example-sending-receiving-msgs.rst
@@ -11,12 +11,12 @@
 .. _aws-boto3-sqs-messages:   
 
 ############################################
-Sending and Receiving Messages in Amazon SQS
+Sending and receiving messages in Amazon SQS
 ############################################
 
 This Python example shows you how to send, receive, and delete messages in a queue.
 
-The Scenario
+The scenario
 ============
 
 In this example, Python code is used to send and receive messages. The code uses the AWS SDK for Python 
@@ -33,7 +33,7 @@ For more information about Amazon SQS messages, see
 and `Receiving and Deleting a Message from an Amazon SQS Queue <http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-receive-delete-message.html>`_ 
 in the *Amazon Simple Queue Service Developer Guide*.
 
-Prerequisite Tasks
+Prerequisite tasks
 ==================
 
 To set up and run this example, you must first complete these tasks:
@@ -43,7 +43,7 @@ To set up and run this example, you must first complete these tasks:
 
 .. _aws-boto3-sqs-send-message:
 
-Send a Message to a Queue
+Send a message to a queue
 =========================
 
 The example below shows how to:
@@ -90,7 +90,7 @@ Example
     print(response['MessageId'])
 
 
-Receive and Delete Messages from a Queue
+Receive and delete messages from a queue
 ========================================
 
 The example below shows how to:

--- a/docs/source/guide/sqs-example-using-queues.rst
+++ b/docs/source/guide/sqs-example-using-queues.rst
@@ -11,7 +11,7 @@
 .. _aws-boto3-sqs-using-queues:   
 
 ##########################
-Using Queues in Amazon SQS
+Using queues in Amazon SQS
 ##########################
 
 This Python example shows you how to:
@@ -22,7 +22,7 @@ This Python example shows you how to:
 
 * Create and delete queues
 
-The Scenario
+The scenario
 ============
 
 In this example, Python code is used to work with queues. The code uses the AWS SDK for Python to use 
@@ -40,7 +40,7 @@ For more information about Amazon SQS messages, see
 `How Queues Work <http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-how-it-works.html>`_ 
 in the *Amazon Simple Queue Service Developer Guide*.
 
-List Your Queues
+List your queues
 ================
 
 The example below shows how to:
@@ -65,7 +65,7 @@ Example
 
 .. _aws-boto3-sqs-create-queue:
 
-Create a Queue
+Create a queue
 ==============
 
 The example below shows how to:
@@ -94,7 +94,7 @@ Example
 
     print(response['QueueUrl'])
 
-Get the URL for a Queue
+Get the URL for a queue
 =======================
 
 The example below shows how to:
@@ -117,7 +117,7 @@ Example
 
     print(response['QueueUrl'])
 
-Delete a Queue
+Delete a queue
 ==============
 
 The example below shows how to:

--- a/docs/source/guide/sqs-example-visibility-timeout.rst
+++ b/docs/source/guide/sqs-example-visibility-timeout.rst
@@ -11,13 +11,13 @@
 .. _aws-boto3-sqs-visibility-timeout:   
 
 #########################################
-Managing Visibility Timeout in Amazon SQS
+Managing visibility timeout in Amazon SQS
 #########################################
 
 This Python example shows you how to specify the time interval during which messages received by a 
 queue are not visible.
 
-The Scenario
+The scenario
 ============
 
 In this example, Python code is used to manage visibility timeout. The code uses the SDK for Python 
@@ -29,7 +29,7 @@ For more information about Amazon SQS visibility timeout, see
 `Visibility Timeout <http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html>`_ 
 in the *Amazon Simple Queue Service Developer Guide*.
 
-Prerequisite Tasks
+Prerequisite tasks
 ==================
 
 To set up and run this example, you must first complete these tasks:
@@ -40,7 +40,7 @@ To set up and run this example, you must first complete these tasks:
 * Send a message to the queue. For an example of sending a message to a 
   queue, see :ref:`aws-boto3-sqs-send-message`.
 
-Change the Visibility Timeout
+Change the visibility timeout
 =============================
 
 The example below shows how to:

--- a/docs/source/guide/sqs-examples.rst
+++ b/docs/source/guide/sqs-examples.rst
@@ -11,7 +11,7 @@
 .. _aws-boto3-sqs-examples:   
 
 ###################
-Amazon SQS Examples
+Amazon SQS examples
 ###################
 
 .. meta::

--- a/docs/source/guide/sqs.rst
+++ b/docs/source/guide/sqs.rst
@@ -1,6 +1,6 @@
 .. _sample_tutorial:
 
-A Sample Tutorial
+A sample tutorial
 =================
 This tutorial will show you how to use Boto3 with an AWS service. In this
 sample tutorial, you will learn how to use Boto3 with 
@@ -13,7 +13,7 @@ create a new queue, get and use an existing queue, push new messages onto the
 queue, and process messages from the queue by using
 :ref:`guide_resources` and :ref:`guide_collections`.
 
-Creating a Queue
+Creating a queue
 ----------------
 Queues are created with a name. You may also optionally set queue
 attributes, such as the number of seconds to wait before an item may be
@@ -37,7 +37,7 @@ Reference: :py:meth:`SQS.ServiceResource.create_queue`
    The code above may throw an exception if you already have a queue named
    ``test``.
 
-Using an Existing Queue
+Using an existing queue
 -----------------------
 It is possible to look up a queue by its name. If the queue does not exist,
 then an exception will be thrown::
@@ -67,7 +67,7 @@ It is also possible to list all of your existing queues::
 Reference: :py:meth:`SQS.ServiceResource.get_queue_by_name`,
 :py:attr:`SQS.ServiceResource.queues`
 
-Sending Messages
+Sending messages
 ----------------
 Sending a message adds it to the end of the queue::
 
@@ -122,7 +122,7 @@ messages, so you can retry failures if needed.
 Reference: :py:meth:`SQS.Queue.send_message`,
 :py:meth:`SQS.Queue.send_messages`
 
-Processing Messages
+Processing messages
 -------------------
 Messages are processed in batches::
 

--- a/docs/source/guide/upgrading.rst
+++ b/docs/source/guide/upgrading.rst
@@ -1,5 +1,5 @@
 ===============
-Upgrading Notes
+Upgrading notes
 ===============
 
 Notes to refer to when upgrading ``boto3`` versions.
@@ -7,13 +7,13 @@ Notes to refer to when upgrading ``boto3`` versions.
 1.9.0
 -----
 
-What Changed
+What changed
 ~~~~~~~~~~~~
 
 The boto3 event system was changed to emit events based on the service id
 rather than the endpoint prefix or service name.
 
-Why Was The Change Was Made
+Why was the change made
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This was done to handle several issues that were becoming increasingly
@@ -27,7 +27,7 @@ problematic:
 * Services whose client name and endpoint prefix differed would require two
   different strings if you want to register against all events.
 
-How Do I Know If I'm Impacted
+How do I know if I'm impacted
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Any users relying on registering an event against one service impacting other
@@ -63,7 +63,7 @@ without shared endpoints we do the work of translating the event name at
 registration and emission time. In future versions of boto3 we will remove
 this translation, so you may wish to update your code anyway.
 
-How Do I Update My Code
+How do I update my code
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 You will need to look at the events you are registering against and determine

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Boto 3 Documentation
+Boto 3 documentation
 ====================
 Boto is the Amazon Web Services (AWS) SDK for Python. It enables Python
 developers to create, configure, and manage AWS services, such as EC2 
@@ -20,7 +20,7 @@ Quickstart
    guide/sqs
    guide/examples
 
-User Guides
+User guides
 -----------
 
 .. toctree::
@@ -36,7 +36,7 @@ Security
 
    guide/security
 
-API Reference
+API reference
 -------------
 
 Services

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Boto 3 documentation
+Boto3 documentation
 ====================
 Boto is the Amazon Web Services (AWS) SDK for Python. It enables Python
 developers to create, configure, and manage AWS services, such as EC2 

--- a/docs/source/reference/core/boto3.rst
+++ b/docs/source/reference/core/boto3.rst
@@ -1,7 +1,7 @@
 .. _ref_core_init:
 
 ===============
-Boto3 Reference
+Boto3 reference
 ===============
 
 .. automodule:: boto3

--- a/docs/source/reference/core/collections.rst
+++ b/docs/source/reference/core/collections.rst
@@ -1,7 +1,7 @@
 .. _ref_core_collections:
 
 =====================
-Collections Reference
+Collections reference
 =====================
 
 .. automodule:: boto3.resources.collection

--- a/docs/source/reference/core/index.rst
+++ b/docs/source/reference/core/index.rst
@@ -1,4 +1,4 @@
-Core References
+Core references
 ===============
 
 .. toctree::

--- a/docs/source/reference/core/resources.rst
+++ b/docs/source/reference/core/resources.rst
@@ -1,10 +1,10 @@
 .. _ref_core_resources:
 
 ===================
-Resources Reference
+Resources reference
 ===================
 
-Resource Model
+Resource model
 --------------
 
 .. automodule:: boto3.resources.model
@@ -12,35 +12,35 @@ Resource Model
    :undoc-members:
    :inherited-members:
 
-Request Parameters
+Request parameters
 ------------------
 
 .. automodule:: boto3.resources.params
    :members:
    :undoc-members:
 
-Response Handlers
+Response handlers
 -----------------
 
 .. automodule:: boto3.resources.response
    :members:
    :undoc-members:
 
-Resource Actions
+Resource actions
 ----------------
 
 .. automodule:: boto3.resources.action
    :members:
    :undoc-members:
 
-Resource Base
+Resource base
 -------------
 
 .. automodule:: boto3.resources.base
    :members:
    :undoc-members:
 
-Resource Factory
+Resource factory
 ----------------
 
 .. automodule:: boto3.resources.factory

--- a/docs/source/reference/core/session.rst
+++ b/docs/source/reference/core/session.rst
@@ -1,7 +1,7 @@
 .. _ref_core_session:
 
 =================
-Session Reference
+Session reference
 =================
 
 .. automodule:: boto3.session

--- a/docs/source/reference/customizations/dynamodb.rst
+++ b/docs/source/reference/customizations/dynamodb.rst
@@ -1,12 +1,12 @@
 .. _ref_custom_dynamodb:
 
 ================================
-DynamoDB Customization Reference
+DynamoDB customization reference
 ================================
 
 .. _ref_valid_dynamodb_types:
 
-Valid DynamoDB Types
+Valid DynamoDB types
 --------------------
 
 These are the valid item types to use with Boto3 Table Resource (:py:class:`dynamodb.Table`) and DynamoDB:
@@ -40,7 +40,7 @@ These are the valid item types to use with Boto3 Table Resource (:py:class:`dyna
 +----------------------------------------------+-----------------------------+
 
 
-Custom Boto3 Types
+Custom Boto3 types
 ------------------
 
 
@@ -50,7 +50,7 @@ Custom Boto3 Types
 
 .. _ref_dynamodb_conditions:
 
-DynamoDB Conditions
+DynamoDB conditions
 -------------------
 
 .. autoclass:: boto3.dynamodb.conditions.Key

--- a/docs/source/reference/customizations/index.rst
+++ b/docs/source/reference/customizations/index.rst
@@ -1,4 +1,4 @@
-Customization References
+Customization references
 ========================
 
 .. toctree::

--- a/docs/source/reference/customizations/s3.rst
+++ b/docs/source/reference/customizations/s3.rst
@@ -1,10 +1,10 @@
 .. _ref_custom_s3:
 
 ==========================
-S3 Customization Reference
+S3 customization reference
 ==========================
 
-S3 Transfers
+S3 transfers
 ------------
 
 .. note::

--- a/docs/source/reference/services/index.rst
+++ b/docs/source/reference/services/index.rst
@@ -1,4 +1,4 @@
-Available Services
+Available services
 ==================
 
 .. toctree::

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -133,7 +133,7 @@ class TestSession(BaseTestCase):
         self.assertFalse(self.bc_session_cls.called)
 
     def test_user_agent(self):
-        # Here we get the underlying Botocore session, create a Boto 3
+        # Here we get the underlying Botocore session, create a Boto3
         # session, and ensure that the user-agent is modified as expected
         bc_session = self.bc_session_cls.return_value
         bc_session.user_agent_name = 'Botocore'


### PR DESCRIPTION
**What's changed?**

* Updated doc index, all user guides, and user guide examples to adhere to AWS style standards of sentence-casing.
* Added a new Retries user guide
* Updated the Resource user guide to include a note about thread safety - addresses this [issue](https://github.com/boto/botocore/issues/1246)
* Updated all "Boto 3" occurrences to "Boto3" across all docs, user guide examples. 
* Additional grammatical edits provided by our editor
* All commits squashed into a single commit, ready for merge