### PR TITLE
Docs build and developer guide updates

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -4,6 +4,8 @@ Documentation for boto3 can be found `here <https://boto3.amazonaws.com/v1/docum
 
 Generating Documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~
+Note: `Botocore's <https://github.com/boto/botocore>`_ requirement-docs.txt must be installed prior to attempting the following steps.
+
 Sphinx is used for documentation. You can generate HTML locally with the
 following:
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -4,7 +4,7 @@ Documentation for boto3 can be found `here <https://boto3.amazonaws.com/v1/docum
 
 Generating Documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~
-Note: `Botocore's <https://github.com/boto/botocore>`_ requirement-docs.txt must be installed prior to attempting the following steps.
+Note: `Botocore's <https://github.com/boto/botocore/blob/develop/requirements-docs.txt>`_ requirement-docs.txt must be installed prior to attempting the following steps.
 
 Sphinx is used for documentation. You can generate HTML locally with the
 following:

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -4,7 +4,7 @@ Documentation for boto3 can be found `here <https://boto3.amazonaws.com/v1/docum
 
 Generating Documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~
-Note: `Botocore's <https://github.com/boto/botocore/blob/develop/requirements-docs.txt>`_ requirement-docs.txt must be installed prior to attempting the following steps.
+Note: Botocore's `requirement-docs.txt <https://github.com/boto/botocore/blob/develop/requirements-docs.txt>`_ must be installed prior to attempting the following steps.
 
 Sphinx is used for documentation. You can generate HTML locally with the
 following:

--- a/docs/source/guide/configuration.rst
+++ b/docs/source/guide/configuration.rst
@@ -83,6 +83,7 @@ In the following example, a proxy list is set up to use ``proxy.amazon.com``, po
 
     client = boto3.client('kinesis', config=my_config)
 
+Alternatively, you can use the ``HTTP_PROXY`` and ``HTTPS_PROXY`` environment variables to specify proxy servers and the ``NO_PROXY`` environment variable to override proxy servers set by ``HTTP_PROXY`` and  ``HTTPS_PROXY``.  Proxy servers specified using the ``Config`` object will override proxy servers specified using environment variables.
 
 .. _configure_proxies:
 

--- a/docs/source/guide/configuration.rst
+++ b/docs/source/guide/configuration.rst
@@ -83,7 +83,7 @@ In the following example, a proxy list is set up to use ``proxy.amazon.com``, po
 
     client = boto3.client('kinesis', config=my_config)
 
-Alternatively, you can use the ``HTTP_PROXY`` and ``HTTPS_PROXY`` environment variables to specify proxy servers and the ``NO_PROXY`` environment variable to override proxy servers set by ``HTTP_PROXY`` and  ``HTTPS_PROXY``.  Proxy servers specified using the ``Config`` object will override proxy servers specified using environment variables.
+Alternatively, you can use the ``HTTP_PROXY`` and ``HTTPS_PROXY`` environment variables to specify proxy servers.  The ``NO_PROXY`` environment variable can be used to override proxy servers set by ``HTTP_PROXY`` and  ``HTTPS_PROXY``.  Proxy servers specified using the ``proxies`` option in the ``Config`` object will override proxy servers specified using environment variables.
 
 .. _configure_proxies:
 


### PR DESCRIPTION
Added a note in our docs build info to inform of Botocore's requirement-docs.txt being needed to build Boto3's docs. Closes #2935.  

Added info to the proxies section of Configuration page in the developer guide that mentions a few supported environment variables that can be used to configure/specify proxies.  Closes #2936.