### PR TITLE
Add Python 3.4/3.5 deprecation warning

### DIFF
--- a/boto3/__init__.py
+++ b/boto3/__init__.py
@@ -14,6 +14,7 @@
 import logging
 
 from boto3.session import Session
+from boto3.compat import _warn_deprecated_python
 
 
 __author__ = 'Amazon Web Services'
@@ -78,6 +79,7 @@ def _get_default_session():
     """
     if DEFAULT_SESSION is None:
         setup_default_session()
+    _warn_deprecated_python()
 
     return DEFAULT_SESSION
 

--- a/boto3/compat.py
+++ b/boto3/compat.py
@@ -14,8 +14,10 @@ import sys
 import os
 import errno
 import socket
+import warnings
 
 from botocore.vendored import six
+from boto3.exceptions import PythonDeprecationWarning
 
 if six.PY3:
     # In python3, socket.error is OSError, which is too general
@@ -46,3 +48,32 @@ if sys.platform.startswith('win'):
         os.rename(current_filename, new_filename)
 else:
     rename_file = os.rename
+
+
+def filter_python_deprecation_warnings():
+    """
+    Invoking this filter acknowledges your runtime will soon be deprecated
+    at which time you will stop receiving all updates to your client.
+    """
+    warnings.filterwarnings(
+        'ignore',
+        message=".*Boto3 will no longer support Python.*",
+        category=PythonDeprecationWarning,
+        module=r".*boto3\.compat"
+    )
+
+
+def _warn_deprecated_python():
+    deprecated_versions = ((3,4), (3,5))
+    py_version = sys.version_info[:2]
+
+    if py_version in deprecated_versions:
+        warning = (
+            "Boto3 will no longer support Python {}.{} "
+            "starting February 1, 2021. To continue receiving service updates, "
+            "bug fixes, and security updates please upgrade to Python 3.6 or "
+            "later. More information can be found here: https://aws.amazon.com"
+            "/blogs/developer/announcing-the-end-of-support-for-python-3-4-and"
+            "-3-5-in-the-aws-sdk-for-python-and-aws-cli-v1/"
+        ).format(py_version[0], py_version[1])
+        warnings.warn(warning, PythonDeprecationWarning)

--- a/boto3/exceptions.py
+++ b/boto3/exceptions.py
@@ -107,3 +107,11 @@ class DynamoDBNeedsConditionError(Boto3Error):
 
 class DynamoDBNeedsKeyConditionError(Boto3Error):
     pass
+
+
+class PythonDeprecationWarning(Warning):
+    """
+    Python version being used is scheduled to become unsupported
+    in an future release. See warning for specifics.
+    """
+    pass


### PR DESCRIPTION
### Deprecation of Python 3.4 and 3.5 for Boto3

As announced in today's blog post, Boto3 will be deprecating support for Python 3.4 and 3.5 on 02/01/2021. Users are encouraged to migrate to Python 3.6 or later. This PR will add a new warning to boto3 to alert users when a `client`, `resource`, or `session` is created. This alert should only be printed once per Python invocation, so creating multiple clients won't result in repeated warnings.

In the event you'd like to disable this warning entirely, we've provided a quick method to disable the warnings. You can add the code below to the top of your python file.
```python
from boto3.compat import filter_python_deprecation_warnings

filter_python_deprecation_warnings()
```
Adding this to your code base acknowledges the upcoming deprecation and that you'll stop receiving updates for boto3 on the deprecation date.

Full details can be found at: https://aws.amazon.com/blogs/developer/announcing-the-end-of-support-for-python-3-4-and-3-5-in-the-aws-sdk-for-python-and-aws-cli-v1/