### PR TITLE
Remove CHANGELOG from linting check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: ^(.github|.changes|docs/|boto3/compat.py|boto3/data)
+exclude: ^(.github|.changes|docs/|boto3/compat.py|boto3/data|CHANGELOG.rst)
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0


### PR DESCRIPTION
We're automatically adding an extra newline at the end of CHANGELOG.rst during each release. This is causing failures in our linter, so we'll ignore the file for now until that can be fixed.