### PR TITLE
Add missing close paren in error handling guide

### DIFF
--- a/docs/source/guide/error-handling.rst
+++ b/docs/source/guide/error-handling.rst
@@ -259,7 +259,7 @@ Using a low-level Amazon SQS client, here’s an example of catching a generic o
     queue_url = 'SQS_QUEUE_URL'
 
     try:
-        client.send_message(QueueUrl=queue_url, MessageBody=('some_message')
+        client.send_message(QueueUrl=queue_url, MessageBody=('some_message'))
 
     except botocore.exceptions.ClientError as err:
         if err.response['Error']['Code'] == 'InternalError': # Generic error


### PR DESCRIPTION
The example under "Discerning useful information from error responses" has a missing close parenthesis on the try block, leading to a syntax error when people copy and paste or otherwise try to use this code. This patch adds it.