### PR TITLE
Fix broken footer link to Sphinx site

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -16,7 +16,7 @@
     </script>
     <a href="http://aws.amazon.com/privacy">Privacy</a> | <a href="http://aws.amazon.com/terms">Site Terms</a> | <a
         href="#" onclick="shortbread.customizeCookies();">Cookie preferences</a> |
-    &copy; Copyright {{ copyright }}. Created using <a href="http://sphinx.pocoo.org/">Sphinx</a>.
+    &copy; Copyright {{ copyright }}. Created using <a href="https://www.sphinx-doc.org/">Sphinx</a>.
 </div>
 
 {%- endblock %}


### PR DESCRIPTION
Replaces the broken link to the Sphinx web site in the Boto3 doc footer  
template with the https link to the current Sphinx web site at  
https://www.sphinx-doc.org/.