### PR TITLE
Python 2.7 deprecation - documentation update 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,16 @@ venv
 env2
 env3
 
+# Virtualenv support files and directories
+.python-version
+
 # IntelliJ / PyCharm IDE
 .idea/
 
 # Visual Studio used to edit docs
 docs/source/.vs
 .vscode
+
+# Project-specific
+.doctrees
+source/_build

--- a/docs/source/guide/migrationpy3.rst
+++ b/docs/source/guide/migrationpy3.rst
@@ -1,0 +1,75 @@
+.. _guide_migration_py3:
+
+Migrating to Python 3
+=====================
+
+Python 2.7 was deprecated by the `Python Software Foundation <https://www.python.org/psf-landing/>`_
+on January 1, 2020 following a multi-year process of phasing it out. Because of this, AWS has
+deprecated support for Python 2.7, which means that new releases of the SDK will no longer work on
+Python 2.7.
+
+This affects both modules that comprise the AWS SDK for Python: Botocore (the underlying low-level
+module) and Boto3 (which implements the API functionality and higher-level features).
+
+Timeline
+--------
+Going forward, all projects using the AWS SDK for Python need to transition to using Python 3, with
+Python 3.6 becoming the minimum by the end of the transition. Boto3 and Botocore will end support
+for Python 2.7 effective July 14, 2021, while Python 3.5 and lower will need to be updated to Python
+3.6 by February 1, 2021.
+
+Updating your project to use Python 3
+-------------------------------------
+
+Before you begin to update your project and environment, make sure you’ve installed or updated to
+Python 3.6 or later as described in :ref:`upgrade to Python 3 <quickstart_install_python>`. You can
+get Python from the `PSF web site <https://www.python.org/downloads>`_ or using your local package
+manager.
+
+After you have installed Python 3, you can upgrade the SDK. To do so, you need
+to update both the Boto3 and Botocore Python modules. You can do this globally
+or within your
+virtual environment if you use one for your project.
+
+To update the AWS SDK for Python
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1. Uninstall the currently installed copies of Boto3 and Botocore::
+
+    $ python -m pip uninstall boto3 botocore
+
+2. Install the new version of Boto3. This will also install Botocore, which it requires::
+
+    $ python3 -m pip install boto3
+
+3. (Optional) Verify that the :command:`aws` tool is using the correct version of Python::
+
+    $ python3 -c "import boto3, sys; print(f'{sys.version} \nboto3: {boto3.__version__}')"
+    3.8.6 (default, Jan  7 2021, 17:11:21)
+    [GCC 7.3.1 20180712 (Red Hat 7.3.1-11)]
+    boto3: 1.16.15
+
+If you're unable to upgrade to Python 3
+---------------------------------------
+
+It may be that you're unable to upgrade to Python 3, for example if you have a large project that's
+heavily dependent on syntax or features that no longer work as desired in Python 3. It's also
+possible that you need to postpone the Python transition while you finish updates to your code.
+
+Under these circumstances, you can prepare for the deprecation date in order to avoid inconvenience
+when the time arrives by keeping all software up-to-date. If you're using an existing installation
+of the AWS SDK for Python on Python 2, you can keep using it even after the deprecation date, but
+deprecated versions of Boto3 will not receive further feature or security updates.
+
+pip-based installations
+~~~~~~~~~~~~~~~~~~~~~~~
+
+If you installed Boto3 using :command:`pip` 10.0 or later, you'll automatically stop receiving Boto3
+updates after the last Python 2 compatible version of the SDK is installed. If you're using an older
+version of :command:`pip`, you need to pin your Boto3 install to no later than version 1.17.
+
+Other installation methods
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you installed Boto3 and Botocore from source or by any other method, be sure to download and
+install a version released prior to the Python 2.7 deprecation date.

--- a/docs/source/guide/quickstart.rst
+++ b/docs/source/guide/quickstart.rst
@@ -2,87 +2,121 @@
 
 Quickstart
 ==========
-Getting started with Boto3 is easy, but requires a few steps.
+
+This guide details the steps needed to install or update the AWS SDK for Python.
+
+The SDK is composed of two key Python modules: Botocore (the library providing the low-level
+functionality shared between the Python SDK and the AWS CLI) and Boto3 (the module implementing the
+Python SDK itself). Both need to be installed properly in order to use the SDK.
+
+.. note::
+
+    Documentation and developers tend to refer to the AWS SDK for Python as "Boto3," and this
+    documentation often does so as well.
 
 Installation
 ------------
+
+To use Boto3, you first need to install it and its dependencies.
+
+.. _quickstart_install_python:
+
+Install or update Python
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Before installing Boto3, install Python 3.6 or later. Boto3 support for earlier versions is
+deprecated and will be removed entirely during the first half of 2021. For more information about
+this change, its timing, and how to transition to Python 3, see :ref:`guide_migration_py3`.
+
+For information about how to get the latest version of Python, see the official `Python
+documentation <https://www.python.org/downloads/>`_. 
+
+Install Boto3
+~~~~~~~~~~~~~
+
 Install the latest Boto3 release via :command:`pip`::
 
     pip install boto3
 
-You may also install a specific version::
+If your project requires requires a specific version of Boto3, or has compatibility concerns with
+certain versions, you may provide that constraint when installing::
 
+    # Install Boto3 version 1.0 specifically
     pip install boto3==1.0.0
 
+    # Make sure Boto3 is no older than version 1.15.0
+    pip install boto3>=1.15.0
+
+    # Avoid versions of Boto3 newer than version 1.15.3
+    pip install boto3<=1.15.3
+
 .. note::
 
-   The latest development version can always be found on
-   `GitHub <https://github.com/boto/boto3>`_.
-
-.. note::
-
-    For best results, please ensure your version of Python is up-to-date. For more information on how to get the latest version of Python, please refer to the official `Python documentation <https://www.python.org/downloads/>`_. 
+   The latest development version of Boto3 is on `GitHub <https://github.com/boto/boto3>`_.
 
 Configuration
 -------------
-Before you can begin using Boto3, you should set up authentication
-credentials. Credentials for your AWS account can be found in the
-`IAM Console <https://console.aws.amazon.com/iam/home>`_. You can
-create or use an existing user. Go to manage access keys and
-generate a new set of keys.
 
-If you have the `AWS CLI <http://aws.amazon.com/cli/>`_
-installed, then you can use it to configure your credentials file::
+Before using Boto3, you need to set up authentication credentials for your AWS account using either
+the `IAM Console <https://console.aws.amazon.com/iam/home>`_ or the AWS CLI. You can either choose
+an existing user or create a new one.
+
+For instructions about how to create a user using the IAM Console, see `Creating IAM users
+<https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html#id_users_create_console>`_.
+Once the user has been created, see `Managing access keys
+<https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_CreateAccessKey>`_
+to learn how to create and retrieve the keys used to authenticate the user.
+
+To configure the credentials using the CLI, use the :command:`aws configure` command.
+
+If you have the `AWS CLI <http://aws.amazon.com/cli/>`_ installed, then you can use it to configure
+your credentials file::
 
     aws configure
 
-Alternatively, you can create the credential file yourself. By default,
-its location is at ``~/.aws/credentials``::
+Alternatively, you can create the credential file yourself. By default, its location is
+``~/.aws/credentials``. At a minimum, the credentials file should specify the access key and secret
+access key. In this example, the key and secret key for the account are specified for a profile
+named ``default``::
 
     [default]
     aws_access_key_id = YOUR_ACCESS_KEY
     aws_secret_access_key = YOUR_SECRET_KEY
 
-You may also want to set a default region. This can be done in the
-configuration file. By default, its location is at ``~/.aws/config``::
+You may also want to add a default region to the AWS configuration file, which is located by default
+at ``~/.aws/config``::
 
     [default]
     region=us-east-1
 
-Alternatively, you can pass a ``region_name`` when creating clients
-and resources.
+Alternatively, you can pass a ``region_name`` when creating clients and resources.
 
-This sets up credentials for the default profile as well as a default
-region to use when creating connections. See
-:ref:`guide_configuration` for in-depth configuration sources and
-options.
+You have now configured credentials for the default profile as well as a default region to use when
+creating connections. See :ref:`guide_configuration` for in-depth configuration sources and options.
 
 Using Boto3
 ------------
-To use Boto3, you must first import it and tell it what service you are
-going to use::
+
+To use Boto3, you must first import it and indicate which service or services you're going to use::
 
     import boto3
 
     # Let's use Amazon S3
     s3 = boto3.resource('s3')
 
-Now that you have an ``s3`` resource, you can make requests and process
-responses from the service. The following uses the ``buckets`` collection
-to print out all bucket names::
+Now that you have an ``s3`` resource, you can make requests of and process responses from the
+service. The following code uses the ``buckets`` collection to print out all bucket names::
 
     # Print out bucket names
     for bucket in s3.buckets.all():
         print(bucket.name)
 
-It's also easy to upload and download binary data. For example, the
-following uploads a new file to S3. It assumes that the bucket ``my-bucket``
-already exists::
+You can also upload and download binary data. For example, the following uploads a new file to S3,
+assuming that the bucket ``my-bucket`` already exists::
 
     # Upload a new file
     data = open('test.jpg', 'rb')
     s3.Bucket('my-bucket').put_object(Key='test.jpg', Body=data)
 
-:ref:`guide_resources` and :ref:`guide_collections` will be covered in more
-detail in the following sections, so don't worry if you do not completely
-understand the examples.
+:ref:`guide_resources` and :ref:`guide_collections`  are covered in more detail in the following
+sections.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,10 +5,16 @@
 
 Boto3 documentation
 ====================
-Boto is the Amazon Web Services (AWS) SDK for Python. It enables Python
-developers to create, configure, and manage AWS services, such as EC2 
-and S3. Boto provides an easy to use, object-oriented API, as well as 
-low-level access to AWS services.
+
+You use the AWS SDK for Python to create, configure, and manage AWS services, such as Amazon
+Elastic Compute Cloud (Amazon EC2) and Amazon Simple Storage Service (Amazon
+S3). The SDK provides an
+object-oriented API as well as low-level access to AWS services.
+
+.. note::
+
+    Documentation and developers tend to refer to the AWS SDK for Python as "Boto3," and this
+    documentation often does so as well.
 
 Quickstart
 ----------


### PR DESCRIPTION
This finishes fixing up the docs for the deprecation of Python 2.7. Mostly minor stuff but some general cleanup and reworking after undergoing editorial review.