### PR TITLE
Add info about proxies_config settings

### DIFF
--- a/docs/source/guide/configuration.rst
+++ b/docs/source/guide/configuration.rst
@@ -118,7 +118,7 @@ Using environment variables
 You can set configuration settings using system-wide environment variables. These configurations are global and will affect all clients created unless you override them with a ``Config`` object.
 
 .. note::
-    Not all configuration settings can be set using environment variables. See `Using environment variables <https://docs.aws.amazon.com/credref/latest/refdocs/environment-variables.html>`_ in AWS SDKs and Tools Shared Configuration and Credentials provides this information.
+    Only the configuration settings listed below can be set using environment variables.
 
 
 ``AWS_ACCESS_KEY_ID``

--- a/docs/source/guide/configuration.rst
+++ b/docs/source/guide/configuration.rst
@@ -61,64 +61,57 @@ Boto3 supports using proxies as intermediaries between your code and AWS. Proxie
 Specifying proxy servers
 ''''''''''''''''''''''''
 
-You can specify proxy servers to be used when communicating between specific endpoints, or when
-using specific protocols. The ``proxies`` option in the ``Config`` object is a dictionary that maps
-the protocol name or endpoint URL to the address of a proxy server.
+You can specify proxy servers to be used for connections when using specific protocols. The ``proxies`` option in the ``Config`` object is a dictionary that maps the protocol name to the address and port number of a proxy server.
 
 .. code-block:: python
 
     import boto3
     from botocore.config import Config
 
-    proxy_list = {
-        'http': 'proxy.example.com:6502',
-        'http://mysite.org': 'proxy.example.org:2010'
+    proxy_definitions = {
+        'http': 'https://proxy.amazon.com:6502',
+        'https': 'https://proxy.amazon.org:2010'
     }
 
     my_config = Config(
         'region_name': 'us-east-2',
         'signature_version': 'v4',
-        'proxies': proxy_list
+        'proxies': proxy_definitions
     }
 
     client = boto3.client('kinesis', config=my_config)
 
 
-In the above example, a proxy list is set up to use ``proxy.example.com``, port 6502 as the proxy for all HTTP requests by default. For requests to ``http://mysite.org``, port 2010 on ``proxy.example.org`` is used instead.
+In the above example, a proxy list is set up to use ``proxy.amazon.com``, port 6502 as the proxy for all HTTP requests by default. HTTPS requests use port 2010 on ``proxy.amazon.org`` instead.
 
 
 .. _configure_proxies:
 
 Configuring proxies
 '''''''''''''''''''
-You can configure proxy usage with the ``proxies-config`` option, which is a dictionary that specifies the values of several proxy options by name. The valid keys for this dictionary are:
-
-* ``proxy_ca_bundle`` (string) - The pathname of a custom certificate bundle to use when establishing TLS/SSL connections using a proxy.
-* ``proxy_client_cert`` (string or tuple) - Specifies the certificate to use for proxy TLS client authentication. When the value is a string, it's the pathname of a certificate file. If it's a tuple it must be two comma-separated strings. The first is used as the pathname of the client certificate, and the second is the path to the certificate's key.
-* ``proxy_use_forwarding_for_https`` (Boolean) - When true, HTTPS requests which specify absolute URIs will be forwarded using the proxy. Only set this to true for highly trusted or corporate proxies; otherwise, the proxy can become a man-in-the-middle attack vector.
+You can configure proxy usage with the ``proxies_config`` option, which is a dictionary that specifies the values of several proxy options by name.  There are three keys in this dictionary: ``proxy_ca_bundle``, ``proxy_client_cert``, and ``proxy_use_forwarding_for_https``. See the `Botocore config reference <https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html>`_ for more information about these.
 
 .. code-block:: python
 
     import boto3
     from botocore.config import Config
 
-    proxy_list = {
-        'http': 'proxy.example.com:6502'
+    proxy_definitions = {
+        'http': 'proxy.amazon.com:6502'
     }
 
     my_config = Config(
         'region_name': 'us-east-2',
         'signature_version': 'v4',
-        'proxies': proxy_list,
-        'proxy_config': {
-            'proxy_client_cert': '/path/of/certificate',
-            'proxy_use_forwarding_for_https': False
+        'proxies': proxy_definitions,
+        'proxies_config': {
+            'proxy_client_cert': '/path/of/certificate'
         }
     }
 
     client = boto3.client('kinesis', config=my_config)
 
-With the addition of the ``proxy_config`` option shown here, the proxy will use the specified certificate file for authentication, and we guarantee that HTTPS will not be passed through the proxy by setting ``proxy_use_forwarding_for_https`` to :code:`False`.
+With the addition of the ``proxies_config`` option shown here, the proxy will use the specified certificate file for authentication.
 
 
 Using environment variables 

--- a/docs/source/guide/configuration.rst
+++ b/docs/source/guide/configuration.rst
@@ -25,7 +25,7 @@ This option is for configuring client-specific configurations that affect the be
 * ``region_name`` (string) - The AWS Region used in instantiating the client. If used, this takes precedence over environment variable and configuration file values. But it doesn't overwrite a ``region_name`` value *explicitly* passed to individual service methods.
 * ``signature_version`` (string) - The signature version used when signing requests. Note that the default version is Signature Version 4. If you're using a presigned URL with an expiry of greater than 7 days, you should specify Signature Version 2.
 * ``s3`` (related configurations; dictionary) - Amazon S3 service-specific configurations. For more information, see the `Botocore config reference <https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html>`_.
-* ``proxies`` (dictionary) - A dictionary mapping protocol names or endpoint locations to the proxy servers that should be used when communicating with them. These proxies, if specified, are used for every request. See :ref:`specify_proxies` for more information.
+* ``proxies`` (dictionary) - A dictionary mapping protocol names to the proxy servers that should be used when communicating with them. These proxies, if specified, are used for every request. See :ref:`specify_proxies` for more information.
 * ``proxies_config`` (dictionary) - Additional proxy configuration settings. These are described in :ref:`configure_proxies`.
 * ``retries`` (dictionary) - Client retry behavior configuration options that include retry mode and maximum retry attempts. For more information, see the :ref:`guide_retries` guide.  
 
@@ -61,7 +61,7 @@ Boto3 supports using proxies as intermediaries between your code and AWS. Proxie
 Specifying proxy servers
 ''''''''''''''''''''''''
 
-You can specify proxy servers to be used for connections when using specific protocols. The ``proxies`` option in the ``Config`` object is a dictionary that maps the protocol name to the address and port number of a proxy server.
+You can specify proxy servers to be used for connections when using specific protocols. The ``proxies`` option in the ``Config`` object is a dictionary in which each entry maps a protocol to the address and port number of the proxy server for that protocol.
 
 .. code-block:: python
 
@@ -69,7 +69,7 @@ You can specify proxy servers to be used for connections when using specific pro
     from botocore.config import Config
 
     proxy_definitions = {
-        'http': 'https://proxy.amazon.com:6502',
+        'http': 'http://proxy.amazon.com:6502',
         'https': 'https://proxy.amazon.org:2010'
     }
 
@@ -89,7 +89,7 @@ In the above example, a proxy list is set up to use ``proxy.amazon.com``, port 6
 
 Configuring proxies
 '''''''''''''''''''
-You can configure proxy usage with the ``proxies_config`` option, which is a dictionary that specifies the values of several proxy options by name.  There are three keys in this dictionary: ``proxy_ca_bundle``, ``proxy_client_cert``, and ``proxy_use_forwarding_for_https``. See the `Botocore config reference <https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html>`_ for more information about these.
+You can configure proxy usage with the ``proxies_config`` option, which is a dictionary that specifies the values of several proxy options by name.  There are three keys in this dictionary: ``proxy_ca_bundle``, ``proxy_client_cert``, and ``proxy_use_forwarding_for_https``. See the `Botocore config reference <https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html#botocore.config.Config>`_ for more information about these keys.
 
 .. code-block:: python
 
@@ -97,7 +97,7 @@ You can configure proxy usage with the ``proxies_config`` option, which is a dic
     from botocore.config import Config
 
     proxy_definitions = {
-        'http': 'proxy.amazon.com:6502'
+        'http': 'http://proxy.amazon.com:6502'
     }
 
     my_config = Config(

--- a/docs/source/guide/configuration.rst
+++ b/docs/source/guide/configuration.rst
@@ -96,7 +96,8 @@ You can configure how Boto3 uses proxies by specifying the ``proxies_config`` op
     from botocore.config import Config
 
     proxy_definitions = {
-        'http': 'http://proxy.amazon.com:6502'
+        'http': 'http://proxy.amazon.com:6502',
+        'https': 'https://proxy.amazon.org:2010'
     }
 
     my_config = Config(
@@ -110,7 +111,7 @@ You can configure how Boto3 uses proxies by specifying the ``proxies_config`` op
 
     client = boto3.client('kinesis', config=my_config)
 
-With the addition of the ``proxies_config`` option shown here, the proxy will use the specified certificate file for authentication.
+With the addition of the ``proxies_config`` option shown here, the proxy will use the specified certificate file for authentication when using the HTTPS proxy.
 
 
 Using environment variables 

--- a/docs/source/guide/configuration.rst
+++ b/docs/source/guide/configuration.rst
@@ -118,7 +118,7 @@ Using environment variables
 You can set configuration settings using system-wide environment variables. These configurations are global and will affect all clients created unless you override them with a ``Config`` object.
 
 .. note::
-    Not all configuration settings can be set using environment variables. The `Using environment variables <https://docs.aws.amazon.com/credref/latest/refdocs/environment-variables.html>`_ chapter of AWS SDKs and Tools Shared Configuration and Credentials provides this information.
+    Not all configuration settings can be set using environment variables. See `Using environment variables <https://docs.aws.amazon.com/credref/latest/refdocs/environment-variables.html>`_ in AWS SDKs and Tools Shared Configuration and Credentials provides this information.
 
 
 ``AWS_ACCESS_KEY_ID``

--- a/docs/source/guide/configuration.rst
+++ b/docs/source/guide/configuration.rst
@@ -25,8 +25,8 @@ This option is for configuring client-specific configurations that affect the be
 * ``region_name`` (string) - The AWS Region used in instantiating the client. If used, this takes precedence over environment variable and configuration file values. But it doesn't overwrite a ``region_name`` value *explicitly* passed to individual service methods.
 * ``signature_version`` (string) - The signature version used when signing requests. Note that the default version is Signature Version 4. If you're using a presigned URL with an expiry of greater than 7 days, you should specify Signature Version 2.
 * ``s3`` (related configurations; dictionary) - Amazon S3 service-specific configurations. For more information, see the `Botocore config reference <https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html>`_.
-* ``proxies`` (dictionary) - A dictionary mapping protocol names to the proxy servers that should be used when communicating with them. These proxies, if specified, are used for every request. See :ref:`specify_proxies` for more information.
-* ``proxies_config`` (dictionary) - Additional proxy configuration settings. These are described in :ref:`configure_proxies`.
+* ``proxies`` (dictionary) - Each entry maps a protocol name to the proxy server Boto3 should use to communicate using that protocol. See :ref:`specify_proxies` for more information.
+* ``proxies_config`` (dictionary) - Additional proxy configuration settings. For more information, see :ref:`configure_proxies`.
 * ``retries`` (dictionary) - Client retry behavior configuration options that include retry mode and maximum retry attempts. For more information, see the :ref:`guide_retries` guide.  
 
 
@@ -53,8 +53,7 @@ To set these configuration options, create a ``Config`` object with the options 
 
 Using proxies
 ~~~~~~~~~~~~~
-Boto3 supports using proxies as intermediaries between your code and AWS. Proxies may provide any number of functions, from filtering to security and firewalls to privacy assurance.
-
+With Boto3, you can use proxies as intermediaries between your code and AWS. Proxies can provide functions such as filtering, security, firewalls, and privacy assurance.
 
 .. _specify_proxies:
 
@@ -62,6 +61,9 @@ Specifying proxy servers
 ''''''''''''''''''''''''
 
 You can specify proxy servers to be used for connections when using specific protocols. The ``proxies`` option in the ``Config`` object is a dictionary in which each entry maps a protocol to the address and port number of the proxy server for that protocol.
+
+In the following example, a proxy list is set up to use ``proxy.amazon.com``, port 6502 as the proxy for all HTTP requests by default. HTTPS requests use port 2010 on ``proxy.amazon.org`` instead.
+
 
 .. code-block:: python
 
@@ -82,14 +84,11 @@ You can specify proxy servers to be used for connections when using specific pro
     client = boto3.client('kinesis', config=my_config)
 
 
-In the above example, a proxy list is set up to use ``proxy.amazon.com``, port 6502 as the proxy for all HTTP requests by default. HTTPS requests use port 2010 on ``proxy.amazon.org`` instead.
-
-
 .. _configure_proxies:
 
 Configuring proxies
 '''''''''''''''''''
-You can configure proxy usage with the ``proxies_config`` option, which is a dictionary that specifies the values of several proxy options by name.  There are three keys in this dictionary: ``proxy_ca_bundle``, ``proxy_client_cert``, and ``proxy_use_forwarding_for_https``. See the `Botocore config reference <https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html#botocore.config.Config>`_ for more information about these keys.
+You can configure how Boto3 uses proxies by specifying the ``proxies_config`` option, which is a dictionary that specifies the values of several proxy options by name.  There are three keys in this dictionary: ``proxy_ca_bundle``, ``proxy_client_cert``, and ``proxy_use_forwarding_for_https``. For more information about these keys, see the `Botocore config reference <https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html#botocore.config.Config>`_.
 
 .. code-block:: python
 
@@ -116,10 +115,11 @@ With the addition of the ``proxies_config`` option shown here, the proxy will us
 
 Using environment variables 
 ---------------------------
-Configurations can be set through the use of system-wide environment variables. If set, these configurations are global and will affect all clients created unless explicitly overwritten through the use of a ``Config`` object.
+You can set configuration settings using system-wide environment variables. These configurations are global and will affect all clients created unless you override them with a ``Config`` object.
 
 .. note::
-    Not all configurations can be set using environment variables.
+    Not all configuration settings can be set using environment variables. The `Using environment variables <https://docs.aws.amazon.com/credref/latest/refdocs/environment-variables.html>`_ chapter of AWS SDKs and Tools Shared Configuration and Credentials provides this information.
+
 
 ``AWS_ACCESS_KEY_ID``
     The access key for your AWS account.


### PR DESCRIPTION
Includes a new section about doing configuration with `proxies_config`. Also
added some links, cleaned up a few bits of the RST, and other minor adjustments.