### PR TITLE
Add composite alarms (cloudwatch resources)

### DIFF
--- a/boto3/data/cloudwatch/2010-08-01/resources-1.json
+++ b/boto3/data/cloudwatch/2010-08-01/resources-1.json
@@ -37,10 +37,10 @@
                         {
                             "target": "Name",
                             "source": "response",
-                            "path": "MetricAlarms[].AlarmName"
+                            "path": "[MetricAlarms[], CompositeAlarms[]][].AlarmName"
                         }
                     ],
-                    "path": "MetricAlarms[]"
+                    "path": "[MetricAlarms[], CompositeAlarms[]][]"
                 }
             },
             "Metrics": {

--- a/boto3/data/cloudwatch/2010-08-01/resources-1.json
+++ b/boto3/data/cloudwatch/2010-08-01/resources-1.json
@@ -81,10 +81,20 @@
                             "target": "AlarmNames[0]",
                             "source": "identifier",
                             "name": "Name"
+                        },
+                        {
+                            "target": "AlarmTypes[0]",
+                            "source": "string",
+                            "value": "MetricAlarm"
+                        },
+                        {
+                            "target": "AlarmTypes[1]",
+                            "source": "string",
+                            "value": "CompositeAlarm"
                         }
                     ]
                 },
-                "path": "MetricAlarms[0]"
+                "path": "MetricAlarms[0] || CompositeAlarms[0]"
             },
             "actions": {
                 "Delete": {


### PR DESCRIPTION
Closes https://github.com/boto/boto3/issues/2610.  

Although the `.all`collections action does not return composite alarms.  The [`describe_alarms` operation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudwatch.html#CloudWatch.Client.describe_alarms) only returns composite alarms when an `AlarmTypes` value of `CompositeAlarm` is provided, and I'm not aware of a way we can provide constant values (`CompositeAlarm` and `MetricAlarm` would be needed) for arguments based on the collection action being used.  This does return all alarms if the `.filter` action is used to specify both alarm types.  

For loading a single `Alarm` resource, constant values for `AlarmTypes` (both `CompositeAlarm` and `MetricAlarm`) are provided, as the lookup is done by name and alarm names cannot be duplicated across alarm types.

Resource actions work fine as well— we use the name as an identifier, and  [`delete_alarms`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudwatch.html#CloudWatch.Client.delete_alarms), [`describe_alarm_history`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudwatch.html#CloudWatch.Client.describe_alarm_history), [`disable_alarm_actions`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudwatch.html#CloudWatch.Client.disable_alarm_actions), [`enable_alarm_actions`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudwatch.html#CloudWatch.Client.enable_alarm_actions) and [`set_alarm_state`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudwatch.html#CloudWatch.Client.set_alarm_state) can all be used with composite alarms.

