### PR TITLE
docs: fix simple typo, mehtods -> methods

### DIFF
--- a/boto3/resources/factory.py
+++ b/boto3/resources/factory.py
@@ -564,7 +564,7 @@ class ResourceFactory:
                 response = action(self, *args, **kwargs)
                 self.meta.data = response
 
-            # Create the docstring for the load/reload mehtods.
+            # Create the docstring for the load/reload methods.
             lazy_docstring = docstring.LoadReloadDocstring(
                 action_name=action_model.name,
                 resource_name=resource_name,


### PR DESCRIPTION
There is a small typo in boto3/resources/factory.py.

Should read `methods` rather than `mehtods`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md