### PR TITLE
Add get_partition_for_region to Session

### DIFF
--- a/.changes/next-release/enhancement-Session-24336.json
+++ b/.changes/next-release/enhancement-Session-24336.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Session",
+  "description": "Added `get_partition_for_region` to lookup partition for a given region_name"
+}

--- a/boto3/session.py
+++ b/boto3/session.py
@@ -182,6 +182,18 @@ class Session(object):
         """
         return self._session.get_credentials()
 
+    def get_partition_for_region(self, region_name):
+        """Lists the partition name of a particular region.
+
+        :type region_name: string
+        :param region_name: Name of the region to list partition for (e.g.,
+             us-east-1).
+
+        :rtype: string
+        :return: Returns the respective partition name (e.g., aws).
+        """
+        return self._session.get_partition_for_region(region_name)
+
     def client(self, service_name, region_name=None, api_version=None,
                use_ssl=True, verify=None, endpoint_url=None,
                aws_access_key_id=None, aws_secret_access_key=None,

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -207,6 +207,17 @@ class TestSession(BaseTestCase):
         )
         assert partitions == ['foo']
 
+    def test_get_partition_for_region(self):
+        bc_session = mock.Mock()
+        bc_session.get_partition_for_region.return_value = 'baz'
+        session = Session(botocore_session=bc_session)
+
+        partition = session.get_partition_for_region('foo-bar-1')
+        bc_session.get_partition_for_region.assert_called_with(
+            'foo-bar-1'
+        )
+        assert partition == 'baz'
+
     def test_create_client(self):
         session = Session(region_name='us-east-1')
         client = session.client('sqs', region_name='us-west-2')


### PR DESCRIPTION
Following up on boto/botocore#1715 to surface `get_partition_for_region` on the Boto3 session as well.