### PR TITLE
Add Session.assume_role method

### DIFF
--- a/boto3/__init__.py
+++ b/boto3/__init__.py
@@ -101,6 +101,15 @@ def resource(*args, **kwargs):
     return _get_default_session().resource(*args, **kwargs)
 
 
+def assume_role(*args, **kwargs):
+    """
+    Create a new session that assumes the given role.
+
+    See :py:meth:`boto3.session.Session.assume_role`.
+    """
+    return _get_default_session().assume_role(*args, **kwargs)
+
+
 # Set up logging to ``/dev/null`` like a library is supposed to.
 # https://docs.python.org/3.3/howto/logging.html#configuring-logging-for-a-library
 class NullHandler(logging.Handler):

--- a/boto3/session.py
+++ b/boto3/session.py
@@ -16,7 +16,8 @@ import os
 
 import botocore.session
 from botocore.client import Config
-from botocore.exceptions import DataNotFoundError, UnknownServiceError
+from botocore.exceptions import DataNotFoundError, UnknownServiceError, NoCredentialsError
+from botocore.credentials import AssumeRoleCredentialFetcher, DeferredRefreshableCredentials
 
 import boto3
 import boto3.utils
@@ -476,6 +477,53 @@ class Session:
         )
 
         return cls(client=client)
+
+    def assume_role(self, role_arn, extra_args=None):
+        """
+        Create a new session that assumes the given role.
+
+        :type role_arn: str
+        :param role_arn: The ARN of the role to be assumed.
+        :type extra_args: dict
+        :param extra_args: Any additional arguments to add to the assume
+            role request using the format of the botocore operation.
+            Possible keys include, but may not be limited to,
+            DurationSeconds, Policy, and RoleSessionName.
+        """
+        botocore_session = self._session
+
+        credentials = botocore_session.get_credentials()
+        if not credentials:
+            # Error out now rather than wait for the new session to get used
+            raise NoCredentialsError
+
+        credential_fetcher = AssumeRoleCredentialFetcher(
+            botocore_session.create_client,
+            credentials,
+            role_arn,
+            extra_args=extra_args
+        )
+
+        assumed_role_credentials = DeferredRefreshableCredentials(
+            credential_fetcher.fetch_credentials,
+            "assume-role"
+        )
+
+        assumed_role_botocore_session = botocore.session.get_session()
+        assumed_role_botocore_session._credentials = assumed_role_credentials
+
+        # note that if this session's region changes, it will not cascade
+        region_name = self.region_name
+
+        assumed_role_boto3_session = Session(
+            botocore_session=assumed_role_botocore_session,
+            region_name=region_name,
+        )
+
+        # provice traceability
+        assumed_role_boto3_session.assume_role_parent_session = self
+
+        return assumed_role_boto3_session
 
     def _register_default_handlers(self):
 


### PR DESCRIPTION
This is a followup on https://github.com/boto/botocore/pull/2096. That was an overcomplicated implementation that used a custom `CredentialProvider` and credential chain, when `botocore.Session` already has a mechanism for overriding the credential chain with a `Credentials` object.

Issue https://github.com/boto/botocore/issues/761 asks for first-class support for sts:AssumeRole, where there is a `Session.assume_role()` method that produces another session. This implements it by using the existing `AssumeRoleCredentialFetcher` and `DeferredRefreshableCredentials` classes, the latter of which is set as the `_credentials` field of the new botocore Session ([like happens when you provide explicit credentials](https://github.com/boto/boto3/blob/abc9598b54cde5d0dfb3ce9678236dafc55e8f2b/boto3/session.py#L80) when setting up a session by calling `set_credentials()` on the botocore session; that method doesn't take a `Credentials` object, so this changes the field directly, but that could be fixed by a small change to `botocore.Session`). It sets the region of the assumed role session to the current value returned by `Session.region_name`.

I'm opening this PR for discussion as to whether it might be accepted, given that it's a substantially smaller change than proposed in the previous PR. As such, I have not yet implemented tests, nor given the method signature any thought (compare with [the comprehensive interface provided by aws-assume-role-lib](https://github.com/benkehoe/aws-assume-role-lib#interface)).