### PR TITLE
Clarify resource feature freeze messaging

### DIFF
--- a/docs/source/guide/resources.rst
+++ b/docs/source/guide/resources.rst
@@ -6,14 +6,11 @@ Resources
 Overview
 --------
 
-.. warning::
-   The AWS Python SDK team is no longer planning to support the resources
-   interface in boto3. Requests for new changes involving resource models
-   will no longer be considered, and the resources interface won't be supported
-   in the next major version of the AWS SDK for Python. The AWS SDK teams are
-   striving to achieve more consistent functionality among SDKs, and implementing
-   customized abstractions in individual SDKs is not a sustainable solution going
-   forward. Future feature requests will need to be considered at the cross-SDK level.
+.. note::
+   The AWS Python SDK team does not intend to add new features to the resources
+   interface in boto3. Existing interfaces will continue to operate during
+   boto3's lifecycle. Customers can find access to newer service features through
+   the client interface.
 
 Resources represent an object-oriented interface to Amazon Web Services (AWS).
 They provide a higher-level abstraction than the raw, low-level calls made by


### PR DESCRIPTION
This PR will amend recent changes to messaging for the Resource documentation to clarify all existing resources **are supported** in Boto3 and will remain supported. Any new feature requests for new changes to Resources may be declined during the feature freeze.