### PR TITLE
Update get_available_regions documentation

### DIFF
--- a/boto3/session.py
+++ b/boto3/session.py
@@ -166,6 +166,11 @@ class Session:
     ):
         """Lists the region and endpoint names of a particular partition.
 
+        The list of regions returned by this method are regions that are
+        explicitly known by the client to exist and is not comprehensive. A
+        region not returned in this list may still be available for the
+        provided service.
+
         :type service_name: string
         :param service_name: Name of a service to list endpoint for (e.g., s3).
 


### PR DESCRIPTION
Adds some clarification to the `get_available_regions` method to ensure it's clear that the function may not return all supported regions.