### PR TITLE
Fix DynamoDB BatchWriter dropping an item bug

### DIFF
--- a/boto3/dynamodb/table.py
+++ b/boto3/dynamodb/table.py
@@ -135,16 +135,15 @@ class BatchWriter(object):
         self._items_buffer = self._items_buffer[self._flush_amount:]
         response = self._client.batch_write_item(
             RequestItems={self._table_name: items_to_send})
-        unprocessed_items = response['UnprocessedItems']
+        unprocessed_items = response['UnprocessedItems'].get(
+            self._table_name, [])
 
-        if unprocessed_items and unprocessed_items[self._table_name]:
+        if unprocessed_items:
             # Any unprocessed_items are immediately added to the
             # next batch we send.
-            self._items_buffer.extend(unprocessed_items[self._table_name])
-        else:
-            self._items_buffer = []
+            self._items_buffer.extend(unprocessed_items)
         logger.debug("Batch write sent %s, unprocessed: %s",
-                     len(items_to_send), len(self._items_buffer))
+                     len(items_to_send), len(unprocessed_items))
 
     def __enter__(self):
         return self


### PR DESCRIPTION
I noticed that _items_buffer was set twice when BatchWriter flushed items:
first the buffer was moved past the items that were sent (according to _flush_amount),
and in the end it was emptied if sent items succeeded. This has a probably rare bug that
if a full batch of _flush_amount items was unprocessed, then the next item that triggers
flushing would be dropped as the buffer would have (_flush_amount + 1) items at that point
and the buffer would be emptied after sending the first _flush_amount items.

Added a test for the bug. Interestingly previous test "test_never_send_more_than_max_batch_size"
almost tested this but as it tested 2 unprocessed -> 1 unprocessed -> 0 unprocessed it didn't catch
this.

Also modified a little how the unprocessed items
are used so that logging number of unprocessed items is correct.

> Ensure batch writer never sends more than flush_amount
> 
> In the case where no items are processed and we received
> all the items back as unprocessed key, the next put_item
> request will have flush_amount + 1, which will trigger
> an error.
> 
> To fix this, the input_buffer is always sliced to
> flush_amount before the batch_write_item() call.

5 years ago the slicing of buffer was added, but leaving emptying the buffer after processed items.