### PR TITLE
dynamodb BatchWriter._flush bug

### DIFF
--- a/boto3/dynamodb/table.py
+++ b/boto3/dynamodb/table.py
@@ -147,10 +147,10 @@ class BatchWriter:
         unprocessed_items = response['UnprocessedItems']
         if not unprocessed_items:
             unprocessed_items = {}
-        unprocessed_items = unprocessed_items.get(self._table_name, [])
+        item_list = unprocessed_items.get(self._table_name, [])
         # Any unprocessed_items are immediately added to the
         # next batch we send.
-        self._items_buffer.extend(unprocessed_items)
+        self._items_buffer.extend(item_list)
         logger.debug(
             "Batch write sent %s, unprocessed: %s",
             len(items_to_send),

--- a/boto3/dynamodb/table.py
+++ b/boto3/dynamodb/table.py
@@ -145,10 +145,9 @@ class BatchWriter:
             RequestItems={self._table_name: items_to_send}
         )
         unprocessed_items = response['UnprocessedItems']
-        if unprocessed_items is None:
-            unprocessed_items = []
-        else:
-            unprocessed_items = unprocessed_items.get(self._table_name, [])
+        if not unprocessed_items:
+            unprocessed_items = {}
+        unprocessed_items = unprocessed_items.get(self._table_name, [])
         # Any unprocessed_items are immediately added to the
         # next batch we send.
         self._items_buffer.extend(unprocessed_items)

--- a/boto3/dynamodb/table.py
+++ b/boto3/dynamodb/table.py
@@ -144,9 +144,11 @@ class BatchWriter:
         response = self._client.batch_write_item(
             RequestItems={self._table_name: items_to_send}
         )
-        unprocessed_items = response['UnprocessedItems'].get(
-            self._table_name, []
-        )
+        unprocessed_items = response['UnprocessedItems']
+        if unprocessed_items is None:
+            unprocessed_items = []
+        else:
+            unprocessed_items = unprocessed_items.get(self._table_name, [])
         # Any unprocessed_items are immediately added to the
         # next batch we send.
         self._items_buffer.extend(unprocessed_items)

--- a/boto3/dynamodb/table.py
+++ b/boto3/dynamodb/table.py
@@ -144,14 +144,12 @@ class BatchWriter:
         response = self._client.batch_write_item(
             RequestItems={self._table_name: items_to_send}
         )
-        unprocessed_items = response['UnprocessedItems']
-
-        if unprocessed_items and unprocessed_items[self._table_name]:
-            # Any unprocessed_items are immediately added to the
-            # next batch we send.
-            self._items_buffer.extend(unprocessed_items[self._table_name])
-        else:
-            self._items_buffer = []
+        unprocessed_items = response['UnprocessedItems'].get(
+            self._table_name, []
+        )
+        # Any unprocessed_items are immediately added to the
+        # next batch we send.
+        self._items_buffer.extend(unprocessed_items)
         logger.debug(
             "Batch write sent %s, unprocessed: %s",
             len(items_to_send),

--- a/tests/unit/dynamodb/test_table.py
+++ b/tests/unit/dynamodb/test_table.py
@@ -413,9 +413,11 @@ class BaseTransformationTest(unittest.TestCase):
         self.assert_batch_write_calls_are([first_batch, second_batch])
 
     def test_added_unsent_request_not_flushed_put(self):
-        # if all requests that get sent fail to process and another gets
-        # created that is not sent, it previously was dropped from the
-        # _item_buffer if all requests were successful on the next run
+        # If n requests that get sent fail to process where n = flush_amount
+        # and at least one more request gets created before the second attempt,
+        # then previously if n requests were successful on the next run and
+        # returned an empty dict, _item_buffer would be emptied before sending
+        # the next batch of n requests
         self.client.batch_write_item.side_effect = [
             {
                 'UnprocessedItems': {
@@ -449,9 +451,11 @@ class BaseTransformationTest(unittest.TestCase):
         self.assert_batch_write_calls_are([batch, batch])
 
     def test_added_unsent_request_not_flushed_delete(self):
-        # if all requests that get sent fail to process and another gets
-        # created that is not sent, it previously was dropped from the
-        # _item_buffer if all requests were successful on the next run
+        # If n requests that get sent fail to process where n = flush_amount
+        # and at least one more request gets created before the second attempt,
+        # then previously if n requests were successful on the next run and
+        # returned an empty dict, _item_buffer would be emptied before sending
+        # the next batch of n requests
         self.client.batch_write_item.side_effect = [
             {
                 'UnprocessedItems': {


### PR DESCRIPTION
This addresses https://github.com/boto/boto3/issues/1424

This fixes an edge case where n requests fail to process where `n = BatchWriter().flush_amount` on the first attempt and additional requests are added to the buffer before attempting to write/delete n requests a second time. If those original requests that failed succeed this time, the buffer would empty out before being able to send another batch of n requests.

With this fix, those remaining requests will stay cached/in the buffer until they're successfully sent.