### PR TITLE
Fix f-strings missed by pyupgrade

### DIFF
--- a/boto3/docs/action.py
+++ b/boto3/docs/action.py
@@ -150,10 +150,9 @@ def document_load_reload_action(
         It is useful for generating docstrings.
     """
     description = (
-        'Calls  :py:meth:`%s.Client.%s` to update the attributes of the'
-        ' %s resource. Note that the load and reload methods are '
-        'the same method and can be used interchangeably.'
-        % (
+        'Calls :py:meth:`{}.Client.{}` to update the attributes of the '
+        '{} resource. Note that the load and reload methods are '
+        'the same method and can be used interchangeably.'.format(
             get_service_module_name(service_model),
             xform_name(load_model.request.operation),
             resource_name,

--- a/boto3/docs/attr.py
+++ b/boto3/docs/attr.py
@@ -49,15 +49,14 @@ def document_identifier(
     description = get_identifier_description(
         resource_name, identifier_model.name
     )
-    description = '*(string)* ' + description
-    section.write(description)
+    section.write(f'*(string)* {description}')
 
 
 def document_reference(section, reference_model, include_signature=True):
     if include_signature:
         section.style.start_sphinx_py_attr(reference_model.name)
-    reference_type = '(:py:class:`%s`) ' % reference_model.resource.type
+    reference_type = f'(:py:class:`{reference_model.resource.type}`) '
     section.write(reference_type)
     section.include_doc_string(
-        'The related %s if set, otherwise ``None``.' % reference_model.name
+        f'The related {reference_model.name} if set, otherwise ``None``.'
     )

--- a/boto3/docs/collection.py
+++ b/boto3/docs/collection.py
@@ -87,12 +87,12 @@ def document_collection_object(
     if include_signature:
         section.style.start_sphinx_py_attr(collection_model.name)
     section.include_doc_string(
-        'A collection of %s resources.' % collection_model.resource.type
+        f'A collection of {collection_model.resource.type} resources.'
     )
     section.include_doc_string(
-        'A %s Collection will include all resources by default, '
-        'and extreme caution should be taken when performing '
-        'actions on all resources.' % collection_model.resource.type
+        f'A {collection_model.resource.type} Collection will include all '
+        f'resources by default, and extreme caution should be taken when '
+        f'performing actions on all resources.'
     )
 
 
@@ -200,8 +200,8 @@ def document_collection_method(
     custom_action_info_dict = {
         'all': {
             'method_description': (
-                'Creates an iterable of all %s resources '
-                'in the collection.' % collection_model.resource.type
+                f'Creates an iterable of all {collection_model.resource.type} '
+                f'resources in the collection.'
             ),
             'example_prefix': '{}_iterator = {}.{}.all'.format(
                 xform_name(collection_model.resource.type),
@@ -212,16 +212,12 @@ def document_collection_method(
         },
         'filter': {
             'method_description': (
-                'Creates an iterable of all %s resources '
-                'in the collection filtered by kwargs passed to '
-                'method. A %s collection will include all resources by '
-                'default if no filters are provided, and extreme '
-                'caution should be taken when performing actions '
-                'on all resources.'
-                % (
-                    collection_model.resource.type,
-                    collection_model.resource.type,
-                )
+                f'Creates an iterable of all {collection_model.resource.type} '
+                f'resources in the collection filtered by kwargs passed to '
+                f'method. A {collection_model.resource.type} collection will '
+                f'include all resources by default if no filters are provided, '
+                f'and extreme caution should be taken when performing actions '
+                f'on all resources.'
             ),
             'example_prefix': '{}_iterator = {}.{}.filter'.format(
                 xform_name(collection_model.resource.type),
@@ -234,9 +230,8 @@ def document_collection_method(
         },
         'limit': {
             'method_description': (
-                'Creates an iterable up to a specified amount of '
-                '%s resources in the collection.'
-                % collection_model.resource.type
+                f'Creates an iterable up to a specified amount of '
+                f'{collection_model.resource.type} resources in the collection.'
             ),
             'example_prefix': '{}_iterator = {}.{}.limit'.format(
                 xform_name(collection_model.resource.type),
@@ -257,10 +252,9 @@ def document_collection_method(
         },
         'page_size': {
             'method_description': (
-                'Creates an iterable of all %s resources '
-                'in the collection, but limits the number of '
-                'items returned by each service call by the specified '
-                'amount.' % collection_model.resource.type
+                f'Creates an iterable of all {collection_model.resource.type} '
+                f'resources in the collection, but limits the number of '
+                f'items returned by each service call by the specified amount.'
             ),
             'example_prefix': '{}_iterator = {}.{}.page_size'.format(
                 xform_name(collection_model.resource.type),
@@ -288,5 +282,5 @@ def document_collection_method(
             event_emitter=event_emitter,
             resource_action_model=collection_model,
             include_signature=include_signature,
-            **action_info
+            **action_info,
         )

--- a/boto3/docs/method.py
+++ b/boto3/docs/method.py
@@ -56,17 +56,17 @@ def document_model_driven_resource_method(
             operation_model.service_model.service_name, resource_type
         )
 
-        return_type = ':py:class:`%s`' % return_resource_type
-        return_description = '%s resource' % (resource_type)
+        return_type = f':py:class:`{return_resource_type}`'
+        return_description = f'{resource_type} resource'
 
         if _method_returns_resource_list(resource_action_model.resource):
-            return_type = 'list(%s)' % return_type
-            return_description = 'A list of %s resources' % (resource_type)
+            return_type = f'list({return_type})'
+            return_description = f'A list of {resource_type} resources'
 
         new_return_section.style.new_line()
-        new_return_section.write(':rtype: %s' % return_type)
+        new_return_section.write(f':rtype: {return_type}')
         new_return_section.style.new_line()
-        new_return_section.write(':returns: %s' % return_description)
+        new_return_section.write(f':returns: {return_description}')
         new_return_section.style.new_line()
 
 

--- a/boto3/docs/resource.py
+++ b/boto3/docs/resource.py
@@ -113,7 +113,7 @@ class ResourceDocumenter(BaseDocumenter):
             description = get_identifier_description(
                 self._resource_name, identifier_name
             )
-            section.write(':type %s: string' % identifier_name)
+            section.write(f':type {identifier_name}: string')
             section.style.new_line()
             section.write(f':param {identifier_name}: {description}')
             section.style.new_line()
@@ -122,20 +122,19 @@ class ResourceDocumenter(BaseDocumenter):
         for resource_member_type in self.member_map:
             section.style.new_line()
             section.write(
-                'These are the resource\'s available %s:'
-                % (resource_member_type)
+                f'These are the resource\'s available {resource_member_type}:'
             )
             section.style.new_line()
             for member in self.member_map[resource_member_type]:
-                if resource_member_type in [
-                    'identifiers',
+                if resource_member_type in (
                     'attributes',
-                    'references',
                     'collections',
-                ]:
-                    section.style.li(':py:attr:`%s`' % member)
+                    'identifiers',
+                    'references',
+                ):
+                    section.style.li(f':py:attr:`{member}`')
                 else:
-                    section.style.li(':py:meth:`%s()`' % member)
+                    section.style.li(f':py:meth:`{member}()`')
 
     def _add_identifiers(self, section):
         identifiers = self._resource.meta.resource_model.identifiers
@@ -262,14 +261,14 @@ class ResourceDocumenter(BaseDocumenter):
 class ServiceResourceDocumenter(ResourceDocumenter):
     @property
     def class_name(self):
-        return '%s.ServiceResource' % self._service_docs_name
+        return f'{self._service_docs_name}.ServiceResource'
 
     def _add_title(self, section):
         section.style.h2('Service Resource')
 
     def _add_description(self, section):
         official_service_name = get_official_service_name(self._service_model)
-        section.write('A resource representing %s' % official_service_name)
+        section.write(f'A resource representing {official_service_name}')
 
     def _add_example(self, section, identifier_names):
         section.style.start_codeblock()
@@ -278,8 +277,6 @@ class ServiceResourceDocumenter(ResourceDocumenter):
         section.style.new_line()
         section.style.new_line()
         section.write(
-            '{} = boto3.resource(\'{}\')'.format(
-                self._service_name, self._service_name
-            )
+            f'{self._service_name} = boto3.resource(\'{self._service_name}\')'
         )
         section.style.end_codeblock()

--- a/boto3/docs/subresource.py
+++ b/boto3/docs/subresource.py
@@ -83,7 +83,7 @@ def document_sub_resource(
         )
 
     method_intro_section = section.add_new_section('method-intro')
-    description = 'Creates a %s resource.' % sub_resource_model.resource.type
+    description = f'Creates a {sub_resource_model.resource.type} resource.'
     method_intro_section.include_doc_string(description)
     example_section = section.add_new_section('example')
     example_values = get_identifier_values_for_example(identifiers_needed)
@@ -105,7 +105,7 @@ def document_sub_resource(
         description = get_identifier_description(
             sub_resource_model.name, identifier
         )
-        param_section.write(':type %s: string' % identifier)
+        param_section.write(f':type {identifier}: string')
         param_section.style.new_line()
         param_section.write(f':param {identifier}: {description}')
         param_section.style.new_line()
@@ -120,6 +120,6 @@ def document_sub_resource(
     )
     return_section.style.new_line()
     return_section.write(
-        ':returns: A %s resource' % sub_resource_model.resource.type
+        f':returns: A {sub_resource_model.resource.type} resource'
     )
     return_section.style.new_line()

--- a/boto3/docs/utils.py
+++ b/boto3/docs/utils.py
@@ -53,8 +53,7 @@ def get_resource_public_actions(resource_class):
 
 
 def get_identifier_values_for_example(identifier_names):
-    example_values = ['\'%s\'' % identifier for identifier in identifier_names]
-    return ','.join(example_values)
+    return ','.join([f'\'{identifier}\'' for identifier in identifier_names])
 
 
 def get_identifier_args_for_signature(identifier_names):
@@ -62,8 +61,9 @@ def get_identifier_args_for_signature(identifier_names):
 
 
 def get_identifier_description(resource_name, identifier_name):
-    return "The {}'s {} identifier. This **must** be set.".format(
-        resource_name, identifier_name
+    return (
+        f"The {resource_name}'s {identifier_name} identifier. "
+        f"This **must** be set."
     )
 
 
@@ -81,9 +81,8 @@ def add_resource_type_overview(
     section.style.new_line()
     if intro_link is not None:
         section.write(
-            'For more information about %s refer to the '
-            ':ref:`Resources Introduction Guide<%s>`.'
-            % (resource_type.lower(), intro_link)
+            f'For more information about {resource_type.lower()} refer to the '
+            f':ref:`Resources Introduction Guide<{intro_link}>`.'
         )
         section.style.new_line()
 
@@ -122,16 +121,17 @@ class DocumentModifiedShape:
         if event_name.startswith(
             'docs.request-params'
         ) or event_name.startswith('docs.response-params'):
+            allowed_sections = (
+                'param-name',
+                'param-documentation',
+                'end-structure',
+                'param-type',
+                'end-param',
+            )
             for section_name in section.available_sections:
                 # Delete any extra members as a new shape is being
                 # used.
-                if section_name not in [
-                    'param-name',
-                    'param-documentation',
-                    'end-structure',
-                    'param-type',
-                    'end-param',
-                ]:
+                if section_name not in allowed_sections:
                     section.delete_section(section_name)
 
             # Update the documentation
@@ -146,4 +146,4 @@ class DocumentModifiedShape:
                 type_section.write(f':type {section.name}: {self._new_type}')
             else:
                 type_section.clear_text()
-                type_section.style.italics('(%s) -- ' % self._new_type)
+                type_section.style.italics(f'({self._new_type}) -- ')

--- a/boto3/docs/waiter.py
+++ b/boto3/docs/waiter.py
@@ -69,12 +69,11 @@ def document_resource_waiter(
     ignore_params = get_resource_ignore_params(resource_waiter_model.params)
     service_module_name = get_service_module_name(service_model)
     description = (
-        'Waits until this %s is %s. This method calls '
-        ':py:meth:`%s.Waiter.%s.wait` which polls. '
-        ':py:meth:`%s.Client.%s` every %s seconds until '
+        'Waits until this {} is {}. This method calls '
+        ':py:meth:`{}.Waiter.{}.wait` which polls. '
+        ':py:meth:`{}.Client.{}` every {} seconds until '
         'a successful state is reached. An error is returned '
-        'after %s failed checks.'
-        % (
+        'after {} failed checks.'.format(
             resource_name,
             ' '.join(resource_waiter_model.name.split('_')[2:]),
             service_module_name,

--- a/boto3/dynamodb/conditions.py
+++ b/boto3/dynamodb/conditions.py
@@ -406,9 +406,9 @@ class ConditionExpressionBuilder:
         elif isinstance(value, AttributeBase):
             if is_key_condition and not isinstance(value, Key):
                 raise DynamoDBNeedsKeyConditionError(
-                    'Attribute object %s is of type %s. '
-                    'KeyConditionExpression only supports Attribute objects '
-                    'of type Key' % (value.name, type(value))
+                    f'Attribute object {value.name} is of type {type(value)}. '
+                    f'KeyConditionExpression only supports Attribute objects '
+                    f'of type Key'
                 )
             return self._build_name_placeholder(
                 value, attribute_name_placeholders

--- a/boto3/dynamodb/transform.py
+++ b/boto3/dynamodb/transform.py
@@ -282,8 +282,8 @@ class ParameterTransformer:
         self, model, params, transformation, target_shape
     ):
         type_name = model.type_name
-        if type_name in ['structure', 'map', 'list']:
-            getattr(self, '_transform_%s' % type_name)(
+        if type_name in ('structure', 'map', 'list'):
+            getattr(self, f'_transform_{type_name}')(
                 model, params, transformation, target_shape
             )
 

--- a/boto3/dynamodb/types.py
+++ b/boto3/dynamodb/types.py
@@ -54,10 +54,8 @@ class Binary:
 
     def __init__(self, value):
         if not isinstance(value, BINARY_TYPES):
-            raise TypeError(
-                'Value must be of the following types: %s.'
-                % ', '.join([str(t) for t in BINARY_TYPES])
-            )
+            types = ', '.join([str(t) for t in BINARY_TYPES])
+            raise TypeError(f'Value must be of the following types: {types}')
         self.value = value
 
     def __eq__(self, other):
@@ -69,7 +67,7 @@ class Binary:
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'Binary(%r)' % self.value
+        return f'Binary({self.value!r})'
 
     def __str__(self):
         return self.value
@@ -113,7 +111,7 @@ class TypeSerializer:
             dictionaries can be directly passed to botocore methods.
         """
         dynamodb_type = self._get_dynamodb_type(value)
-        serializer = getattr(self, '_serialize_%s' % dynamodb_type.lower())
+        serializer = getattr(self, f'_serialize_{dynamodb_type}'.lower())
         return {dynamodb_type: serializer(value)}
 
     def _get_dynamodb_type(self, value):
@@ -274,12 +272,10 @@ class TypeDeserializer:
         dynamodb_type = list(value.keys())[0]
         try:
             deserializer = getattr(
-                self, '_deserialize_%s' % dynamodb_type.lower()
+                self, f'_deserialize_{dynamodb_type}'.lower()
             )
         except AttributeError:
-            raise TypeError(
-                'Dynamodb type %s is not supported' % dynamodb_type
-            )
+            raise TypeError(f'Dynamodb type {dynamodb_type} is not supported')
         return deserializer(value[dynamodb_type])
 
     def _deserialize_null(self, value):

--- a/boto3/exceptions.py
+++ b/boto3/exceptions.py
@@ -40,9 +40,8 @@ class UnknownAPIVersionError(
 ):
     def __init__(self, service_name, bad_api_version, available_api_versions):
         msg = (
-            "The '%s' resource does not an API version of: %s\n"
-            "Valid API versions are: %s"
-            % (service_name, bad_api_version, available_api_versions)
+            f"The '{service_name}' resource does not an API version of: {bad_api_version}\n"
+            f"Valid API versions are: {available_api_versions}"
         )
         # Not using super because we don't want the DataNotFoundError
         # to be called, it has a different __init__ signature.
@@ -56,14 +55,16 @@ class ResourceNotExistsError(
 
     def __init__(self, service_name, available_services, has_low_level_client):
         msg = (
-            "The '%s' resource does not exist.\n"
+            "The '{}' resource does not exist.\n"
             "The available resources are:\n"
-            "   - %s\n" % (service_name, '\n   - '.join(available_services))
+            "   - {}\n".format(
+                service_name, '\n   - '.join(available_services)
+            )
         )
         if has_low_level_client:
-            msg += (
-                "\nConsider using a boto3.client('%s') instead "
-                "of a resource for '%s'" % (service_name, service_name)
+            msg = (
+                f"{msg}\nConsider using a boto3.client('{service_name}') "
+                f"instead of a resource for '{service_name}'"
             )
         # Not using super because we don't want the DataNotFoundError
         # to be called, it has a different __init__ signature.
@@ -89,10 +90,9 @@ class DynamoDBOperationNotSupportedError(Boto3Error):
 
     def __init__(self, operation, value):
         msg = (
-            '%s operation cannot be applied to value %s of type %s directly. '
-            'Must use AttributeBase object methods (i.e. Attr().eq()). to '
-            'generate ConditionBase instances first.'
-            % (operation, value, type(value))
+            f'{operation} operation cannot be applied to value {value} of type '
+            f'{type(value)} directly. Must use AttributeBase object methods '
+            f'(i.e. Attr().eq()). to generate ConditionBase instances first.'
         )
         Exception.__init__(self, msg)
 
@@ -106,9 +106,9 @@ class DynamoDBNeedsConditionError(Boto3Error):
 
     def __init__(self, value):
         msg = (
-            'Expecting a ConditionBase object. Got %s of type %s. '
-            'Use AttributeBase object methods (i.e. Attr().eq()). to '
-            'generate ConditionBase instances.' % (value, type(value))
+            f'Expecting a ConditionBase object. Got {value} of type {type(value)}. '
+            f'Use AttributeBase object methods (i.e. Attr().eq()). to '
+            f'generate ConditionBase instances.'
         )
         Exception.__init__(self, msg)
 

--- a/boto3/resources/factory.py
+++ b/boto3/resources/factory.py
@@ -150,7 +150,7 @@ class ResourceFactory:
         base_classes = [ServiceResource]
         if self._emitter is not None:
             self._emitter.emit(
-                'creating-resource-class.%s' % cls_name,
+                f'creating-resource-class.{cls_name}',
                 class_attributes=attrs,
                 base_classes=base_classes,
                 service_context=service_context,

--- a/boto3/utils.py
+++ b/boto3/utils.py
@@ -72,8 +72,8 @@ def lazy_call(full_name, **kwargs):
 def inject_attribute(class_attributes, name, value):
     if name in class_attributes:
         raise RuntimeError(
-            'Cannot inject class attribute "%s", attribute '
-            'already exists in class dict.' % name
+            f'Cannot inject class attribute "{name}", attribute '
+            f'already exists in class dict.'
         )
     else:
         class_attributes[name] = value


### PR DESCRIPTION
This is a follow up from #3041, doing clean up on some `%` format strings, moving them to either use `format` or f-strings.