### PR TITLE
Add crt extra to Boto3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,6 @@ requires_dist =
     botocore>=1.21.5,<1.22.0
     jmespath>=0.7.1,<1.0.0
     s3transfer>=0.5.0,<0.6.0
+
+[options.extras_require]
+crt = botocore[crt]>=1.21.0,<2.0a0


### PR DESCRIPTION
Adding an extra to Boto3 as an alias down to `botocore[crt]`. This will make it easier for users to get all the dependencies they need without requiring a separately managed botocore installation.