### PR TITLE
Add info about CRT support to Quickstart page

### DIFF
--- a/docs/source/guide/quickstart.rst
+++ b/docs/source/guide/quickstart.rst
@@ -55,6 +55,36 @@ certain versions, you may provide constraints when installing::
 
    The latest development version of Boto3 is on `GitHub <https://github.com/boto/boto3>`_.
 
+
+Using the AWS Common Runtime (CRT)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In addition to the standard version of Boto3, there's a version based on the new AWS Common Runtime
+(CRT). The AWS CRT is a collection of modular packages that serve as a new foundation for AWS
+SDKs. Each library provides good performance and minimal footprint for the functional area it
+implements. Using the CRT, SDKs can share the same base code wherever possible, allowing for better
+code reuse, optimization, and accuracy.
+
+The current version of the AWS CRT-based Boto3 uses the its authentication package (`aws-c-auth
+<https://github.com/awslabs/aws-c-auth>`_) to add support for CRT's new signers:
+
+* **Signature Version 4** (**sigv4**) adds authentication to your AWS requests using your security
+  credentials (your AWS access key and secret access key). This signing is locked to one region
+  since the region is part of the signing criteria.
+
+* **Signature Version 4 Asymmetric** (**sigv4a** or **sigv4 asymmetric**) supports
+  region-independent services with a global endpoint.
+
+Boto3 doesn't use the AWS CRT by default but you can opt into using it by specifying the
+:code:`crt` `extra feature <https://www.python.org/dev/peps/pep-0508/#extras>`_ when installing Boto3::
+
+    pip install boto3[crt]
+
+To revert to the non-CRT version of Boto3, use this command::
+
+    pip uninstall awscrt
+
+
 Configuration
 -------------
 


### PR DESCRIPTION
This update adds a new section to the Quickstart article, "Using the AWS Common Runtime (CRT)". This section covers (briefly) what CRT is and why it matters, then what it's currently used for, plus how to install and remove CRT support from a project.