### PR TITLE
fix sphinx-build error after docutils 0.16 is released

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -3,6 +3,8 @@
 # removed python 3.5 support we need to add our own pins.
 markupsafe>=1.1,<2.0
 jinja2>=2.3,<3.0
+# docutils needs a pin until we update to Sphinx > 3.0
+docutils<0.16
 Sphinx>=1.1.3,<1.3
 guzzle_sphinx_theme>=0.7.10,<0.8
 -rrequirements.txt


### PR DESCRIPTION
Fix for #2935.

Docutils 0.16 removed the `handle_io_errors` parameter. This patch is adapted from a similar one in [botocore/requirements-docs.txt](https://github.com/boto/botocore/blob/develop/requirements-docs.txt).