### PR TITLE
apigatewaymanagementapi constructor example added #1914

### DIFF
--- a/boto3/docs/client.py
+++ b/boto3/docs/client.py
@@ -20,6 +20,12 @@ class Boto3ClientDocumenter(ClientDocumenter):
         section.write('import boto3')
         section.style.new_line()
         section.style.new_line()
+        if self._service_name == 'apigatewaymanagementapi':
+            section.write(
+                'client = boto3.client(\'apigatewaymanagementapi\', endpoint_url=\'https://{api_id}.execute-api.{region}.amazonaws.com/{stage}\')'
+            )
+            section.style.end_codeblock()
+            return
         section.write(
             'client = boto3.client(\'{service}\')'.format(
                 service=self._service_name)


### PR DESCRIPTION
fixes #1914

There's a shoutout that the documentation contains it in an above example, but it isn't easily skimmable.
Feels a little ugly to hardcode it in there. Thought I'd just throw a PR for a naive solution since it's really a really niche error that burned me for a while.