### PR TITLE
Bump docutils and sphinx pin to match AWS CLI

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -3,6 +3,7 @@
 # removed python 3.5 support we need to add our own pins.
 markupsafe>=1.1,<2.0
 jinja2>=2.3,<3.0
-Sphinx>=1.1.3,<1.3
+Sphinx>=1.1.3,<=1.3.2
+docutils>=0.10,<0.17
 guzzle_sphinx_theme>=0.7.10,<0.8
 -rrequirements.txt


### PR DESCRIPTION
Matches the updates here: https://github.com/aws/aws-cli/pull/6977