### PR TITLE
Update Return type of _get_related_resources to Action

### DIFF
--- a/boto3/resources/model.py
+++ b/boto3/resources/model.py
@@ -549,7 +549,7 @@ class ResourceModel(object):
         :type subresources: bool
         :param subresources: ``True`` to get sub-resources, ``False`` to
                              get references.
-        :rtype: list(:py:class:`ResponseResource`)
+        :rtype: list(:py:class:`Action`)
         """
         resources = []
 
@@ -578,7 +578,7 @@ class ResourceModel(object):
         """
         Get a list of sub-resources.
 
-        :type: list(:py:class:`ResponseResource`)
+        :type: list(:py:class:`Action`)
         """
         return self._get_related_resources(True)
 
@@ -587,7 +587,7 @@ class ResourceModel(object):
         """
         Get a list of reference resources.
 
-        :type: list(:py:class:`ResponseResource`)
+        :type: list(:py:class:`Action`)
         """
         return self._get_related_resources(False)
 


### PR DESCRIPTION
Tiny PR to correct the documented return type of `_get_related_resources` from `ResponseResource` to `Action`.