### PR TITLE
Returned future result in S3Transfer's download and upload

### DIFF
--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -276,6 +276,8 @@ class S3Transfer:
         .. seealso::
             :py:meth:`S3.Client.upload_file`
             :py:meth:`S3.Client.upload_fileobj`
+
+        :returns: The result of the specific manager's upload function.
         """
         if not isinstance(filename, str):
             raise ValueError('Filename must be a string')
@@ -285,7 +287,7 @@ class S3Transfer:
             filename, bucket, key, extra_args, subscribers
         )
         try:
-            future.result()
+            return future.result()
         # If a client error was raised, add the backwards compatibility layer
         # that raises a S3UploadFailedError. These specific errors were only
         # ever thrown for upload_parts but now can be thrown for any related
@@ -308,6 +310,8 @@ class S3Transfer:
         .. seealso::
             :py:meth:`S3.Client.download_file`
             :py:meth:`S3.Client.download_fileobj`
+
+        :returns: The result of the specific manager's download function.
         """
         if not isinstance(filename, str):
             raise ValueError('Filename must be a string')
@@ -317,7 +321,7 @@ class S3Transfer:
             bucket, key, filename, extra_args, subscribers
         )
         try:
-            future.result()
+            return future.result()
         # This is for backwards compatibility where when retries are
         # exceeded we need to throw the same error from boto3 instead of
         # s3transfer's built in RetriesExceededError as current users are

--- a/tests/unit/s3/test_transfer.py
+++ b/tests/unit/s3/test_transfer.py
@@ -141,24 +141,26 @@ class TestS3Transfer(unittest.TestCase):
 
     def test_upload_file(self):
         extra_args = {'ACL': 'public-read'}
-        self.transfer.upload_file(
+        upload_metadata = self.transfer.upload_file(
             'smallfile', 'bucket', 'key', extra_args=extra_args
         )
         self.manager.upload.assert_called_with(
             'smallfile', 'bucket', 'key', extra_args, None
         )
+        self.assertIsNotNone(upload_metadata)
 
     def test_download_file(self):
         extra_args = {
             'SSECustomerKey': 'foo',
             'SSECustomerAlgorithm': 'AES256',
         }
-        self.transfer.download_file(
+        download_metadata = self.transfer.download_file(
             'bucket', 'key', '/tmp/smallfile', extra_args=extra_args
         )
         self.manager.download.assert_called_with(
             'bucket', 'key', '/tmp/smallfile', extra_args, None
         )
+        self.assertIsNotNone(download_metadata)
 
     def test_upload_wraps_callback(self):
         self.transfer.upload_file(


### PR DESCRIPTION
**Summary of changes**
- Adds a `return` statement to S3Transfer's methods `upload_file()` and `download_file()`.
- This gives them the same return behavior as `copy()`, `upload_fileobj()`, and `download_fileobj()` inside `s3/inject.py`. These functions return the value for their future objects.
- Returning the value will allow integrations to access metadata returned by the service, such as the "ETag" for uploaded entities for example.

**Rationale**
- There is currently no way to access metadata about S3 service operations when using `upload_file()` and `upload_fileobj()` on a bucket object. For example, before the changes in this PR, in this case:
    ```session = boto3.Session()
    s3 = session.resource("s3")
    bucket = s3.Bucket("redacted")
    fp = io.BytesIO("test".encode("utf-8"))
    resp = bucket.upload_fileobj(fp, "test")
    ```
    the value for `resp` was `None`. This is in contrast to `put_object()`, which does return upload metadata.
- One example of a good use case to access metadata is accessing the upload ETag. This is currently an open issue as documented here: https://github.com/boto/boto3/issues/2861.

**Caveats**
- ETag information won't be available until another PR is merged in `s3transfer`, namely this PR: https://github.com/boto/s3transfer/pull/244. However, these two PRs can be independently merged and are not necessarily related. One might want to merge this PR even indepenently for the sake of ensuring [consistent return behavior](https://github.com/boto/boto3/blob/develop/boto3/s3/inject.py#L444) with `copy()`, `upload_fileobj()`, and `download_fileobj()` inside `inject.py`.