### PR TITLE
Convert xrange to range

### DIFF
--- a/boto3/dynamodb/table.py
+++ b/boto3/dynamodb/table.py
@@ -44,7 +44,7 @@ class TableResource(object):
         Example usage::
 
             with table.batch_writer() as batch:
-                for _ in xrange(1000000):
+                for _ in range(1000000):
                     batch.put_item(Item={'HashKey': '...',
                                          'Otherstuff': '...'})
                 # You can also delete_items in a batch.


### PR DESCRIPTION
Closes #2863

`xrange` is Python2 whereas `range` is Python3.