### PR TITLE
Add info on installing with CRT support

### DIFF
--- a/docs/source/guide/quickstart.rst
+++ b/docs/source/guide/quickstart.rst
@@ -55,25 +55,23 @@ certain versions, you may provide constraints when installing::
 
    The latest development version of Boto3 is on `GitHub <https://github.com/boto/boto3>`_.
 
-
 Using the AWS Common Runtime (CRT)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In addition to the standard version of Boto3, there's a version based on the new AWS Common Runtime
-(CRT). The AWS CRT is a collection of modular packages that serve as a new foundation for AWS
-SDKs. Each library provides good performance and minimal footprint for the functional area it
-implements. Using the CRT, SDKs can share the same base code wherever possible, allowing for better
-code reuse, optimization, and accuracy.
+In addition to the default install of Boto3, you can choose to include the new AWS Common Runtime
+(CRT). The AWS CRT is a collection of modular packages that serve as a new foundation for AWS SDKs.
+Each library provides better performance and minimal footprint for the functional area it
+implements. Using the CRT, SDKs can share the same base code when possible, improving consistency
+and throughput optimizations across AWS SDKs.
 
-The current version of the AWS CRT-based Boto3 uses the its authentication package (`aws-c-auth
-<https://github.com/awslabs/aws-c-auth>`_) to add support for CRT's new signers:
+When the AWS CRT is included, Boto3 uses it to incorporate features not otherwise
+available in the AWS SDK for Python.
 
-* **Signature Version 4** (**sigv4**) adds authentication to your AWS requests using your security
-  credentials (your AWS access key and secret access key). This signing is locked to one region
-  since the region is part of the signing criteria.
-
-* **Signature Version 4 Asymmetric** (**sigv4a** or **sigv4 asymmetric**) supports
-  region-independent services with a global endpoint.
+At this time, Boto3 uses the AWS CRT's authentication package (`aws-c-auth
+<https://github.com/awslabs/aws-c-auth>`_) to add support for the `AWS Signature Version 4
+<https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html>`_ (sigv4) signer, which
+adds authentication to your AWS requests using your security credentials (your AWS access key and
+secret access key).
 
 Boto3 doesn't use the AWS CRT by default but you can opt into using it by specifying the
 :code:`crt` `extra feature <https://www.python.org/dev/peps/pep-0508/#extras>`_ when installing Boto3::
@@ -84,6 +82,9 @@ To revert to the non-CRT version of Boto3, use this command::
 
     pip uninstall awscrt
 
+If you need to re-enable CRT,  reinstall :code:`boto3[crt]` to ensure you get a compatible version of :code:`awscrt`::
+
+    pip install boto3[crt]
 
 Configuration
 -------------

--- a/docs/source/guide/quickstart.rst
+++ b/docs/source/guide/quickstart.rst
@@ -55,6 +55,36 @@ certain versions, you may provide constraints when installing::
 
    The latest development version of Boto3 is on `GitHub <https://github.com/boto/boto3>`_.
 
+
+Using the AWS Common Runtime (CRT)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In addition to the standard version of Boto3, there's a version based on the new AWS Common Runtime
+(CRT). The AWS CRT is a collection of modular packages that serve as a new foundation for AWS
+SDKs. Each library provides good performance and minimal footprint for the functional area it
+implements. Using the CRT, SDKs can share the same base code wherever possible, allowing for better
+code reuse, optimization, and accuracy.
+
+The current version of the AWS CRT-based Boto3 uses the its authentication package (`aws-c-auth
+<https://github.com/awslabs/aws-c-auth>`_) to add support for CRT's new signers:
+
+* **Signature Version 4** (**sigv4**) adds authentication to your AWS requests using your security
+  credentials (your AWS access key and secret access key). This signing is locked to one region
+  since the region is part of the signing criteria.
+
+* **Signature Version 4 Asymmetric** (**sigv4a** or **sigv4 asymmetric**) supports
+  region-independent services with a global endpoint.
+
+Boto3 doesn't use the AWS CRT by default but you can opt into using it by specifying the
+:code:`crt` `extra feature <https://www.python.org/dev/peps/pep-0508/#extras>`_ when installing Boto3::
+
+    pip install boto3[crt]
+
+To revert to the non-CRT version of Boto3, use this command::
+
+    pip uninstall awscrt
+
+
 Configuration
 -------------
 

--- a/docs/source/guide/quickstart.rst
+++ b/docs/source/guide/quickstart.rst
@@ -58,7 +58,7 @@ certain versions, you may provide constraints when installing::
 Using the AWS Common Runtime (CRT)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In addition to the default install of Boto3, you can choose to include the new AWS Common Runtime
+In addition to the default install of Boto3, you can choose to include the new `AWS Common Runtime <https://docs.aws.amazon.com/sdkref/latest/guide/common-runtime.html>`_
 (CRT). The AWS CRT is a collection of modular packages that serve as a new foundation for AWS SDKs.
 Each library provides better performance and minimal footprint for the functional area it
 implements. Using the CRT, SDKs can share the same base code when possible, improving consistency


### PR DESCRIPTION
This update adds a section to the Quickstart page that covers  
what the AWS Common Runtime is and how to install Boto3 with it  
so that the features enabled by having CRT support in place  
can be used.