### PR TITLE
Fix first code block in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,8 @@ Getting Started
 Assuming that you have a supported version of Python installed, you can first
 set up your environment with:
 
-..code-block:: sh
+.. code-block:: sh
+
     $ python -m venv .venv
     ...
     $ . .venv/bin/activate


### PR DESCRIPTION
Adds missing space and blank line to get code block highlighted correctly.

Issue introduced in #3188.