### PR TITLE
Update SDK configuration examples with the correct v4 signature string

### DIFF
--- a/docs/source/guide/configuration.rst
+++ b/docs/source/guide/configuration.rst
@@ -41,7 +41,7 @@ To set these configuration options, create a ``Config`` object with the options 
 
     my_config = Config(
         region_name = 'us-west-2',
-        signature_version = 'v4',
+        signature_version = 's3v4',
         retries = {
             'max_attempts': 10,
             'mode': 'standard'
@@ -77,7 +77,7 @@ In the following example, a proxy list is set up to use ``proxy.amazon.com``, po
 
     my_config = Config(
         region_name='us-east-2',
-        signature_version='v4',
+        signature_version='s3v4',
         proxies=proxy_definitions
     )
 
@@ -103,7 +103,7 @@ You can configure how Boto3 uses proxies by specifying the ``proxies_config`` op
 
     my_config = Config(
         region_name='us-east-2',
-        signature_version='v4',
+        signature_version='s3v4',
         proxies=proxy_definitions,
         proxies_config={
             'proxy_client_cert': '/path/of/certificate'


### PR DESCRIPTION
If the `signature_version` field is `v4` as the [documentation examples show,](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-the-config-object) a `MissingSecurityHeader` exception is thrown during operations such as `PutObject`. The correct string to use here is `s3v4`, which is also referenced elsewhere in the [configuration file](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-the-config-object), under the description of the `signature_version` field.

Example Python code that will throw an exception; note that your endpoint must already have a bucket pre-created:

> ```import boto3
> import botocore
> 
> cl = boto3.client(
>     region_name='local',
>     service_name='s3',
>     endpoint_url=ENDPOINT_URL,
>     aws_access_key_id=ACCESS_KEY,
>     aws_secret_access_key=SECRET_KEY,
>     verify=False,
>     config=botocore.config.Config(signature_version='v4', s3={'payload_signing_enabled': True}),
> )
> 
> cl.put_object(Body=b'foo', Bucket='my-bucket', Key='foo')```


If you perform the same exact action, but change `signature_version` to `s3v4`, the operation succeeds.