### PR TITLE
Fixed error in credentials example

### DIFF
--- a/docs/source/guide/configuration.rst
+++ b/docs/source/guide/configuration.rst
@@ -252,7 +252,7 @@ needed to configure an assume role profile::
   # In ~/.aws/credentials:
   [development]
   aws_access_key_id=foo
-  aws_access_key_id=bar
+  aws_secret_access_key=bar
 
   # In ~/.aws/config
   [profile crossaccount]


### PR DESCRIPTION
I fixed a small error in the docs.
I think the second parameter should be `aws_secret_access_key`