### PR TITLE
Update 3.6 deprecation notice with blog post

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,12 +15,15 @@ Boto3 is maintained and published by `Amazon Web Services`_.
 Notices
 -------
 
-On 01/15/2021 deprecation for Python 2.7 was announced and support was dropped
-on 07/15/2021. To avoid disruption, customers using Boto3 on Python 2.7 may
+On 2021-01-15, deprecation for Python 2.7 was announced and support was dropped
+on 2021-07-15. To avoid disruption, customers using Boto3 on Python 2.7 may
 need to upgrade their version of Python or pin the version of Boto3. For
 more information, see this `blog post <https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/>`__.
 
-Starting in May 2022, we will be dropping support for Python 3.6. This follows the Python Software Foundation `end of support <https://www.python.org/dev/peps/pep-0494/#lifespan>`__ for the runtime which occurred on 2021-12-23.
+On 2022-05-30, we will be dropping support for Python 3.6. This follows the
+Python Software Foundation `end of support <https://www.python.org/dev/peps/pep-0494/#lifespan>`__
+for the runtime which occurred on 2021-12-23.
+For more information, see this `blog post <https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/>`__.
 
 .. _boto: https://docs.pythonboto.org/
 .. _`doc site`: https://boto3.amazonaws.com/v1/documentation/api/latest/index.html


### PR DESCRIPTION
Adding link to [blog post](https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/) and cleaning up date format mismatches from previous campaigns.