### PR TITLE
Add support for jmespath 1.0

### DIFF
--- a/.changes/next-release/enhancement-Dependency-73732.json
+++ b/.changes/next-release/enhancement-Dependency-73732.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Dependency",
+  "description": "Added support for jmespath 1.0"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 -e git+https://github.com/boto/botocore.git@develop#egg=botocore
--e git+https://github.com/boto/jmespath.git@develop#egg=jmespath
+-e 'git+https://github.com/boto/jmespath.git@develop#egg=jmespath; python_version > "3.6"'
+jmespath<1.0; python_version <= '3.6'
 -e git+https://github.com/boto/s3transfer.git@develop#egg=s3transfer

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ universal = 0
 [metadata]
 requires_dist =
     botocore>=1.24.20,<1.25.0
-    jmespath>=0.7.1,<1.0.0
+    jmespath>=0.7.1,<2.0.0
     s3transfer>=0.5.0,<0.6.0
 
 [options.extras_require]

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ VERSION_RE = re.compile(r'''__version__ = ['"]([0-9.]+)['"]''')
 
 requires = [
     'botocore>=1.24.20,<1.25.0',
-    'jmespath>=0.7.1,<1.0.0',
+    'jmespath>=0.7.1,<2.0.0',
     's3transfer>=0.5.0,<0.6.0',
 ]
 


### PR DESCRIPTION
jmespath released 1.0 today. We'll add support since our [`requirements.txt`](https://github.com/boto/boto3/blob/develop/requirements.txt) still pulls directly from the head of their develop branch.