### PR TITLE
Fix typo in docstring Session get_credential

### DIFF
--- a/boto3/session.py
+++ b/boto3/session.py
@@ -174,7 +174,7 @@ class Session(object):
 
     def get_credentials(self):
         """
-        Return the :class:`botocore.credential.Credential` object
+        Return the :class:`botocore.credentials.Credentials` object
         associated with this session.  If the credentials have not
         yet been loaded, this will attempt to load them.  If they
         have already been loaded, this will return the cached


### PR DESCRIPTION
The object is called botocore.credentials.Credentials. 

"s" are missing: https://github.com/boto/botocore/blob/1.23.52/botocore/credentials.py