### PR TITLE
Python2.7 deprecation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,7 +51,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Boto3 Docs'
-copyright = '2020, Amazon Web Services, Inc'
+copyright = '2021, Amazon Web Services, Inc'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -10,9 +10,9 @@
 
 .. _user_guides:
 
-+++++++++++
++++++++++++++++
 Developer guide
-+++++++++++
++++++++++++++++
 
 
 SDK features
@@ -51,4 +51,5 @@ Migrations
 
    new
    migration
+   migrationpy3
    upgrading

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -1,4 +1,4 @@
-.. Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+.. Copyright 2010-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
    This work is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0
    International License (the "License"). You may not use this file except in compliance with the

--- a/docs/source/guide/migration.rst
+++ b/docs/source/guide/migration.rst
@@ -40,7 +40,7 @@ Second, while every service now uses the runtime-generated low-level client, som
     boto3_bucket = s3.Bucket('mybucket')
 
 Installation and configuration
-----------------------------
+------------------------------
 The :ref:`guide_quickstart` guide provides instructions for installing Boto3. You can also follow the instructions there to set up new credential files, or you can continue to use your existing Boto 2.x credentials. Please note that Boto3, the AWS CLI, and several other SDKs all use the shared credentials file (usually at ``~/.aws/credentials``).
 
 Once configured, you may begin using Boto3::

--- a/docs/source/guide/migrationpy3.rst
+++ b/docs/source/guide/migrationpy3.rst
@@ -11,11 +11,11 @@ Going forward, all projects using the AWS SDK for Python need to transition to u
 ==================     ===================
 Python version         Deprecation date
 ==================     ===================
-Python 2.7             July 14, 2021
+Python 2.7             July 15, 2021
 Python 3.4 and 3.5     February 1, 2021
 ==================     ===================
 
-As shown in the table, Python 2.7 projects must transition to Python 3.6 by July 14, 2021, while Python 3.4 and 3.5 projects need to be updated to Python 3.6 by February 1, 2021.
+As shown in the table, Python 2.7 projects must transition to Python 3.6 by July 15, 2021, while Python 3.4 and 3.5 projects need to be updated to Python 3.6 by February 1, 2021.
 
 Updating your project to use Python 3
 -------------------------------------

--- a/docs/source/guide/migrationpy3.rst
+++ b/docs/source/guide/migrationpy3.rst
@@ -33,7 +33,7 @@ Once you're sure you have Python 3 installed, you can proceed to upgrade boto3 a
 
     $ python3 -m pip install boto3
 
-3. You can optionally verify that the freshly installed copy of the :command:`aws` tool is using the correct version of Python. One way to do that is to run a snippet of code that uses boto3 and outputs the Python and boto3 versions, such as the following::
+3. You can optionally verify that the freshly installed copy of Boto3 is using the correct version of Python. One way to do that is to run a snippet of code that uses boto3 and outputs the Python and boto3 versions, such as the following::
 
     $ python3 -c "import boto3, sys; print(f'{sys.version} \nboto3: {boto3.__version__}')"
     3.8.6 (default, Jan  7 2021, 17:11:21)

--- a/docs/source/guide/migrationpy3.rst
+++ b/docs/source/guide/migrationpy3.rst
@@ -48,7 +48,7 @@ Under these circumstances, you should be prepared for the deprecation date in or
 
 pip-based installations
 ~~~~~~~~~~~~~~~~~~~~~~~
-If you installed boto3 using pip 10.0 or later, you'll automatically stop receiving boto3 updates after the last Python 2 compatible version of boto3 is installed. If you're using an older version of pip, you need to pin your boto3 install to no later than version 1.17.
+If you installed boto3 using :command:`pip` 10.0 or later, you'll automatically stop receiving boto3 updates after the last Python 2 compatible version of boto3 is installed. If you're using an older version of :command:`pip`, you need to pin your boto3 install to no later than version 1.17.
 
 Other installation methods
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/guide/migrationpy3.rst
+++ b/docs/source/guide/migrationpy3.rst
@@ -90,10 +90,12 @@ If you're still using the AWS CLI v1 as installed using the Windows MSI Installe
 You can download these installers using the links below.
 
 **For Python 3**
+
 * `Windows MSI Installer for Python 3 (32 bit) <https://s3.amazonaws.com/aws-cli/AWSCLI32PY3.msi>`_
 * `Windows MSI Installer for Python 3 (64 bit) <https://s3.amazonaws.com/aws-cli/AWSCLI64PY3.msi>`_
 
 **For Python 2**
+
 * `Windows MSI Installer for Python 2 (32 bit) <https://s3.amazonaws.com/aws-cli/AWSCLI32.msi>`_
 * `Windows MSI Installer for Python 2 (64 bit) <https://s3.amazonaws.com/aws-cli/AWSCLI64.msi>`_
 

--- a/docs/source/guide/migrationpy3.rst
+++ b/docs/source/guide/migrationpy3.rst
@@ -1,0 +1,101 @@
+.. _guide_migration_py3:
+
+Migrating from Python 2.7 to Python 3
+=====================================
+Python 2.7 was deprecated back on January 1, 2020 following a multi-year process of phasing it out. Because of this, AWS has deprecated support for Python 2.7, and support for Python 2.7 will be removed from all SDKs before the end of 2021. This includes the AWS SDK for Python and the AWS Command Line Interface (CLI).
+
+This transition also requires transitioning from Boto 2.x to Boto3. See :ref:`Install or upgrade Python <quickstart_install_python>` for details.
+
+.. note::
+
+    Since the AWS CLI v2 bundles its own copy of Python, this transition only impacts users of the version 1 CLI.
+
+Timeline
+--------
+Going forward, all projects using the AWS SDK for Python need to transition to using Python 3, with Python 3.6 becoming the minimum by the end of the transition. The deprecation dates the affected versions of Python are:
+
+============== ===================
+Python version Date of deprecation
+============== ===================
+Python 2.7     June 1, 2021
+Python 3.4     February 1, 2021
+Python 3.5     February 1, 2021
+============== ===================
+
+As shown in the table, you must transition to Python 3.6 by June 1, 2021, while Python 3.4 and 3.5 projects need to be updated to Python 3.7 by February 1, 2021.
+
+Impact on the AWS CLI
+---------------------
+The AWS Command Line Interface is built using the Python SDK, so it's affected by this transition. AWS CLI v2 isn't affected by this transition, since it bundles its own copy of Python 3. However, if you still use the AWS CLI v1, you need to decide whether to :ref:`upgrade to Python 3 <quickstart_install_python>` or to `transition to the version 2 CLI <https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html>`_.
+
+Updating your project to use Python 3
+-------------------------------------
+If your project is currently based on Python 2, you need to begin by ensuring that you're using the latest version of the CLI. If you need to continue to use the version 1 CLI, you may do so, as long as you `update to the newest version of the v1 CLI <https://docs.aws.amazon.com/cli/latest/userguide/install-cliv1.html>`_.
+
+.. note::
+
+    Before you get started make, sure you’ve updated Python as described in  from the `PSF <https://www.python.org/downloads>`_ or your local package manager.
+
+Update the CLI
+~~~~~~~~~~~~~~
+First, upgrade to the latest version of the AWS CLI v1.
+
+1. To begin, uninstall your existing copy of the AWS CLI using the following command::
+
+    $ python -m pip uninstall awscli
+
+2. Next, use Python 3 to reinstall the AWS CLI. Here, we're using the :command:`python3` command to ensure that Python 3 is used rather than Python 2::
+
+    $ python3 -m pip install awscli
+
+3. If you wish, you may verify that the newly installed copy of the AWS CLI tool, :command:`aws`, is using the correct version of Python. The :command:`aws --version` command reports the :command:`aws` tool's version number, followed by the version of Python it's running under, then the operating system version and the computer's processor family. As long as the Python version is at least 3.6, you're ready to go::
+
+    $ aws --version
+    aws-cli/2.0.61 *Python/3.7.4* Darwin/19.6.0 exe/x86_64
+
+Update Boto3 and Botocore
+~~~~~~~~~~~~~~~~~~~~~~~~~
+Now that you're sure you have Python 3 installed and you've updated the CLI (if needed), you can proceed to upgrade Boto3 and Botocore. You can do this globally, or within your virtual environment if you use one for your project.
+
+1. Begin by uninstalling the currently installed copies of Boto3 and Botocore::
+
+    $ python -m pip uninstall boto3 botocore
+
+2. Then install the new version of Boto3. This will also install Botocore, which it requires::
+
+    $ python3 -m pip install boto3
+
+3. You can optionally verify that the freshly installed copy of the :command:`aws` tool is using the correct version of Python. One way to do that is to run a snippet of code that uses Boto3 and outputs the Python and Boto3 versions, such as the following::
+
+    $ python3 -c "import boto3, sys; print(f'{sys.version} \nBoto3: {boto3.__version__}')"
+    3.8.6 (default, Jan  7 2021, 17:11:21)
+    [GCC 7.3.1 20180712 (Red Hat 7.3.1-11)]
+    Boto3: 1.16.15
+
+If you're unable to upgrade to Python 3
+---------------------------------------
+It may be possible that you're unable to upgrade to Python 3. If you have a large project that's heavily dependent on syntax or features that no longer work as desired in Python 3, for example, you may need to keep using Python 2.7. It's also possible that you need to postpone the Python transition while you finish updates to your code.
+
+Under these circumstances, you should be prepared for the deprecation date, in order to not be inconvenienced when the time arrives. If you've kept all software up-to-date, you shouldn't need to do anything. If you're using the a version of the AWS CLI v1 and/or Boto3 that requires Python 2, the version you have will keep working as long as you're on Python 2.
+
+.. note::
+
+    Keep in mind that Python 2.7-based versions of Boto3 and the AWS CLI v1 will not receive support for new AWS capabilities after the scheduled deprecation dates. Its also worth noting that by 2023, all operating systems on which Python can be installed will have ended support for Python 2.7. This means you'll probably have to complete the Python 3 transition eventually.
+
+Upgrade a pip-based install
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This is particularly true if you installed the AWS CLI and/or Boto3 using `pip`, since `pip` 10.0 and later will automatically prevent you from installing upgrades to the CLI or Boto3 that wouldn't be compatible with the version of Python you're using.
+
+Since the bundled installer only performs global installs, any virtual environment based projects will likely be using the CLI installed using `pip`.
+
+Upgrade with the AWS CLI bundled installer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If you used the AWS CLI bundled installer when you previously installed the AWS CLI v1, and the installed copy of the CLI package doesn't support the Python 2.7 runtime, you need to upgrade to a version that does. You can do this by downloading the installer using the URL `https://s3.amazonaws.com/aws-cli/awscli-bundle-{VERSION}.zip`, where "{VERSION}" is the AWS CLI version you wish to install. For example, you could choose version 1.18.50 using the following command::
+
+    curl https://s3.amazonaws.com/aws-cli/awscli-bundle-1.18.50.zip -o awscli-bundle.zip
+
+Once you've downloaded the bundle, proceed with *step 2* of the bundle-based installation instructions for your platform:
+
+* `Linux <https://docs.aws.amazon.com/cli/latest/userguide/install-linux.html#install-linux-bundled>`_
+* `macOS <https://docs.aws.amazon.com/cli/latest/userguide/install-macos.html#install-macosos-bundled-sudo>`_
+* `Windows <https://docs.aws.amazon.com/cli/latest/userguide/install-windows.html#msi-on-windows>`_

--- a/docs/source/guide/migrationpy3.rst
+++ b/docs/source/guide/migrationpy3.rst
@@ -2,11 +2,7 @@
 
 Migrating from Python 2.7 to Python 3
 =====================================
-Python 2.7 was deprecated by the `Python Software Foundation <https://www.python.org/psf-landing/>`_ back on January 1, 2020 following a multi-year process of phasing it out. Because of this, AWS has deprecated support for Python 2.7, so versions of Boto3 and the AWS CLI v1 released after the deprecation date will no longer work with Python 2.7.
-
-.. note::
-
-    Since the AWS CLI v2 bundles its own copy of Python, this transition only impacts users of the CLI v1.
+Python 2.7 was deprecated by the `Python Software Foundation <https://www.python.org/psf-landing/>`_ back on January 1, 2020 following a multi-year process of phasing it out. Because of this, AWS has deprecated support for Python 2.7, so versions of boto3 and botocore released after the deprecation date will no longer work with Python 2.7.
 
 Timeline
 --------
@@ -21,91 +17,39 @@ Python 3.4 and 3.5     February 1, 2021
 
 As shown in the table, Python 2.7 projects must transition to Python 3.6 by July 14, 2021, while Python 3.4 and 3.5 projects need to be updated to Python 3.6 by February 1, 2021.
 
-Impact on the AWS CLI
----------------------
-The AWS Command Line Interface is built using the Python SDK, so it's affected by this transition. AWS CLI v2 isn't affected by this transition, since it bundles its own copy of Python 3. However, if you still use the AWS CLI v1, you need to decide whether to :ref:`upgrade to Python 3 <quickstart_install_python>` or to `transition to the AWS CLI v2 <https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html>`_.
-
 Updating your project to use Python 3
 -------------------------------------
 Before you begin to update your project and environment, make sure you’ve installed or updated to Python 3.6 or later as described in :ref:`upgrade to Python 3 <quickstart_install_python>`. You can get Python from the `PSF web site <https://www.python.org/downloads>`_ or using your local package manager.
 
-Update the CLI
-~~~~~~~~~~~~~~
-Updating the CLI to the latest version isn't difficult:
-
-1. To begin, uninstall your existing copy of the AWS CLI using the following command::
-
-    $ python -m pip uninstall awscli
-
-2. Next, use Python 3 to reinstall the AWS CLI. Here, we're using the :command:`python3` command to ensure that Python 3 is used rather than Python 2::
-
-    $ python3 -m pip install awscli
-
-3. If you wish, you may verify that the newly installed copy of the AWS CLI tool, :command:`aws`, is using the correct version of Python. The :command:`aws --version` command reports the :command:`aws` tool's version number, followed by the version of Python it's running under, then the operating system version and the computer's processor family. As long as the Python version is at least 3.6, you're ready to go::
-
-    $ aws --version
-    aws-cli/1.18.191 Python/3.6.6 Darwin/19.6.0 botocore/1.19.31
-
-Update Boto3 and Botocore
+Update boto3 and botocore
 ~~~~~~~~~~~~~~~~~~~~~~~~~
-Now that you're sure you have Python 3 installed, you can proceed to upgrade Boto3 and Botocore. You can do this globally, or within your virtual environment if you use one for your project.
+Once you're sure you have Python 3 installed, you can proceed to upgrade boto3 and botocore. You can do this globally, or within your virtual environment if you use one for your project.
 
-1. Begin by uninstalling the currently installed copies of Boto3 and Botocore::
+1. Begin by uninstalling the currently installed copies of boto3 and botocore::
 
     $ python -m pip uninstall boto3 botocore
 
-2. Then install the new version of Boto3. This will also install Botocore, which it requires::
+2. Then install the new version of boto3. This will also install botocore, which it requires::
 
     $ python3 -m pip install boto3
 
-3. You can optionally verify that the freshly installed copy of the :command:`aws` tool is using the correct version of Python. One way to do that is to run a snippet of code that uses Boto3 and outputs the Python and Boto3 versions, such as the following::
+3. You can optionally verify that the freshly installed copy of the :command:`aws` tool is using the correct version of Python. One way to do that is to run a snippet of code that uses boto3 and outputs the Python and boto3 versions, such as the following::
 
-    $ python3 -c "import boto3, sys; print(f'{sys.version} \nBoto3: {boto3.__version__}')"
+    $ python3 -c "import boto3, sys; print(f'{sys.version} \nboto3: {boto3.__version__}')"
     3.8.6 (default, Jan  7 2021, 17:11:21)
     [GCC 7.3.1 20180712 (Red Hat 7.3.1-11)]
-    Boto3: 1.16.15
+    boto3: 1.16.15
 
 If you're unable to upgrade to Python 3
 ---------------------------------------
 It may be possible that you're unable to upgrade to Python 3. If you have a large project that's heavily dependent on syntax or features that no longer work as desired in Python 3, for example, you may need to keep using Python 2.7. It's also possible that you need to postpone the Python transition while you finish updates to your code.
 
-Under these circumstances, you should be prepared for the deprecation date, in order to not be inconvenienced when the time arrives. If you've kept all software up-to-date, you shouldn't need to do anything. If you're using a version of the AWS CLI v1 and/or Boto3 that requires Python 2, you can keep using the version you have after the deprecation date. You should, however, update to the most recent version of the AWS SDK for Python 2 that you can.
+Under these circumstances, you should be prepared for the deprecation date in order to not be inconvenienced when the time arrives. If you've kept all software up-to-date, you shouldn't need to do anything. If you're using an existing installation of boto3 on Python 2, you can keep using it even after the deprecation date. That version of boto3, however, will not receive further feature or security updates, so you should consider migrating to Python 3 as soon as possible.
 
-.. note::
+pip-based installations
+~~~~~~~~~~~~~~~~~~~~~~~
+If you installed boto3 using pip 10.0 or later, you'll automatically stop receiving boto3 updates after the last Python 2 compatible version of boto3 is installed. If you're using an older version of pip, you need to pin your boto3 install to no later than version 1.17.
 
-    Keep in mind that Python 2.7-based versions of Boto3 and the AWS CLI v1 will not receive support for new AWS capabilities after the scheduled deprecation dates.
-
-Upgrade a pip-based install
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-This is particularly true if you installed the AWS CLI and/or Boto3 using `pip`, since `pip` 10.0 and later will automatically prevent you from installing upgrades to the CLI or Boto3 that wouldn't be compatible with the version of Python you're using.
-
-Since the bundled installer only performs global installs, any virtual environment based projects will likely be using the CLI installed using `pip`.
-
-Windows MSI Installer
-~~~~~~~~~~~~~~~~~~~~~
-If you installed the AWS CLI v1 using the Windows MSI Installer for Python 3 [`32 bit <https://s3.amazonaws.com/aws-cli/AWSCLI32PY3.msi>`_] [`64 bit <https://s3.amazonaws.com/aws-cli/AWSCLI64PY3.msi>`_], you're not impacted by this transition, since these installers stay up-to-date with each release.
-
-If you're still using the AWS CLI v1 as installed using the Windows MSI Installer for *Python 2*, be aware that after the deprecation date, the download links for the latest version of the CLI v1 Windows MSI Installer will *only* be available for Python 3. The previous releases, including those for Python 2, will remain available at their version-specific URLs (``https://s3.amazonaws.com/aws-cli/AWSCLI32-{VERSION}.msi`` and ``https://s3.amazonaws.com/aws-cli/AWSCLI64-{VERSION}.msi``).
-
-You can download the current versions of these installers using the links below.
-
-**For Python 3**
-
-* `Windows MSI Installer for Python 3 (32 bit) <https://s3.amazonaws.com/aws-cli/AWSCLI32PY3.msi>`_
-* `Windows MSI Installer for Python 3 (64 bit) <https://s3.amazonaws.com/aws-cli/AWSCLI64PY3.msi>`_
-
-**For Python 2**
-
-* `Windows MSI Installer for Python 2 (32 bit) <https://s3.amazonaws.com/aws-cli/AWSCLI32.msi>`_
-* `Windows MSI Installer for Python 2 (64 bit) <https://s3.amazonaws.com/aws-cli/AWSCLI64.msi>`_
-
-Upgrade with the AWS CLI bundled installer
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-If you used the AWS CLI bundled installer when you previously installed the AWS CLI v1, and the installed copy of the CLI package doesn't support the Python 2.7 runtime, you need to upgrade to a version that does. You can do this by downloading the installer using the URL `https://s3.amazonaws.com/aws-cli/awscli-bundle-{VERSION}.zip`, where "{VERSION}" is the AWS CLI version you wish to install. For example, you could choose version 1.18.200 using the following command::
-
-    curl https://s3.amazonaws.com/aws-cli/awscli-bundle-1.18.200.zip -o awscli-bundle.zip
-
-Once you've downloaded the bundle, proceed with *step 2* of the bundle-based installation instructions for your platform:
-
-* `Linux <https://docs.aws.amazon.com/cli/latest/userguide/install-linux.html#install-linux-bundled>`_
-* `macOS <https://docs.aws.amazon.com/cli/latest/userguide/install-macos.html#install-macosos-bundled-sudo>`_
+Other installation methods
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+If install boto3 from source or using any other approach, be sure you download and install a version released prior to the Python 2.7 deprecation date.

--- a/docs/source/guide/migrationpy3.rst
+++ b/docs/source/guide/migrationpy3.rst
@@ -85,9 +85,9 @@ Windows MSI Installer
 ~~~~~~~~~~~~~~~~~~~~~
 If you installed the AWS CLI v1 using the Windows MSI Installer for Python 3 [`32 bit <https://s3.amazonaws.com/aws-cli/AWSCLI32PY3.msi>`_] [`64 bit <https://s3.amazonaws.com/aws-cli/AWSCLI64PY3.msi>`_], you're not impacted by this transition, since these installers stay up-to-date with each release.
 
-If you're still using the AWS CLI v1 as installed using the Windows MSI Installer for *Python 2*, be aware that after the deprecation date, we will no longer offer these Python 2-based installers, so you may wish to download and save copies now if you believe you need them [`32 bit <https://s3.amazonaws.com/aws-cli/AWSCLI32.msi>`_] [`64 bit <https://s3.amazonaws.com/aws-cli/AWSCLI64.msi>`_].
+If you're still using the AWS CLI v1 as installed using the Windows MSI Installer for *Python 2*, be aware that after the deprecation date, the download links for the latest version of the CLI v1 Windows MSI Installer will *only* be available for Python 3. The previous releases, including those for Python 2, will remain available at their version-specific URLs (``https://s3.amazonaws.com/aws-cli/AWSCLI32-{VERSION}.msi`` and ``https://s3.amazonaws.com/aws-cli/AWSCLI64-{VERSION}.msi``).
 
-You can download these installers using the links below.
+You can download the current versions of these installers using the links below.
 
 **For Python 3**
 

--- a/docs/source/guide/migrationpy3.rst
+++ b/docs/source/guide/migrationpy3.rst
@@ -2,43 +2,36 @@
 
 Migrating from Python 2.7 to Python 3
 =====================================
-Python 2.7 was deprecated back on January 1, 2020 following a multi-year process of phasing it out. Because of this, AWS has deprecated support for Python 2.7, and support for Python 2.7 will be removed from all SDKs before the end of 2021. This includes the AWS SDK for Python and the AWS Command Line Interface (CLI).
-
-This transition also requires transitioning from Boto 2.x to Boto3. See :ref:`Install or upgrade Python <quickstart_install_python>` for details.
+Python 2.7 was deprecated by the `Python Software Foundation <https://www.python.org/psf-landing/>`_ back on January 1, 2020 following a multi-year process of phasing it out. Because of this, AWS has deprecated support for Python 2.7, so versions of Boto3 and the AWS CLI v1 released after the deprecation date will no longer work with Python 2.7.
 
 .. note::
 
-    Since the AWS CLI v2 bundles its own copy of Python, this transition only impacts users of the version 1 CLI.
+    Since the AWS CLI v2 bundles its own copy of Python, this transition only impacts users of the CLI v1.
 
 Timeline
 --------
-Going forward, all projects using the AWS SDK for Python need to transition to using Python 3, with Python 3.6 becoming the minimum by the end of the transition. The deprecation dates the affected versions of Python are:
+Going forward, all projects using the AWS SDK for Python need to transition to using Python 3, with Python 3.6 becoming the minimum by the end of the transition. The deprecation dates for the affected versions of Python are:
 
-============== ===================
-Python version Date of deprecation
-============== ===================
-Python 2.7     June 1, 2021
-Python 3.4     February 1, 2021
-Python 3.5     February 1, 2021
-============== ===================
+==================     ===================
+Python version         Deprecation date
+==================     ===================
+Python 2.7             July 14, 2021
+Python 3.4 and 3.5     February 1, 2021
+==================     ===================
 
-As shown in the table, you must transition to Python 3.6 by June 1, 2021, while Python 3.4 and 3.5 projects need to be updated to Python 3.7 by February 1, 2021.
+As shown in the table, Python 2.7 projects must transition to Python 3.6 by July 14, 2021, while Python 3.4 and 3.5 projects need to be updated to Python 3.6 by February 1, 2021.
 
 Impact on the AWS CLI
 ---------------------
-The AWS Command Line Interface is built using the Python SDK, so it's affected by this transition. AWS CLI v2 isn't affected by this transition, since it bundles its own copy of Python 3. However, if you still use the AWS CLI v1, you need to decide whether to :ref:`upgrade to Python 3 <quickstart_install_python>` or to `transition to the version 2 CLI <https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html>`_.
+The AWS Command Line Interface is built using the Python SDK, so it's affected by this transition. AWS CLI v2 isn't affected by this transition, since it bundles its own copy of Python 3. However, if you still use the AWS CLI v1, you need to decide whether to :ref:`upgrade to Python 3 <quickstart_install_python>` or to `transition to the AWS CLI v2 <https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html>`_.
 
 Updating your project to use Python 3
 -------------------------------------
-If your project is currently based on Python 2, you need to begin by ensuring that you're using the latest version of the CLI. If you need to continue to use the version 1 CLI, you may do so, as long as you `update to the newest version of the v1 CLI <https://docs.aws.amazon.com/cli/latest/userguide/install-cliv1.html>`_.
-
-.. note::
-
-    Before you get started make, sure you’ve updated Python as described in  from the `PSF <https://www.python.org/downloads>`_ or your local package manager.
+Before you begin to update your project and environment, make sure you’ve installed or updated to Python 3.6 or later as described in :ref:`upgrade to Python 3 <quickstart_install_python>`. You can get Python from the `PSF web site <https://www.python.org/downloads>`_ or using your local package manager.
 
 Update the CLI
 ~~~~~~~~~~~~~~
-First, upgrade to the latest version of the AWS CLI v1.
+Updating the CLI to the latest version isn't difficult:
 
 1. To begin, uninstall your existing copy of the AWS CLI using the following command::
 
@@ -51,11 +44,11 @@ First, upgrade to the latest version of the AWS CLI v1.
 3. If you wish, you may verify that the newly installed copy of the AWS CLI tool, :command:`aws`, is using the correct version of Python. The :command:`aws --version` command reports the :command:`aws` tool's version number, followed by the version of Python it's running under, then the operating system version and the computer's processor family. As long as the Python version is at least 3.6, you're ready to go::
 
     $ aws --version
-    aws-cli/2.0.61 *Python/3.7.4* Darwin/19.6.0 exe/x86_64
+    aws-cli/1.18.191 Python/3.6.6 Darwin/19.6.0 botocore/1.19.31
 
 Update Boto3 and Botocore
 ~~~~~~~~~~~~~~~~~~~~~~~~~
-Now that you're sure you have Python 3 installed and you've updated the CLI (if needed), you can proceed to upgrade Boto3 and Botocore. You can do this globally, or within your virtual environment if you use one for your project.
+Now that you're sure you have Python 3 installed, you can proceed to upgrade Boto3 and Botocore. You can do this globally, or within your virtual environment if you use one for your project.
 
 1. Begin by uninstalling the currently installed copies of Boto3 and Botocore::
 
@@ -76,11 +69,11 @@ If you're unable to upgrade to Python 3
 ---------------------------------------
 It may be possible that you're unable to upgrade to Python 3. If you have a large project that's heavily dependent on syntax or features that no longer work as desired in Python 3, for example, you may need to keep using Python 2.7. It's also possible that you need to postpone the Python transition while you finish updates to your code.
 
-Under these circumstances, you should be prepared for the deprecation date, in order to not be inconvenienced when the time arrives. If you've kept all software up-to-date, you shouldn't need to do anything. If you're using the a version of the AWS CLI v1 and/or Boto3 that requires Python 2, the version you have will keep working as long as you're on Python 2.
+Under these circumstances, you should be prepared for the deprecation date, in order to not be inconvenienced when the time arrives. If you've kept all software up-to-date, you shouldn't need to do anything. If you're using a version of the AWS CLI v1 and/or Boto3 that requires Python 2, you can keep using the version you have after the deprecation date. You should, however, update to the most recent version of the AWS SDK for Python 2 that you can.
 
 .. note::
 
-    Keep in mind that Python 2.7-based versions of Boto3 and the AWS CLI v1 will not receive support for new AWS capabilities after the scheduled deprecation dates. Its also worth noting that by 2023, all operating systems on which Python can be installed will have ended support for Python 2.7. This means you'll probably have to complete the Python 3 transition eventually.
+    Keep in mind that Python 2.7-based versions of Boto3 and the AWS CLI v1 will not receive support for new AWS capabilities after the scheduled deprecation dates.
 
 Upgrade a pip-based install
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -88,14 +81,29 @@ This is particularly true if you installed the AWS CLI and/or Boto3 using `pip`,
 
 Since the bundled installer only performs global installs, any virtual environment based projects will likely be using the CLI installed using `pip`.
 
+Windows MSI Installer
+~~~~~~~~~~~~~~~~~~~~~
+If you installed the AWS CLI v1 using the Windows MSI Installer for Python 3 [`32 bit <https://s3.amazonaws.com/aws-cli/AWSCLI32PY3.msi>`_] [`64 bit <https://s3.amazonaws.com/aws-cli/AWSCLI64PY3.msi>`_], you're not impacted by this transition, since these installers stay up-to-date with each release.
+
+If you're still using the AWS CLI v1 as installed using the Windows MSI Installer for *Python 2*, be aware that after the deprecation date, we will no longer offer these Python 2-based installers, so you may wish to download and save copies now if you believe you need them [`32 bit <https://s3.amazonaws.com/aws-cli/AWSCLI32.msi>`_] [`64 bit <https://s3.amazonaws.com/aws-cli/AWSCLI64.msi>`_].
+
+You can download these installers using the links below.
+
+**For Python 3**
+* `Windows MSI Installer for Python 3 (32 bit) <https://s3.amazonaws.com/aws-cli/AWSCLI32PY3.msi>`_
+* `Windows MSI Installer for Python 3 (64 bit) <https://s3.amazonaws.com/aws-cli/AWSCLI64PY3.msi>`_
+
+**For Python 2**
+* `Windows MSI Installer for Python 2 (32 bit) <https://s3.amazonaws.com/aws-cli/AWSCLI32.msi>`_
+* `Windows MSI Installer for Python 2 (64 bit) <https://s3.amazonaws.com/aws-cli/AWSCLI64.msi>`_
+
 Upgrade with the AWS CLI bundled installer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-If you used the AWS CLI bundled installer when you previously installed the AWS CLI v1, and the installed copy of the CLI package doesn't support the Python 2.7 runtime, you need to upgrade to a version that does. You can do this by downloading the installer using the URL `https://s3.amazonaws.com/aws-cli/awscli-bundle-{VERSION}.zip`, where "{VERSION}" is the AWS CLI version you wish to install. For example, you could choose version 1.18.50 using the following command::
+If you used the AWS CLI bundled installer when you previously installed the AWS CLI v1, and the installed copy of the CLI package doesn't support the Python 2.7 runtime, you need to upgrade to a version that does. You can do this by downloading the installer using the URL `https://s3.amazonaws.com/aws-cli/awscli-bundle-{VERSION}.zip`, where "{VERSION}" is the AWS CLI version you wish to install. For example, you could choose version 1.18.200 using the following command::
 
-    curl https://s3.amazonaws.com/aws-cli/awscli-bundle-1.18.50.zip -o awscli-bundle.zip
+    curl https://s3.amazonaws.com/aws-cli/awscli-bundle-1.18.200.zip -o awscli-bundle.zip
 
 Once you've downloaded the bundle, proceed with *step 2* of the bundle-based installation instructions for your platform:
 
 * `Linux <https://docs.aws.amazon.com/cli/latest/userguide/install-linux.html#install-linux-bundled>`_
 * `macOS <https://docs.aws.amazon.com/cli/latest/userguide/install-macos.html#install-macosos-bundled-sudo>`_
-* `Windows <https://docs.aws.amazon.com/cli/latest/userguide/install-windows.html#msi-on-windows>`_

--- a/docs/source/guide/quickstart.rst
+++ b/docs/source/guide/quickstart.rst
@@ -6,6 +6,24 @@ Getting started with Boto3 is easy, but requires a few steps.
 
 Installation
 ------------
+Prior to using Boto3, you need to install it and its dependencies.
+
+.. _quickstart_install_python:
+
+Install or update Python
+~~~~~~~~~~~~~~~~~~~~~~~~
+Before installing Boto3, ensure that you're using an up-to-date version of
+Python. Unless you have specific reasons to use another version of Python, you
+should be using Python 3.7 or later. Boto3 support for Python 2.7 is
+deprecated and will end effective June 1, 2021. See :ref:`guide_migration_py3`
+for more details, including timeline information and guidance regarding how to
+transition to Python 3 if you haven't done so yet.
+
+For more information on how to get the latest version of Python, please refer
+to the official `Python documentation <https://www.python.org/downloads/>`_. 
+
+Install Boto3
+~~~~~~~~~~~~~
 Install the latest Boto3 release via :command:`pip`::
 
     pip install boto3
@@ -16,12 +34,8 @@ You may also install a specific version::
 
 .. note::
 
-   The latest development version can always be found on
+   The latest development version of Boto3 can always be found on
    `GitHub <https://github.com/boto/boto3>`_.
-
-.. note::
-
-    For best results, please ensure your version of Python is up-to-date. For more information on how to get the latest version of Python, please refer to the official `Python documentation <https://www.python.org/downloads/>`_. 
 
 Configuration
 -------------

--- a/docs/source/guide/quickstart.rst
+++ b/docs/source/guide/quickstart.rst
@@ -15,7 +15,7 @@ Install or update Python
 Before installing Boto3, ensure that you're using an up-to-date version of
 Python. Unless you have specific reasons to use another version of Python, you
 should be using Python 3.7 or later. Boto3 support for Python 2.7 is
-deprecated and will end effective June 1, 2021. See :ref:`guide_migration_py3`
+deprecated and will end effective July 15, 2021. See :ref:`guide_migration_py3`
 for more details, including timeline information and guidance regarding how to
 transition to Python 3 if you haven't done so yet.
 


### PR DESCRIPTION
Add a new page about the deprecation of Python 2.7 to the Migrations section. Integrated into the sidebar and the Quickstart page. Updated documentation copyright to 2021.