### PR TITLE
Correct code example in migration3.rst file.

### DIFF
--- a/docs/source/guide/migrations3.rst
+++ b/docs/source/guide/migrations3.rst
@@ -121,7 +121,7 @@ Boto3 lacks the grant shortcut methods present in Boto 2.x, but it is still fair
     bucket.add_email_grant('READ', 'user@domain.tld')
 
     # Boto3
-    bucket.Acl.put(GrantRead='emailAddress=user@domain.tld')
+    bucket.Acl().put(GrantRead='emailAddress="user@domain.tld"')
 
 Key metadata
 ------------


### PR DESCRIPTION
Code provided in documentation was incorrect. 
1. Acl method must be invoked
2. Missing quotes are causing regex to fail when parsing headers.