### PR TITLE
Add changes for Python 3.4/3.5 removal

### DIFF
--- a/.changes/next-release/feature-Python-34330.json
+++ b/.changes/next-release/feature-Python-34330.json
@@ -1,0 +1,5 @@
+{
+  "category": "Python", 
+  "type": "feature", 
+  "description": "Dropped support for Python 3.4 and 3.5"
+}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,13 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [2.7, 3.6, 3.7, 3.8]
         os: [ubuntu-latest, macOS-latest, windows-latest ]
-        include:
-          # Python 3.4 is not available on mac and windows so it needs to to
-          # be manually added to the matrix for linux.
-          - python-version: 3.4
-            os: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/boto3/compat.py
+++ b/boto3/compat.py
@@ -64,12 +64,6 @@ def filter_python_deprecation_warnings():
 
 
 def _warn_deprecated_python():
-    py_34_35_params = {
-        'date': 'February 1, 2021',
-        'blog_link': 'https://aws.amazon.com/blogs/developer/announcing-'
-                     'the-end-of-support-for-python-3-4-and-3-5-in-the-'
-                     'aws-sdk-for-python-and-aws-cli-v1/'
-    }
     py_27_params = {
         'date': 'July 15, 2021',
         'blog_link': 'https://aws.amazon.com/blogs/developer/announcing-end-'
@@ -77,8 +71,6 @@ def _warn_deprecated_python():
                      'aws-cli-v1/'
     }
     deprecated_versions = {
-        (3,4): py_34_35_params,
-        (3,5): py_34_35_params,
         (2,7): py_27_params,
     }
     py_version = sys.version_info[:2]

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     include_package_data=True,
     install_requires=requires,
     license="Apache License 2.0",
+    python_requires=">= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -52,8 +53,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37,py38
+envlist = py27,py36,py37,py38
 
 # Comment to build sdist and install into virtualenv
 # This is helpful to test installation but takes extra time


### PR DESCRIPTION
This is a draft PR with the list of possible cleanup changes we can make with the deprecation of Python 3.4 and 3.5 on Feb 1, 2021. This should cover the full scope of 3.4/3.5 specific code but not all of these are strictly required. Looking for feedback before we merge.

### Changes
- [x] Add `python_requires` to setup.py to inform pip of compatibility
- [x] Updated trove classifiers
- [x] Removed versions from GHA CI
- [x] Removed version from tox.ini
- [x] Removed 3.4/3.5 from unsupported warnings