### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
         os: [ubuntu-latest, macOS-latest, windows-latest ]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
     project_urls={
         'Documentation': 'https://boto3.amazonaws.com/v1/documentation/api/latest/index.html',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39
+envlist = py36,py37,py38,py39,py310
 
 # Comment to build sdist and install into virtualenv
 # This is helpful to test installation but takes extra time


### PR DESCRIPTION
This PR will start testing us on what is hopefully the final release candidate for Python 3.10. Release is currently scheduled for October 4th, so we'll start regularly testing now to make sure things remaining functioning smoothly.