### PR TITLE
Rework test runners to centralized workflow

### DIFF
--- a/scripts/ci/run-crt-tests
+++ b/scripts/ci/run-crt-tests
@@ -4,6 +4,7 @@
 # binary package not from the CWD.
 
 import os
+import sys
 from subprocess import check_call
 
 _dname = os.path.dirname
@@ -16,4 +17,10 @@ def run(command):
     return check_call(command, shell=True)
 
 
-run(f"{REPO_ROOT}/scripts/ci/run-tests --with-cov integration")
+try:
+    import awscrt
+except ImportError:
+    print("MISSING DEPENDENCY: awscrt must be installed to run the crt tests.")
+    sys.exit(1)
+
+run(f'{REPO_ROOT}/scripts/ci/run-tests unit/ functional/')

--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -3,19 +3,58 @@
 # We want to ensure we're importing from the installed
 # binary package not from the CWD.
 
+import argparse
 import os
-import sys
 from subprocess import check_call
 
 _dname = os.path.dirname
 
 REPO_ROOT = _dname(_dname(_dname(os.path.abspath(__file__))))
-os.chdir(os.path.join(REPO_ROOT, 'tests'))
+PACKAGE = "boto3"
+os.chdir(os.path.join(REPO_ROOT, "tests"))
 
-args = sys.argv[1:]
-if not args:
-    args = ['unit/', 'functional/']
 
-check_call(['nosetests', '--with-coverage', '--cover-erase',
-            '--cover-package', 'boto3', '--with-xunit', '--cover-xml',
-            '-v'] + args)
+def run(command):
+    return check_call(command, shell=True)
+
+
+def process_args(args):
+    runner = args.test_runner
+    test_args = ''
+    if args.with_cov:
+        test_args += (
+            f"--with-xunit --cover-erase --with-coverage "
+            f"--cover-package {PACKAGE} --cover-xml -v "
+        )
+    dirs = " ".join(args.test_dirs)
+
+    return runner, test_args, dirs
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "test_dirs",
+        default=["unit/", "functional/"],
+        nargs="*",
+        help="One or more directories containing tests.",
+    )
+    parser.add_argument(
+        "-r",
+        "--test-runner",
+        default="nosetests",
+        help="Test runner to execute tests. Defaults to nose.",
+    )
+    parser.add_argument(
+        "-c",
+        "--with-cov",
+        default=False,
+        action="store_true",
+        help="Run default test-runner with code coverage enabled.",
+    )
+    raw_args = parser.parse_args()
+    test_runner, test_args, test_dirs = process_args(raw_args)
+
+    cmd = f"{test_runner} {test_args}{test_dirs}"
+    print(f"Running {cmd}...")
+    run(cmd)


### PR DESCRIPTION
This is part of a series of PRs to standardize our test runner scripts for CI across the boto repos. This will work as a stepping block to getting us migrated to arbitrary test runners such as `pytest` that can be used on a per project basis.