### PR TITLE
Add max_bandwidth to TransferConfig

### DIFF
--- a/.changes/next-release/enchancement-s3-6820.json
+++ b/.changes/next-release/enchancement-s3-6820.json
@@ -1,0 +1,5 @@
+{
+  "type": "enchancement",
+  "category": "``s3``",
+  "description": "TransferConfig now supports the `max_bandwidth` argument."
+}

--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -166,14 +166,17 @@ class TransferConfig(S3TransferConfig):
         'max_io_queue': 'max_io_queue_size'
     }
 
-    def __init__(self,
-                 multipart_threshold=8 * MB,
-                 max_concurrency=10,
-                 multipart_chunksize=8 * MB,
-                 num_download_attempts=5,
-                 max_io_queue=100,
-                 io_chunksize=256 * KB,
-                 use_threads=True):
+    def __init__(
+        self,
+        multipart_threshold=8 * MB,
+        max_concurrency=10,
+        multipart_chunksize=8 * MB,
+        num_download_attempts=5,
+        max_io_queue=100,
+        io_chunksize=256 * KB,
+        use_threads=True,
+        max_bandwidth=None,
+    ):
         """Configuration object for managed S3 transfers
 
         :param multipart_threshold: The transfer size threshold for which
@@ -209,6 +212,10 @@ class TransferConfig(S3TransferConfig):
         :param use_threads: If True, threads will be used when performing
             S3 transfers. If False, no threads will be used in
             performing transfers: all logic will be ran in the main thread.
+
+        :param max_bandwidth: The maximum bandwidth that will be consumed
+            in uploading and downloading file content. The value is an integer
+            in terms of bytes per second.
         """
         super(TransferConfig, self).__init__(
             multipart_threshold=multipart_threshold,
@@ -217,6 +224,7 @@ class TransferConfig(S3TransferConfig):
             num_download_attempts=num_download_attempts,
             max_io_queue_size=max_io_queue,
             io_chunksize=io_chunksize,
+            max_bandwidth=max_bandwidth,
         )
         # Some of the argument names are not the same as the inherited
         # S3TransferConfig so we add aliases so you can still access the

--- a/tests/unit/s3/test_transfer.py
+++ b/tests/unit/s3/test_transfer.py
@@ -23,6 +23,7 @@ from boto3.s3.transfer import create_transfer_manager
 from boto3.s3.transfer import S3Transfer
 from boto3.s3.transfer import OSUtils, TransferConfig, ProgressCallbackInvoker
 from boto3.s3.transfer import ClientError, S3TransferRetriesExceededError
+from boto3.s3.transfer import KB, MB
 
 
 class TestCreateTransferManager(unittest.TestCase):
@@ -82,6 +83,26 @@ class TestTransferConfig(unittest.TestCase):
         # value that will be used in the TransferManager
         self.assert_value_of_actual_and_alias(
             config, 'max_io_queue_size', 'max_io_queue', new_value)
+
+    def test_transferconfig_parameters(self):
+        config = TransferConfig(
+            multipart_threshold=8 * MB,
+            max_concurrency=10,
+            multipart_chunksize=8 * MB,
+            num_download_attempts=5,
+            max_io_queue=100,
+            io_chunksize=256 * KB,
+            use_threads=True,
+            max_bandwidth=1024 * KB,
+        )
+        assert config.multipart_threshold == 8 * MB
+        assert config.multipart_chunksize == 8 * MB
+        assert config.max_request_concurrency == 10
+        assert config.num_download_attempts == 5
+        assert config.max_io_queue_size == 100
+        assert config.io_chunksize == 256 * KB
+        assert config.use_threads is True
+        assert config.max_bandwidth == 1024 * KB
 
 
 class TestProgressCallbackInvoker(unittest.TestCase):


### PR DESCRIPTION
This PR should address #1430 by adding a `max_bandwidth` argument to Boto3's `TransferConfig` wrapper class. This will allow direct support for forwarding the parameter down to s3 with additional work arounds.