### PR TITLE
Update black to 22.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: isort
   - repo: 'https://github.com/psf/black'
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: 'https://github.com/pycqa/flake8'


### PR DESCRIPTION
Fix the[ import issues](https://github.com/boto/boto3/runs/5822373922?check_suite_focus=true) with the most recent release of click