### PR TITLE
Minor tweak to boto3 usecase in the readme file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,8 @@ Then, from a Python interpreter:
     >>> for bucket in s3.buckets.all():
             print(bucket.name)
 
+Press  ``Shift+Enter`` to end the for loop. The new line should print the output, i.e., names of all the s3 buckets available.  
+
 Running Tests
 ~~~~~~~~~~~~~
 You can run tests in all supported Python versions using ``tox``. By default,


### PR DESCRIPTION
Hi, I am suggesting a slight change in the project `README.rst` file to make the existing `boto3` use-case even more beginner friendly. It already is pretty straightforward, but I think adding a next step that explains how to end the `for loop` by using `shift + Enter` will make following those instructions more convenient for someone who may not be very familiar with running loops and functions in the interpreter. 

@kellertk @kdaily @tim-finnigan Ptal, and share your feedback. 