### PR TITLE
Fix ExtraArgs supported by Bucket.copy

### DIFF
--- a/boto3/s3/inject.py
+++ b/boto3/s3/inject.py
@@ -407,7 +407,7 @@ def copy(
     :type ExtraArgs: dict
     :param ExtraArgs: Extra arguments that may be passed to the
         client operation. For allowed download arguments see
-        boto3.s3.transfer.S3Transfer.ALLOWED_DOWNLOAD_ARGS.
+        boto3.s3.transfer.S3Transfer.ALLOWED_COPY_ARGS.
 
     :type Callback: function
     :param Callback: A method which takes a number of bytes transferred to


### PR DESCRIPTION
Fixes https://github.com/boto/boto3/issues/3163