### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.changes/next-release/feature-Python-23194.json
+++ b/.changes/next-release/feature-Python-23194.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Python",
+  "description": "Dropped support for Python 3.6"
+}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macOS-latest, windows-latest ]
 
     steps:

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ on 2021-07-15. To avoid disruption, customers using Boto3 on Python 2.7 may
 need to upgrade their version of Python or pin the version of Boto3. For
 more information, see this `blog post <https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/>`__.
 
-On 2022-05-30, we will be dropping support for Python 3.6. This follows the
+On 2022-05-30, support for Python 3.6 was ended. This follows the
 Python Software Foundation `end of support <https://www.python.org/dev/peps/pep-0494/#lifespan>`__
 for the runtime which occurred on 2021-12-23.
 For more information, see this `blog post <https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/>`__.

--- a/boto3/compat.py
+++ b/boto3/compat.py
@@ -73,7 +73,8 @@ def _warn_deprecated_python():
         )
     }
     deprecated_versions = {
-        (3, 6): py_36_params,
+        # Example template for future deprecations
+        # (3, 6): py_36_params,
     }
     py_version = sys.version_info[:2]
 

--- a/docs/source/guide/migrationpy3.rst
+++ b/docs/source/guide/migrationpy3.rst
@@ -13,7 +13,7 @@ module) and Boto3 (which implements the API functionality and higher-level featu
 
 Timeline
 --------
-Going forward, all projects using Boto3 need to transition to Python 3.6 or later. Boto3 and
+Going forward, all projects using Boto3 need to transition to Python 3.7 or later. Boto3 and
 Botocore ended support for Python 3.4 and 3.5 on Feb 21, 2021, and support for Python 2.7
 ended July 15, 2021.
 
@@ -21,7 +21,7 @@ Updating your project to use Python 3
 -------------------------------------
 
 Before you begin to update your project and environment, make sure you’ve installed or updated to
-Python 3.6 or later as described in :ref:`upgrade to Python 3 <quickstart_install_python>`. You can
+Python 3.7 or later as described in :ref:`upgrade to Python 3 <quickstart_install_python>`. You can
 get Python from the `PSF web site <https://www.python.org/downloads>`_ or using your local package
 manager.
 

--- a/docs/source/guide/quickstart.rst
+++ b/docs/source/guide/quickstart.rst
@@ -24,11 +24,11 @@ To use Boto3, you first need to install it and its dependencies.
 Install or update Python
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Before installing Boto3, install Python 3.6 or later; support for Python 3.5 and
+Before installing Boto3, install Python 3.7 or later; support for Python 3.6 and
 earlier is deprecated. After the deprecation date listed for each Python
 version, new releases of Boto3 will not include support for that version of
 Python. For details, including the deprecation schedule and how to update your
-project to use Python 3.6, see :ref:`guide_migration_py3`.
+project to use Python 3.7, see :ref:`guide_migration_py3`.
 
 For information about how to get the latest version of Python, see the official `Python
 documentation <https://www.python.org/downloads/>`_. 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 -e git+https://github.com/boto/botocore.git@develop#egg=botocore
--e 'git+https://github.com/boto/jmespath.git@develop#egg=jmespath; python_version > "3.6"'
-jmespath<1.0; python_version <= '3.6'
+-e git+https://github.com/boto/jmespath.git@develop#egg=jmespath
 -e git+https://github.com/boto/s3transfer.git@develop#egg=s3transfer

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     include_package_data=True,
     install_requires=requires,
     license="Apache License 2.0",
-    python_requires=">= 3.6",
+    python_requires=">= 3.7",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -45,7 +45,6 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py310
+envlist = py37,py38,py39,py310
 
 # Comment to build sdist and install into virtualenv
 # This is helpful to test installation but takes extra time


### PR DESCRIPTION
**DO NOT MERGE PRIOR TO 5/30**

This PR will end support for Python 3.6 in boto3 as [announced](https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/#:~:text=Overview,deprecations%20which%20started%20in%202021) earlier this year. This PR will remove the testing scaffolding, update documentation, and remove any Python 3.6 specific code paths. This will need to be merged in conjunction with the other PRs in awscli, botocore, and s3transfer.