### PR TITLE
Update obsolete credref link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,8 +143,8 @@ Boto3 was made generally available on 06/22/2015 and is currently in the full su
 
 For information about maintenance and support for SDK major versions and their underlying dependencies, see the following in the AWS SDKs and Tools Shared Configuration and Credentials Reference Guide:
 
-* `AWS SDKs and Tools Maintenance Policy <https://docs.aws.amazon.com/credref/latest/refdocs/maint-policy.html>`__
-* `AWS SDKs and Tools Version Support Matrix <https://docs.aws.amazon.com/credref/latest/refdocs/version-support-matrix.html>`__
+* `AWS SDKs and Tools Maintenance Policy <https://docs.aws.amazon.com/sdkref/latest/guide/maint-policy.html>`__
+* `AWS SDKs and Tools Version Support Matrix <https://docs.aws.amazon.com/sdkref/latest/guide/version-support-matrix.html>`__
 
 
 More Resources


### PR DESCRIPTION
Replaces the link to the old credentials reference to the new
AWS SDKs and Tools reference guide.