### PR TITLE
.editorconfig to give IDE an formatting hint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# https://editorconfig.org/
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+charset = utf-8
+
+[*.py]
+max_line_length = 79


### PR DESCRIPTION
Hi,
while working on another feature I saw my IDE not formatting propertly. With the .editorconfig file IDEs with editorconfig support can pickup the format settings.
Kind regards
Conni