### PR TITLE
Adding support for float in DynamoDB type serilizer

### DIFF
--- a/docs/source/reference/customizations/dynamodb.rst
+++ b/docs/source/reference/customizations/dynamodb.rst
@@ -18,6 +18,8 @@ These are the valid item types to use with Boto3 Table Resource (:py:class:`dyna
 +----------------------------------------------+-----------------------------+
 | integer                                      | Number (N)                  |
 +----------------------------------------------+-----------------------------+
+| float *(see note below)*                     | Number (N)                  |
++----------------------------------------------+-----------------------------+
 | :py:class:`decimal.Decimal`                  | Number (N)                  |
 +----------------------------------------------+-----------------------------+
 | :py:class:`boto3.dynamodb.types.Binary`      | Binary (B)                  |
@@ -30,6 +32,8 @@ These are the valid item types to use with Boto3 Table Resource (:py:class:`dyna
 +----------------------------------------------+-----------------------------+
 | integer set                                  | Number Set (NS)             |
 +----------------------------------------------+-----------------------------+
+| float set *(see note below)*                 | Number Set (NS)             |
++----------------------------------------------+-----------------------------+
 | :py:class:`decimal.Decimal` set              | Number Set (NS)             |
 +----------------------------------------------+-----------------------------+
 | :py:class:`boto3.dynamodb.types.Binary` set  | Binary Set (BS)             |
@@ -38,6 +42,15 @@ These are the valid item types to use with Boto3 Table Resource (:py:class:`dyna
 +----------------------------------------------+-----------------------------+
 | dict                                         | Map (M)                     |
 +----------------------------------------------+-----------------------------+
+
+  **Note:**  In Python, the 'float' data type provides an approximation 
+  of the computer hardware representation of binary fractions.  
+  This issue is explained in the Python documentation section titled `Floating Point Arithmetic`_.
+  Because of this, float values are converted to Decimal using create_decimal_from_float_ 
+  and may be an inexact and/or rounded representation of the true value.
+  
+.. _Floating Point Arithmetic: https://docs.python.org/3/tutorial/floatingpoint.html
+.. _create_decimal_from_float: https://docs.python.org/3/library/decimal.html#decimal.Context.create_decimal_from_float
 
 
 Custom Boto3 types

--- a/docs/source/reference/customizations/dynamodb.rst
+++ b/docs/source/reference/customizations/dynamodb.rst
@@ -47,7 +47,8 @@ These are the valid item types to use with Boto3 Table Resource (:py:class:`dyna
   of the computer hardware representation of binary fractions.  
   This issue is explained in the Python documentation section titled `Floating Point Arithmetic`_.
   Because of this, float values are converted to Decimal using create_decimal_from_float_ 
-  and may be an inexact and/or rounded representation of the true value.
+  and may be an inexact rounded representation of the value.
+  Sterilization of float uses decimal precision set to 38 places.
   
 .. _Floating Point Arithmetic: https://docs.python.org/3/tutorial/floatingpoint.html
 .. _create_decimal_from_float: https://docs.python.org/3/library/decimal.html#decimal.Context.create_decimal_from_float

--- a/tests/unit/dynamodb/test_types.py
+++ b/tests/unit/dynamodb/test_types.py
@@ -73,12 +73,10 @@ class TestSerializer(unittest.TestCase):
     def test_serialize_decimal(self):
         self.assertEqual(
             self.serializer.serialize(Decimal('1.25')), {'N': '1.25'})
-
-    def test_serialize_float_error(self):
-        with self.assertRaisesRegexp(
-                TypeError,
-                'Float types are not supported. Use Decimal types instead'):
-            self.serializer.serialize(1.25)
+    
+    def test_serialize_float(self):
+        self.assertEqual(
+            self.serializer.serialize(1.25), {'N': '1.25'})
 
     def test_serialize_NaN_error(self):
         with self.assertRaisesRegexp(

--- a/tests/unit/dynamodb/test_types.py
+++ b/tests/unit/dynamodb/test_types.py
@@ -10,12 +10,12 @@
 # distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from decimal import Decimal
+from decimal import Decimal, Inexact, Rounded, localcontext
 from tests import unittest
 
 from botocore.compat import six
 
-from boto3.dynamodb.types import Binary, TypeSerializer, TypeDeserializer
+from boto3.dynamodb.types import Binary, TypeSerializer, TypeDeserializer, DYNAMODB_CONTEXT
 
 
 class TestBinary(unittest.TestCase):
@@ -75,8 +75,10 @@ class TestSerializer(unittest.TestCase):
             self.serializer.serialize(Decimal('1.25')), {'N': '1.25'})
     
     def test_serialize_float(self):
-        self.assertEqual(
-            self.serializer.serialize(1.25), {'N': '1.25'})
+        for val in [0.999999999999, 0.1, 0.25, 
+                    1.23456789012345678901234567890123456789012]: # 42 places
+            self.assertEqual(
+                self.serializer.serialize(val), {'N': format(val, '.38g')} )
 
     def test_serialize_NaN_error(self):
         with self.assertRaisesRegexp(

--- a/tests/unit/dynamodb/test_types.py
+++ b/tests/unit/dynamodb/test_types.py
@@ -10,12 +10,12 @@
 # distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from decimal import Decimal, Inexact, Rounded, localcontext
+from decimal import Decimal
 from tests import unittest
 
 from botocore.compat import six
 
-from boto3.dynamodb.types import Binary, TypeSerializer, TypeDeserializer, DYNAMODB_CONTEXT
+from boto3.dynamodb.types import Binary, TypeSerializer, TypeDeserializer
 
 
 class TestBinary(unittest.TestCase):


### PR DESCRIPTION
The existing implementation of type serialization seems to deliberately not support Python float data type, resulting in errors.  Often, data returned from other API's, including AWS API's, will be dropped into a DynamoDB table as an item.  Python's float is a standard data type and is commonly returned from other sources.

As discussed in #665, while some other workarounds exist, the optimal solution is to properly handle float data types.  Using float within Python is known to be non-precise, so inexact rounding in this process should not be an issue.  Just in case, I've also updated the documentation to make it clear that float data types may not be precisely represented.

Please let me know if I should add additional details or modifications to meet the standards for boto3.