### PR TITLE
Pin jinja2 to <3.0

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,8 @@
+# Sphinx does not have an upper bound pin on jinja2, and jinja2 does
+# not have an upper bound pin on markupsafe. Since jinja2 and markupsafe
+# removed python 3.5 support we need to add our own pins.
+markupsafe>=1.1,<2.0
+jinja2>=2.3,<3.0
 Sphinx>=1.1.3,<1.3
 guzzle_sphinx_theme>=0.7.10,<0.8
 -rrequirements.txt


### PR DESCRIPTION
Jinja2 3.0 drops support for python 3.5 and Sphinx doens't have a pin.
Markupsafe was also unbounded by jinja2, which means an incompatible
version is now pulled in and we need to put a ceiling pin on that as
well.

markupsafe>=1.1,<2.0
jinja2>=2.3,<3.0