### PR TITLE
Convert functional tests to pytest

### DIFF
--- a/tests/functional/docs/__init__.py
+++ b/tests/functional/docs/__init__.py
@@ -16,14 +16,14 @@ from tests import unittest
 class BaseDocsFunctionalTests(unittest.TestCase):
     def assert_contains_lines_in_order(self, lines, contents):
         for line in lines:
-            self.assertIn(line, contents)
+            assert line in contents
             beginning = contents.find(line)
             contents = contents[(beginning + len(line)):]
 
     def get_class_document_block(self, class_name, contents):
         start_class_document = '.. py:class:: %s' % class_name
         start_index = contents.find(start_class_document)
-        self.assertNotEqual(start_index, -1, 'Class is not found in contents')
+        assert start_index != -1, 'Class is not found in contents'
         contents = contents[start_index:]
         end_index = contents.find(
             '  .. py:class::', len(start_class_document))
@@ -32,7 +32,7 @@ class BaseDocsFunctionalTests(unittest.TestCase):
     def get_method_document_block(self, method_name, contents):
         start_method_document = '  .. py:method:: %s(' % method_name
         start_index = contents.find(start_method_document)
-        self.assertNotEqual(start_index, -1, 'Method is not found in contents')
+        assert start_index != -1, 'Method is not found in contents'
         contents = contents[start_index:]
         end_index = contents.find(
             '  .. py:method::', len(start_method_document))
@@ -41,8 +41,7 @@ class BaseDocsFunctionalTests(unittest.TestCase):
     def get_request_syntax_document_block(self, contents):
         start_marker = '**Request Syntax**'
         start_index = contents.find(start_marker)
-        self.assertNotEqual(
-            start_index, -1, 'There is no request syntax section')
+        assert start_index != -1, 'There is no request syntax section'
         contents = contents[start_index:]
         end_index = contents.find(
             ':type', len(start_marker))
@@ -51,8 +50,7 @@ class BaseDocsFunctionalTests(unittest.TestCase):
     def get_response_syntax_document_block(self, contents):
         start_marker = '**Response Syntax**'
         start_index = contents.find(start_marker)
-        self.assertNotEqual(
-            start_index, -1, 'There is no response syntax section')
+        assert start_index != -1, 'There is no response syntax section'
         contents = contents[start_index:]
         end_index = contents.find(
             '**Response Structure**', len(start_marker))
@@ -61,7 +59,7 @@ class BaseDocsFunctionalTests(unittest.TestCase):
     def get_request_parameter_document_block(self, param_name, contents):
         start_param_document = ':type %s:' % param_name
         start_index = contents.find(start_param_document)
-        self.assertNotEqual(start_index, -1, 'Param is not found in contents')
+        assert start_index != -1, 'Param is not found in contents'
         contents = contents[start_index:]
         end_index = contents.find(':type', len(start_param_document))
         return contents[:end_index]
@@ -69,11 +67,11 @@ class BaseDocsFunctionalTests(unittest.TestCase):
     def get_response_parameter_document_block(self, param_name, contents):
         start_param_document = '**Response Structure**'
         start_index = contents.find(start_param_document)
-        self.assertNotEqual(start_index, -1, 'There is no response structure')
+        assert start_index != -1, 'There is no response structure'
 
         start_param_document = '- **%s**' % param_name
         start_index = contents.find(start_param_document)
-        self.assertNotEqual(start_index, -1, 'Param is not found in contents')
+        assert start_index != -1, 'Param is not found in contents'
         contents = contents[start_index:]
         end_index = contents.find('- **', len(start_param_document))
         return contents[:end_index]

--- a/tests/functional/docs/test_smoke.py
+++ b/tests/functional/docs/test_smoke.py
@@ -18,46 +18,68 @@ from botocore.exceptions import DataNotFoundError
 import boto3
 from boto3.docs.service import ServiceDocumenter
 
+boto3_session = None
+botocore_session = None
 
-def test_docs_generated():
+def create_boto3_session():
+    global boto3_session
+    if boto3_session is None:
+        boto3_session = boto3.Session(region_name='us-east-1')
+    return boto3_session
+
+
+def create_botocore_session():
+    global botocore_session
+    if botocore_session is None:
+        botocore_session = botocore.session.get_session()
+    return botocore_session
+
+
+def get_available_services():
+    session = create_boto3_session()
+    return session.get_available_services()
+
+
+@pytest.mark.parametrize(
+    "service_name", get_available_services()
+)
+def test_docs_generated(service_name):
     """Verify we can generate the appropriate docs for all services"""
-    botocore_session = botocore.session.get_session()
-    session = boto3.Session(region_name='us-east-1')
-    for service_name in session.get_available_services():
-        generated_docs = ServiceDocumenter(
-            service_name, session=session).document_service()
-        generated_docs = generated_docs.decode('utf-8')
-        client = boto3.client(service_name, 'us-east-1')
+    botocore_session = create_botocore_session()
+    session = create_boto3_session()
 
-        # Check that all of the services have the appropriate title
-        yield (_assert_has_title, generated_docs, client)
+    generated_docs = ServiceDocumenter(
+        service_name, session=session
+    ).document_service().decode('utf-8')
+    client = boto3.client(service_name, 'us-east-1')
 
-        # Check that all services have the client documented.
-        yield (_assert_has_client_documentation, generated_docs, service_name,
-               client)
+    # Check that all of the services have the appropriate title
+    _assert_has_title(generated_docs, client)
 
-        # If the client can paginate, make sure the paginators are documented.
-        try:
-            paginator_model = botocore_session.get_paginator_model(
-                service_name)
-            yield (_assert_has_paginator_documentation, generated_docs,
-                   service_name, client,
-                   sorted(paginator_model._paginator_config))
-        except DataNotFoundError:
-            pass
+    # Check that all services have the client documented.
+    _assert_has_client_documentation(generated_docs, service_name, client)
 
-        # If the client has waiters, make sure the waiters are documented
-        if client.waiter_names:
-            waiter_model = botocore_session.get_waiter_model(service_name)
-            yield (_assert_has_waiter_documentation, generated_docs,
-                   service_name, client, waiter_model)
+    # If the client can paginate, make sure the paginators are documented.
+    try:
+        paginator_model = botocore_session.get_paginator_model(
+            service_name)
+        _assert_has_paginator_documentation(generated_docs, service_name,
+               client, sorted(paginator_model._paginator_config))
+    except DataNotFoundError:
+        pass
 
-        # If the service has resources, make sure the service resource
-        # is at least documented.
-        if service_name in session.get_available_resources():
-            resource = boto3.resource(service_name, 'us-east-1')
-            yield (_assert_has_resource_documentation, generated_docs,
-                   service_name, resource)
+    # If the client has waiters, make sure the waiters are documented
+    if client.waiter_names:
+        waiter_model = botocore_session.get_waiter_model(service_name)
+        _assert_has_waiter_documentation(generated_docs,
+               service_name, client, waiter_model)
+
+    # If the service has resources, make sure the service resource
+    # is at least documented.
+    if service_name in session.get_available_resources():
+        resource = boto3.resource(service_name, 'us-east-1')
+        _assert_has_resource_documentation(generated_docs,
+               service_name, resource)
 
 
 def _assert_contains_lines_in_order(lines, contents):

--- a/tests/functional/dynamodb/test_stubber_conditions.py
+++ b/tests/functional/dynamodb/test_stubber_conditions.py
@@ -41,7 +41,7 @@ class TestStubberSupportsFilterExpressions(unittest.TestCase):
             response = table.query(KeyConditionExpression=key_expr,
                                    FilterExpression=filter_expr)
 
-        self.assertEqual(list(), response['Items'])
+        assert response['Items'] == []
         stubber.assert_no_pending_responses()
 
     def test_table_scan_can_be_stubbed_with_expressions(self):
@@ -59,5 +59,5 @@ class TestStubberSupportsFilterExpressions(unittest.TestCase):
         with stubber:
             response = table.scan(FilterExpression=filter_expr)
 
-        self.assertEqual(list(), response['Items'])
+        assert response['Items'] == []
         stubber.assert_no_pending_responses()

--- a/tests/functional/dynamodb/test_table.py
+++ b/tests/functional/dynamodb/test_table.py
@@ -25,7 +25,7 @@ class TestTableResourceCustomizations(unittest.TestCase):
 
     def test_resource_has_batch_writer_added(self):
         table = self.resource.Table('mytable')
-        self.assertTrue(hasattr(table, 'batch_writer'))
+        assert hasattr(table, 'batch_writer')
 
     def test_operation_without_output(self):
         table = self.resource.Table('mytable')

--- a/tests/functional/test_collection.py
+++ b/tests/functional/test_collection.py
@@ -25,9 +25,8 @@ class TestCollection(unittest.TestCase):
         self.ec2_resource = self.session.resource('ec2')
 
     def test_can_use_collection_methods(self):
-        self.assertIsInstance(
-            self.ec2_resource.instances.all(), ResourceCollection)
+        assert isinstance(self.ec2_resource.instances.all(), ResourceCollection)
 
     def test_can_chain_methods(self):
-        self.assertIsInstance(
+        assert isinstance(
             self.ec2_resource.instances.all().page_size(5), ResourceCollection)

--- a/tests/functional/test_dynamodb.py
+++ b/tests/functional/test_dynamodb.py
@@ -43,13 +43,12 @@ class TestDynamoDB(unittest.TestCase):
         table.scan(FilterExpression=Attr('mykey').eq('myvalue'))
         request = self.make_request_mock.call_args_list[0][0][1]
         request_params = json.loads(request['body'].decode('utf-8'))
-        self.assertEqual(
-            request_params,
-            {'TableName': 'MyTable',
-             'FilterExpression': '#n0 = :v0',
-             'ExpressionAttributeNames': {'#n0': 'mykey'},
-             'ExpressionAttributeValues': {':v0': {'S': 'myvalue'}}}
-        )
+        assert request_params == {
+            'TableName': 'MyTable',
+            'FilterExpression': '#n0 = :v0',
+            'ExpressionAttributeNames': {'#n0': 'mykey'},
+            'ExpressionAttributeValues': {':v0': {'S': 'myvalue'}}
+        }
 
     def test_client(self):
         dynamodb = self.session.client('dynamodb')
@@ -62,10 +61,9 @@ class TestDynamoDB(unittest.TestCase):
         )
         request = self.make_request_mock.call_args_list[0][0][1]
         request_params = json.loads(request['body'].decode('utf-8'))
-        self.assertEqual(
-            request_params,
-            {'TableName': 'MyTable',
-             'FilterExpression': '#n0 = :v0',
-             'ExpressionAttributeNames': {'#n0': 'mykey'},
-             'ExpressionAttributeValues': {':v0': {'S': 'myvalue'}}}
-        )
+        assert request_params == {
+            'TableName': 'MyTable',
+            'FilterExpression': '#n0 = :v0',
+            'ExpressionAttributeNames': {'#n0': 'mykey'},
+            'ExpressionAttributeValues': {':v0': {'S': 'myvalue'}}
+        }

--- a/tests/functional/test_ec2.py
+++ b/tests/functional/test_ec2.py
@@ -23,8 +23,7 @@ class TestInstanceDeleteTags(unittest.TestCase):
         self.instance_resource = self.service_resource.Instance('i-abc123')
 
     def test_delete_tags_injected(self):
-        self.assertTrue(hasattr(self.instance_resource, 'delete_tags'),
-                        'delete_tags was not injected onto Instance resource.')
+        assert hasattr(self.instance_resource, 'delete_tags')
 
     def test_delete_tags(self):
         stubber = Stubber(self.instance_resource.meta.client)
@@ -32,7 +31,7 @@ class TestInstanceDeleteTags(unittest.TestCase):
         stubber.activate()
         response = self.instance_resource.delete_tags(Tags=[{'Key': 'foo'}])
         stubber.assert_no_pending_responses()
-        self.assertEqual(response, {})
+        assert response == {}
         stubber.deactivate()
 
     def test_mutating_filters(self):

--- a/tests/functional/test_resource.py
+++ b/tests/functional/test_resource.py
@@ -10,6 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pytest
+
 import boto3
 from boto3.exceptions import ResourceNotExistsError
 
@@ -35,8 +37,8 @@ class TestResourceCustomization(unittest.TestCase):
         self.botocore_session.register('creating-resource-class.s3',
                                        self.add_new_method(name='my_method'))
         resource = session.resource('s3')
-        self.assertTrue(hasattr(resource, 'my_method'))
-        self.assertEqual(resource.my_method('anything'), 'anything')
+        assert hasattr(resource, 'my_method')
+        assert resource.my_method('anything') == 'anything'
 
 
 class TestSessionErrorMessages(unittest.TestCase):
@@ -45,11 +47,11 @@ class TestSessionErrorMessages(unittest.TestCase):
         err_regex = (
             '%s.*resource does not exist.' % bad_resource_name
         )
-        with self.assertRaisesRegexp(ResourceNotExistsError, err_regex):
+        with pytest.raises(ResourceNotExistsError, match=err_regex):
             boto3.resource(bad_resource_name)
 
 
 class TestGetAvailableSubresources(unittest.TestCase):
     def test_s3_available_subresources_exists(self):
         s3 = boto3.resource('s3')
-        self.assertTrue(hasattr(s3, 'get_available_subresources'))
+        assert hasattr(s3, 'get_available_subresources')

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -10,6 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pytest
+
 from tests import unittest
 
 import botocore
@@ -26,36 +28,26 @@ class TestS3MethodInjection(unittest.TestCase):
     def test_transfer_methods_injected_to_client(self):
         session = boto3.session.Session(region_name='us-west-2')
         client = session.client('s3')
-        self.assertTrue(hasattr(client, 'upload_file'),
-                        'upload_file was not injected onto S3 client')
-        self.assertTrue(hasattr(client, 'download_file'),
-                        'download_file was not injected onto S3 client')
-        self.assertTrue(hasattr(client, 'copy'),
-                        'copy was not injected onto S3 client')
+        assert hasattr(client, 'upload_file')
+        assert hasattr(client, 'download_file')
+        assert hasattr(client, 'copy')
 
     def test_bucket_resource_has_load_method(self):
         session = boto3.session.Session(region_name='us-west-2')
         bucket = session.resource('s3').Bucket('fakebucket')
-        self.assertTrue(hasattr(bucket, 'load'),
-                        'load() was not injected onto S3 Bucket resource.')
+        assert hasattr(bucket, 'load')
 
     def test_transfer_methods_injected_to_bucket(self):
         bucket = boto3.resource('s3').Bucket('my_bucket')
-        self.assertTrue(hasattr(bucket, 'upload_file'),
-                        'upload_file was not injected onto S3 bucket')
-        self.assertTrue(hasattr(bucket, 'download_file'),
-                        'download_file was not injected onto S3 bucket')
-        self.assertTrue(hasattr(bucket, 'copy'),
-                        'copy was not injected onto S3 bucket')
+        assert hasattr(bucket, 'upload_file')
+        assert hasattr(bucket, 'download_file')
+        assert hasattr(bucket, 'copy')
 
     def test_transfer_methods_injected_to_object(self):
         obj = boto3.resource('s3').Object('my_bucket', 'my_key')
-        self.assertTrue(hasattr(obj, 'upload_file'),
-                        'upload_file was not injected onto S3 object')
-        self.assertTrue(hasattr(obj, 'download_file'),
-                        'download_file was not injected onto S3 object')
-        self.assertTrue(hasattr(obj, 'copy'),
-                        'copy was not injected onto S3 object')
+        assert hasattr(obj, 'upload_file')
+        assert hasattr(obj, 'download_file')
+        assert hasattr(obj, 'copy')
 
 
 class BaseTransferTest(unittest.TestCase):
@@ -208,7 +200,7 @@ class TestCopy(BaseTransferTest):
             response = self.s3.meta.client.copy(
                 self.copy_source, self.bucket, self.key)
         # The response will be none on a successful transfer.
-        self.assertIsNone(response)
+        assert response is None
 
     def test_bucket_copy(self):
         self.stub_single_part_copy()
@@ -216,14 +208,14 @@ class TestCopy(BaseTransferTest):
         with self.stubber:
             response = bucket.copy(self.copy_source, self.key)
         # The response will be none on a successful transfer.
-        self.assertIsNone(response)
+        assert response is None
 
     def test_object_copy(self):
         self.stub_single_part_copy()
         obj = self.s3.Object(self.bucket, self.key)
         with self.stubber:
             response = obj.copy(self.copy_source)
-        self.assertIsNone(response)
+        assert response is None
 
     def test_copy_progress(self):
         chunksize = 8 * (1024 ** 2)
@@ -243,8 +235,8 @@ class TestCopy(BaseTransferTest):
 
         # Assert that the progress callback was called the correct number of
         # times with the correct amounts.
-        self.assertEqual(self.progress_times_called, 3)
-        self.assertEqual(self.progress, chunksize * 3)
+        assert self.progress_times_called == 3
+        assert self.progress == chunksize * 3
 
 
 class TestUploadFileobj(BaseTransferTest):
@@ -310,7 +302,7 @@ class TestUploadFileobj(BaseTransferTest):
 
     def test_raises_value_error_on_invalid_fileobj(self):
         with self.stubber:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 self.s3.meta.client.upload_fileobj(
                     Fileobj='foo', Bucket=self.bucket, Key=self.key)
 
@@ -427,12 +419,12 @@ class TestDownloadFileobj(BaseTransferTest):
             self.s3.meta.client.download_fileobj(
                 Bucket=self.bucket, Key=self.key, Fileobj=self.fileobj)
 
-        self.assertEqual(self.fileobj.getvalue(), self.contents)
+        assert self.fileobj.getvalue() == self.contents
         self.stubber.assert_no_pending_responses()
 
     def test_raises_value_error_on_invalid_fileobj(self):
         with self.stubber:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 self.s3.meta.client.download_fileobj(
                     Bucket=self.bucket, Key=self.key, Fileobj='foo')
 
@@ -442,7 +434,7 @@ class TestDownloadFileobj(BaseTransferTest):
         with self.stubber:
             bucket.download_fileobj(Key=self.key, Fileobj=self.fileobj)
 
-        self.assertEqual(self.fileobj.getvalue(), self.contents)
+        assert self.fileobj.getvalue() == self.contents
         self.stubber.assert_no_pending_responses()
 
     def test_object_download(self):
@@ -451,7 +443,7 @@ class TestDownloadFileobj(BaseTransferTest):
         with self.stubber:
             obj.download_fileobj(Fileobj=self.fileobj)
 
-        self.assertEqual(self.fileobj.getvalue(), self.contents)
+        assert self.fileobj.getvalue() == self.contents
         self.stubber.assert_no_pending_responses()
 
     def test_multipart_download(self):
@@ -467,7 +459,7 @@ class TestDownloadFileobj(BaseTransferTest):
                 Bucket=self.bucket, Key=self.key, Fileobj=self.fileobj,
                 Config=transfer_config)
 
-        self.assertEqual(self.fileobj.getvalue(), self.contents)
+        assert self.fileobj.getvalue() == self.contents
         self.stubber.assert_no_pending_responses()
 
     def test_download_progress(self):
@@ -489,8 +481,8 @@ class TestDownloadFileobj(BaseTransferTest):
 
         # Assert that the progress callback was called the correct number of
         # times with the correct amounts.
-        self.assertEqual(self.progress_times_called, 11)
-        self.assertEqual(self.progress, 55)
+        assert self.progress_times_called == 11
+        assert self.progress == 55
         self.stubber.assert_no_pending_responses()
 
 
@@ -520,19 +512,19 @@ class TestS3ObjectSummary(unittest.TestCase):
         self.stubber.deactivate()
 
     def test_has_load(self):
-        self.assertTrue(hasattr(self.obj_summary, 'load'),
-                        'load() was not injected onto ObjectSummary resource.')
+        # Validate load was injected onto ObjectSummary.
+        assert hasattr(self.obj_summary, 'load')
 
     def test_autoloads_correctly(self):
         # In HeadObject the parameter returned is ContentLength, this
         # should get mapped to Size of ListObject since the resource uses
         # the shape returned to by ListObjects.
-        self.assertEqual(self.obj_summary.size, self.obj_summary_size)
+        assert self.obj_summary.size == self.obj_summary_size
 
     def test_cannot_access_other_non_related_parameters(self):
         # Even though an HeadObject was used to load this, it should
         # only expose the attributes from its shape defined in ListObjects.
-        self.assertFalse(hasattr(self.obj_summary, 'content_length'))
+        assert not hasattr(self.obj_summary, 'content_length')
 
 
 class TestServiceResource(unittest.TestCase):
@@ -542,7 +534,5 @@ class TestServiceResource(unittest.TestCase):
     def test_unsigned_signature_version_is_not_corrupted(self):
         config = Config(signature_version=botocore.UNSIGNED)
         resource = self.session.resource('s3', config=config)
-        self.assertIs(
-            resource.meta.client.meta.config.signature_version,
-            botocore.UNSIGNED
-        )
+        sig_version = resource.meta.client.meta.config.signature_version
+        assert sig_version is botocore.UNSIGNED

--- a/tests/functional/test_session.py
+++ b/tests/functional/test_session.py
@@ -31,18 +31,18 @@ class TestSession(unittest.TestCase):
         # Emit the event.
         self.session.events.emit('myevent', my_list=initial_list)
         # Ensure that the registered handler was called.
-        self.assertEqual(initial_list, ['my_handler called'])
+        assert initial_list == ['my_handler called']
 
     def test_can_access_region_property(self):
         session = boto3.session.Session(region_name='us-west-1')
-        self.assertEqual(session.region_name, 'us-west-1')
+        assert session.region_name == 'us-west-1'
 
     def test_get_available_partitions(self):
         partitions = self.session.get_available_partitions()
-        self.assertIsInstance(partitions, list)
-        self.assertTrue(partitions)
+        assert isinstance(partitions, list)
+        assert partitions
 
     def test_get_available_regions(self):
         regions = self.session.get_available_regions('s3')
-        self.assertIsInstance(regions, list)
-        self.assertTrue(regions)
+        assert isinstance(regions, list)
+        assert regions

--- a/tests/functional/test_smoke.py
+++ b/tests/functional/test_smoke.py
@@ -15,51 +15,60 @@ import pytest
 from boto3.session import Session
 import botocore.session
 
+boto3_session = None
 
 def create_session():
-    session = Session(aws_access_key_id='dummy',
-                      aws_secret_access_key='dummy',
-                      region_name='us-east-1')
-    return session
+    global boto3_session
+    if boto3_session is None:
+        boto3_session = Session(
+            aws_access_key_id='dummy',
+            aws_secret_access_key='dummy',
+            region_name='us-east-1'
+        )
+
+    return boto3_session
 
 
-def test_can_create_all_resources():
+def available_resources():
+    session = create_session()
+    return session.get_available_resources()
+
+
+def available_services():
+    session = create_session()
+    return session.get_available_services()
+
+
+@pytest.mark.parametrize(
+    "resource_name", available_resources()
+)
+def test_create_resource(resource_name):
     """Verify we can create all existing resources."""
     session = create_session()
-    for service_name in session.get_available_resources():
-        yield _test_create_resource, session, service_name
-
-
-def _test_create_resource(session, service_name):
-    resource = session.resource(service_name)
+    resource = session.resource(resource_name)
     # Verifying we have a "meta" attr is just an arbitrary
     # sanity check.
     assert hasattr(resource, 'meta')
 
 
-def test_can_create_all_clients():
+@pytest.mark.parametrize(
+    "service_name", available_services()
+)
+def test_create_client(service_name):
     session = create_session()
-    for service_name in session.get_available_services():
-        yield _test_create_client, session, service_name
-
-
-def _test_create_client(session, service_name):
     client = session.client(service_name)
     assert hasattr(client, 'meta')
 
 
-def test_api_versions_synced_with_botocore():
+@pytest.mark.parametrize(
+    "resource_name", available_resources()
+)
+def test_api_versions_synced_with_botocore(resource_name):
     botocore_session = botocore.session.get_session()
     boto3_session = create_session()
-    for service_name in boto3_session.get_available_resources():
-        yield (_assert_same_api_versions, service_name,
-               botocore_session, boto3_session)
-
-
-def _assert_same_api_versions(service_name, botocore_session, boto3_session):
-    resource = boto3_session.resource(service_name)
+    resource = boto3_session.resource(resource_name)
     boto3_api_version = resource.meta.client.meta.service_model.api_version
-    client = botocore_session.create_client(service_name,
+    client = botocore_session.create_client(resource_name,
                                             region_name='us-east-1',
                                             aws_access_key_id='foo',
                                             aws_secret_access_key='bar')
@@ -67,6 +76,6 @@ def _assert_same_api_versions(service_name, botocore_session, boto3_session):
     if botocore_api_version != boto3_api_version:
         raise AssertionError(
             "Different latest API versions found for %s: "
-            "%s (botocore), %s (boto3)\n" % (service_name,
+            "%s (botocore), %s (boto3)\n" % (resource_name,
                                              botocore_api_version,
                                              boto3_api_version))

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -10,10 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pytest
+
 from tests import unittest
 
 import botocore.session
-
 
 from boto3 import utils
 import boto3.session
@@ -30,7 +31,7 @@ class TestUtils(unittest.TestCase):
 
         botocore_session.register('creating-client-class', shadows_put_object)
 
-        with self.assertRaises(RuntimeError):
+        with pytest.raises(RuntimeError):
             # This should raise an exception because we're trying to
             # shadow the put_object client method in the
             # shadows_put_object handler above.


### PR DESCRIPTION
This is the second of three PRs to move our testing infrastructure for Boto3 over to pytest. We're removing the majority of the unittest assertions for base python assert statements to keep consistency with our other usage and general pytest convention. These tests will likely benefit from adopting `pytest-xdist` to start spreading tests across CPU cores, we may want to do this before merging this into develop.

#### nose run pre-migration
```
python -m nose tests/functional 
....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 1044 tests in 341.230s
```

#### pytest run post-migration
```
$ pytest tests/functional
=========================================================================================== test session starts ============================================================================================
platform darwin -- Python 2.7.13, pytest-4.6.11, py-1.9.0, pluggy-0.13.1
rootdir: /Users/nateprewitt/Work/OpenSource/boto3
plugins: xdist-1.34.0, forked-1.3.0
collected 533 items                                                                                                                                                                                        

tests/functional/test_collection.py ..                                                                                                                                                               [  0%]
tests/functional/test_dynamodb.py ..                                                                                                                                                                 [  0%]
tests/functional/test_ec2.py ...                                                                                                                                                                     [  1%]
tests/functional/test_resource.py ...                                                                                                                                                                [  1%]
tests/functional/test_s3.py .......................                                                                                                                                                  [  6%]
tests/functional/test_session.py ....                                                                                                                                                                [  6%]
tests/functional/test_smoke.py ..................................................................................................................................................................... [ 37%]
........................................................................................                                                                                                             [ 54%]
tests/functional/test_utils.py .                                                                                                                                                                     [ 54%]
tests/functional/docs/test_dynamodb.py ...                                                                                                                                                           [ 55%]
tests/functional/docs/test_ec2.py .                                                                                                                                                                  [ 55%]
tests/functional/docs/test_s3.py .                                                                                                                                                                   [ 55%]
tests/functional/docs/test_smoke.py ................................................................................................................................................................ [ 85%]
.........................................................................                                                                                                                            [ 99%]
tests/functional/dynamodb/test_stubber_conditions.py ..                                                                                                                                              [ 99%]
tests/functional/dynamodb/test_table.py ..                                                                                                                                                           [100%]

======================================================================================= 533 passed in 331.02 seconds =======================================================================================
```

Tests are lower for pytest because tests/functional/docs/test_smoke.py was doing conditional branching on some tests. We're now running all of those branches as a single test.

### Difference in test count:
511 tests exist in nose run that aren't in pytest. This is due to 4 potential tests being collapsed to 1, reducing tests run by ~70%.

#### tests/functional/docs
```
python -m nose tests/functional/docs 
.............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 749 tests in 309.159s
```
```
pytest -n auto tests/functional/docs
=========================================================================================== test session starts ============================================================================================
platform darwin -- Python 2.7.13, pytest-4.6.11, py-1.9.0, pluggy-0.13.1
rootdir: /Users/nateprewitt/Work/OpenSource/boto3
plugins: xdist-1.34.0, forked-1.3.0
gw0 [238] / gw1 [238] / gw2 [238] / gw3 [238]
.................................................................................................................................................................................................... [ 82%]
..........................................                                                                                                                                                           [100%]
======================================================================================= 238 passed in 126.26 seconds =======================================================================================
```

