### PR TITLE
Change object name to use only filename on s3 file upload example.

### DIFF
--- a/docs/source/guide/s3-uploading-files.rst
+++ b/docs/source/guide/s3-uploading-files.rst
@@ -25,6 +25,7 @@ and uploading each chunk in parallel.
     import logging
     import boto3
     from botocore.exceptions import ClientError
+    import os
 
 
     def upload_file(file_name, bucket, object_name=None):
@@ -38,7 +39,7 @@ and uploading each chunk in parallel.
 
         # If S3 object_name was not specified, use file_name
         if object_name is None:
-            object_name = file_name
+            object_name = os.path.basename(file_name)
 
         # Upload the file
         s3_client = boto3.client('s3')


### PR DESCRIPTION
On the boto3's [file upload example](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-uploading-files.html) if the object_name is missing it uses the file_name.
This can lead to confusion, where a seemingly successful upload [appears to be missing](https://forums.aws.amazon.com/thread.jspa?messageID=933107). 
This PR fixes it by forcing only the filename to be used as object_name