### PR TITLE
Fix example for ExposeHeaders

### DIFF
--- a/docs/source/guide/s3-example-configuring-buckets.rst
+++ b/docs/source/guide/s3-example-configuring-buckets.rst
@@ -68,7 +68,7 @@ method.
             'AllowedHeaders': ['Authorization'],
             'AllowedMethods': ['GET', 'PUT'],
             'AllowedOrigins': ['*'],
-            'ExposeHeaders': ['GET', 'PUT'],
+            'ExposeHeaders': ['ETag', 'x-amz-request-id'],
             'MaxAgeSeconds': 3000
         }]
     }


### PR DESCRIPTION
ExposeHeaders should be a list of HTTP header names, not a list of HTTP methods.