### PR TITLE
Updated signatures to support sphinx domain

### DIFF
--- a/boto3/docs/action.py
+++ b/boto3/docs/action.py
@@ -56,6 +56,7 @@ class ActionDocumenter(NestedDocumenter):
             action_doc = DocumentStructure(action_name, target='html')
             action_doc.add_title_section(action_name)
             action_section = action_doc.add_new_section(action_name)
+            full_action_name = f'{self.class_name}.{action_name}'
             if action_name in ['load', 'reload'] and self._resource_model.load:
                 document_load_reload_action(
                     section=action_section,
@@ -64,6 +65,7 @@ class ActionDocumenter(NestedDocumenter):
                     event_emitter=self._resource.meta.client.meta.events,
                     load_model=self._resource_model.load,
                     service_model=self._service_model,
+                    full_action_name=full_action_name,
                 )
             elif action_name in modeled_actions:
                 document_action(
@@ -72,10 +74,14 @@ class ActionDocumenter(NestedDocumenter):
                     event_emitter=self._resource.meta.client.meta.events,
                     action_model=modeled_actions[action_name],
                     service_model=self._service_model,
+                    full_action_name=full_action_name,
                 )
             else:
                 document_custom_method(
-                    action_section, action_name, resource_actions[action_name]
+                    action_section,
+                    action_name,
+                    resource_actions[action_name],
+                    full_method_name=full_action_name,
                 )
             # Write actions in individual/nested files.
             # Path: <root>/reference/services/<service>/<resource_name>/<action_name>.rst
@@ -94,6 +100,7 @@ def document_action(
     action_model,
     service_model,
     include_signature=True,
+    full_action_name=None,
 ):
     """Documents a resource action
 
@@ -124,9 +131,11 @@ def document_action(
     example_prefix = '{} = {}.{}'.format(
         example_return_value, example_resource_name, action_model.name
     )
+    if full_action_name is None:
+        full_action_name = action_model.name
     document_model_driven_resource_method(
         section=section,
-        method_name=action_model.name,
+        method_name=full_action_name,
         operation_model=operation_model,
         event_emitter=event_emitter,
         method_description=operation_model.documentation,
@@ -145,6 +154,7 @@ def document_load_reload_action(
     load_model,
     service_model,
     include_signature=True,
+    full_action_name=None,
 ):
     """Documents the resource load action
 
@@ -176,9 +186,11 @@ def document_load_reload_action(
     if service_model.service_name == resource_name:
         example_resource_name = resource_name
     example_prefix = f'{example_resource_name}.{action_name}'
+    if full_action_name is None:
+        full_action_name = action_name
     document_model_driven_method(
         section=section,
-        method_name=action_name,
+        method_name=full_action_name,
         operation_model=OperationModel({}, service_model),
         event_emitter=event_emitter,
         method_description=description,

--- a/boto3/docs/action.py
+++ b/boto3/docs/action.py
@@ -53,12 +53,11 @@ class ActionDocumenter(NestedDocumenter):
 
         for action_name in sorted(resource_actions):
             # Create a new DocumentStructure for each action and add contents.
-            full_action_name = f'{self.class_name}.{action_name}'
             action_doc = DocumentStructure(action_name, target='html')
             action_doc.add_title_section(action_name)
             action_section = action_doc.add_new_section(
                 action_name,
-                context={'full_action_name': full_action_name},
+                context={'qualifier': f'{self.class_name}.'},
             )
             if action_name in ['load', 'reload'] and self._resource_model.load:
                 document_load_reload_action(
@@ -79,9 +78,7 @@ class ActionDocumenter(NestedDocumenter):
                 )
             else:
                 document_custom_method(
-                    action_section,
-                    full_action_name,
-                    resource_actions[action_name],
+                    action_section, action_name, resource_actions[action_name]
                 )
             # Write actions in individual/nested files.
             # Path: <root>/reference/services/<service>/<resource_name>/<action_name>.rst
@@ -130,8 +127,8 @@ def document_action(
     example_prefix = '{} = {}.{}'.format(
         example_return_value, example_resource_name, action_model.name
     )
-    full_action_name = section.context.get(
-        'full_action_name', action_model.name
+    full_action_name = (
+        f"{section.context.get('qualifier', '')}{action_model.name}"
     )
     document_model_driven_resource_method(
         section=section,
@@ -185,7 +182,7 @@ def document_load_reload_action(
     if service_model.service_name == resource_name:
         example_resource_name = resource_name
     example_prefix = f'{example_resource_name}.{action_name}'
-    full_action_name = section.context.get('full_action_name', action_name)
+    full_action_name = f"{section.context.get('qualifier', '')}{action_name}"
     document_model_driven_method(
         section=section,
         method_name=full_action_name,

--- a/boto3/docs/attr.py
+++ b/boto3/docs/attr.py
@@ -29,7 +29,7 @@ def document_attribute(
     include_signature=True,
 ):
     if include_signature:
-        full_attr_name = section.context.get('full_attr_name', attr_name)
+        full_attr_name = f"{section.context.get('qualifier', '')}{attr_name}"
         section.style.start_sphinx_py_attr(full_attr_name)
     # Note that an attribute may have one, may have many, or may have no
     # operations that back the resource's shape. So we just set the
@@ -49,8 +49,8 @@ def document_identifier(
     include_signature=True,
 ):
     if include_signature:
-        full_identifier_name = section.context.get(
-            'full_identifier_name', identifier_model.name
+        full_identifier_name = (
+            f"{section.context.get('qualifier', '')}{identifier_model.name}"
         )
         section.style.start_sphinx_py_attr(full_identifier_name)
     description = get_identifier_description(
@@ -61,8 +61,8 @@ def document_identifier(
 
 def document_reference(section, reference_model, include_signature=True):
     if include_signature:
-        full_reference_name = section.context.get(
-            'full_reference_name', reference_model.name
+        full_reference_name = (
+            f"{section.context.get('qualifier', '')}{reference_model.name}"
         )
         section.style.start_sphinx_py_attr(full_reference_name)
     reference_type = f'(:py:class:`{reference_model.resource.type}`) '

--- a/boto3/docs/attr.py
+++ b/boto3/docs/attr.py
@@ -27,11 +27,9 @@ def document_attribute(
     event_emitter,
     attr_model,
     include_signature=True,
-    full_attr_name=None,
 ):
     if include_signature:
-        if full_attr_name is None:
-            full_attr_name = attr_name
+        full_attr_name = section.context.get('full_attr_name', attr_name)
         section.style.start_sphinx_py_attr(full_attr_name)
     # Note that an attribute may have one, may have many, or may have no
     # operations that back the resource's shape. So we just set the
@@ -49,11 +47,11 @@ def document_identifier(
     resource_name,
     identifier_model,
     include_signature=True,
-    full_identifier_name=None,
 ):
     if include_signature:
-        if full_identifier_name is None:
-            full_identifier_name = identifier_model.name
+        full_identifier_name = section.context.get(
+            'full_identifier_name', identifier_model.name
+        )
         section.style.start_sphinx_py_attr(full_identifier_name)
     description = get_identifier_description(
         resource_name, identifier_model.name
@@ -61,12 +59,11 @@ def document_identifier(
     section.write(f'*(string)* {description}')
 
 
-def document_reference(
-    section, reference_model, include_signature=True, full_reference_name=None
-):
+def document_reference(section, reference_model, include_signature=True):
     if include_signature:
-        if full_reference_name is None:
-            full_reference_name = reference_model.name
+        full_reference_name = section.context.get(
+            'full_reference_name', reference_model.name
+        )
         section.style.start_sphinx_py_attr(full_reference_name)
     reference_type = f'(:py:class:`{reference_model.resource.type}`) '
     section.write(reference_type)

--- a/boto3/docs/attr.py
+++ b/boto3/docs/attr.py
@@ -27,9 +27,12 @@ def document_attribute(
     event_emitter,
     attr_model,
     include_signature=True,
+    full_attr_name=None,
 ):
     if include_signature:
-        section.style.start_sphinx_py_attr(attr_name)
+        if full_attr_name is None:
+            full_attr_name = attr_name
+        section.style.start_sphinx_py_attr(full_attr_name)
     # Note that an attribute may have one, may have many, or may have no
     # operations that back the resource's shape. So we just set the
     # operation_name to the resource name if we ever to hook in and modify
@@ -42,19 +45,29 @@ def document_attribute(
 
 
 def document_identifier(
-    section, resource_name, identifier_model, include_signature=True
+    section,
+    resource_name,
+    identifier_model,
+    include_signature=True,
+    full_identifier_name=None,
 ):
     if include_signature:
-        section.style.start_sphinx_py_attr(identifier_model.name)
+        if full_identifier_name is None:
+            full_identifier_name = identifier_model.name
+        section.style.start_sphinx_py_attr(full_identifier_name)
     description = get_identifier_description(
         resource_name, identifier_model.name
     )
     section.write(f'*(string)* {description}')
 
 
-def document_reference(section, reference_model, include_signature=True):
+def document_reference(
+    section, reference_model, include_signature=True, full_reference_name=None
+):
     if include_signature:
-        section.style.start_sphinx_py_attr(reference_model.name)
+        if full_reference_name is None:
+            full_reference_name = reference_model.name
+        section.style.start_sphinx_py_attr(full_reference_name)
     reference_type = f'(:py:class:`{reference_model.resource.type}`) '
     section.write(reference_type)
     section.include_doc_string(

--- a/boto3/docs/base.py
+++ b/boto3/docs/base.py
@@ -39,3 +39,10 @@ class NestedDocumenter(BaseDocumenter):
         self._resource_sub_path = self._resource_name.lower()
         if self._resource_name == self._service_name:
             self._resource_sub_path = 'service-resource'
+
+    @property
+    def class_name(self):
+        resource_class_name = self._resource_name
+        if self._resource_name == self._service_name:
+            resource_class_name = 'ServiceResource'
+        return f'{self._service_docs_name}.{resource_class_name}'

--- a/boto3/docs/collection.py
+++ b/boto3/docs/collection.py
@@ -62,7 +62,10 @@ class CollectionDocumenter(NestedDocumenter):
         methods = get_instance_public_methods(
             getattr(self._resource, collection.name)
         )
-        document_collection_object(section, collection)
+        full_collection_name = f'{self.class_name}.{collection.name}'
+        document_collection_object(
+            section, collection, full_collection_name=full_collection_name
+        )
         batch_actions = {}
         for batch_action in collection.batch_actions:
             batch_actions[batch_action.name] = batch_action
@@ -90,7 +93,10 @@ class CollectionDocumenter(NestedDocumenter):
 
 
 def document_collection_object(
-    section, collection_model, include_signature=True
+    section,
+    collection_model,
+    include_signature=True,
+    full_collection_name=None,
 ):
     """Documents a collection resource object
 
@@ -102,7 +108,9 @@ def document_collection_object(
         It is useful for generating docstrings.
     """
     if include_signature:
-        section.style.start_sphinx_py_attr(collection_model.name)
+        if full_collection_name is None:
+            full_collection_name = collection_model.name
+        section.style.start_sphinx_py_attr(full_collection_name)
     section.include_doc_string(
         f'A collection of {collection_model.resource.type} resources.'
     )

--- a/boto3/docs/collection.py
+++ b/boto3/docs/collection.py
@@ -42,12 +42,11 @@ class CollectionDocumenter(NestedDocumenter):
         for collection in collections:
             collections_list.append(collection.name)
             # Create a new DocumentStructure for each collection and add contents.
-            full_collection_name = f'{self.class_name}.{collection.name}'
             collection_doc = DocumentStructure(collection.name, target='html')
             collection_doc.add_title_section(collection.name)
             collection_section = collection_doc.add_new_section(
                 collection.name,
-                context={'full_collection_name': full_collection_name},
+                context={'qualifier': f'{self.class_name}.'},
             )
             self._document_collection(collection_section, collection)
 
@@ -106,8 +105,8 @@ def document_collection_object(
         It is useful for generating docstrings.
     """
     if include_signature:
-        full_collection_name = section.context.get(
-            'full_collection_name', collection_model.name
+        full_collection_name = (
+            f"{section.context.get('qualifier', '')}{collection_model.name}"
         )
         section.style.start_sphinx_py_attr(full_collection_name)
     section.include_doc_string(

--- a/boto3/docs/collection.py
+++ b/boto3/docs/collection.py
@@ -42,10 +42,12 @@ class CollectionDocumenter(NestedDocumenter):
         for collection in collections:
             collections_list.append(collection.name)
             # Create a new DocumentStructure for each collection and add contents.
+            full_collection_name = f'{self.class_name}.{collection.name}'
             collection_doc = DocumentStructure(collection.name, target='html')
             collection_doc.add_title_section(collection.name)
             collection_section = collection_doc.add_new_section(
-                collection.name
+                collection.name,
+                context={'full_collection_name': full_collection_name},
             )
             self._document_collection(collection_section, collection)
 
@@ -62,10 +64,7 @@ class CollectionDocumenter(NestedDocumenter):
         methods = get_instance_public_methods(
             getattr(self._resource, collection.name)
         )
-        full_collection_name = f'{self.class_name}.{collection.name}'
-        document_collection_object(
-            section, collection, full_collection_name=full_collection_name
-        )
+        document_collection_object(section, collection)
         batch_actions = {}
         for batch_action in collection.batch_actions:
             batch_actions[batch_action.name] = batch_action
@@ -96,7 +95,6 @@ def document_collection_object(
     section,
     collection_model,
     include_signature=True,
-    full_collection_name=None,
 ):
     """Documents a collection resource object
 
@@ -108,8 +106,9 @@ def document_collection_object(
         It is useful for generating docstrings.
     """
     if include_signature:
-        if full_collection_name is None:
-            full_collection_name = collection_model.name
+        full_collection_name = section.context.get(
+            'full_collection_name', collection_model.name
+        )
         section.style.start_sphinx_py_attr(full_collection_name)
     section.include_doc_string(
         f'A collection of {collection_model.resource.type} resources.'

--- a/boto3/docs/resource.py
+++ b/boto3/docs/resource.py
@@ -156,17 +156,17 @@ class ResourceDocumenter(BaseDocumenter):
         for identifier in identifiers:
             member_list.append(identifier.name)
             # Create a new DocumentStructure for each identifier and add contents.
+            full_identifier_name = f'{self.class_name}.{identifier.name}'
             identifier_doc = DocumentStructure(identifier.name, target='html')
             identifier_doc.add_title_section(identifier.name)
             identifier_section = identifier_doc.add_new_section(
-                identifier.name
+                identifier.name,
+                context={'full_identifier_name': full_identifier_name},
             )
-            full_identifier_name = f'{self.class_name}.{identifier.name}'
             document_identifier(
                 section=identifier_section,
                 resource_name=self._resource_name,
                 identifier_model=identifier,
-                full_identifier_name=full_identifier_name,
             )
             # Write identifiers in individual/nested files.
             # Path: <root>/reference/services/<service>/<resource_name>/<identifier_name>.rst
@@ -209,10 +209,13 @@ class ResourceDocumenter(BaseDocumenter):
             _, attr_shape = attributes[attr_name]
             attribute_list.append(attr_name)
             # Create a new DocumentStructure for each attribute and add contents.
+            full_attr_name = f'{self.class_name}.{attr_name}'
             attribute_doc = DocumentStructure(attr_name, target='html')
             attribute_doc.add_title_section(attr_name)
-            attribute_section = attribute_doc.add_new_section(attr_name)
-            full_attr_name = f'{self.class_name}.{attr_name}'
+            attribute_section = attribute_doc.add_new_section(
+                attr_name,
+                context={'full_attr_name': full_attr_name},
+            )
             document_attribute(
                 section=attribute_section,
                 service_name=self._service_name,
@@ -220,7 +223,6 @@ class ResourceDocumenter(BaseDocumenter):
                 attr_name=attr_name,
                 event_emitter=self._resource.meta.client.meta.events,
                 attr_model=attr_shape,
-                full_attr_name=full_attr_name,
             )
             # Write attributes in individual/nested files.
             # Path: <root>/reference/services/<service>/<resource_name>/<attribute_name>.rst
@@ -252,14 +254,16 @@ class ResourceDocumenter(BaseDocumenter):
         for reference in references:
             reference_list.append(reference.name)
             # Create a new DocumentStructure for each reference and add contents.
+            full_reference_name = f'{self.class_name}.{reference.name}'
             reference_doc = DocumentStructure(reference.name, target='html')
             reference_doc.add_title_section(reference.name)
-            reference_section = reference_doc.add_new_section(reference.name)
-            full_reference_name = f'{self.class_name}.{reference.name}'
+            reference_section = reference_doc.add_new_section(
+                reference.name,
+                context={'full_reference_name': full_reference_name},
+            )
             document_reference(
                 section=reference_section,
                 reference_model=reference,
-                full_reference_name=full_reference_name,
             )
             # Write references in individual/nested files.
             # Path: <root>/reference/services/<service>/<resource_name>/<reference_name>.rst

--- a/boto3/docs/resource.py
+++ b/boto3/docs/resource.py
@@ -161,10 +161,12 @@ class ResourceDocumenter(BaseDocumenter):
             identifier_section = identifier_doc.add_new_section(
                 identifier.name
             )
+            full_identifier_name = f'{self.class_name}.{identifier.name}'
             document_identifier(
                 section=identifier_section,
                 resource_name=self._resource_name,
                 identifier_model=identifier,
+                full_identifier_name=full_identifier_name,
             )
             # Write identifiers in individual/nested files.
             # Path: <root>/reference/services/<service>/<resource_name>/<identifier_name>.rst
@@ -210,6 +212,7 @@ class ResourceDocumenter(BaseDocumenter):
             attribute_doc = DocumentStructure(attr_name, target='html')
             attribute_doc.add_title_section(attr_name)
             attribute_section = attribute_doc.add_new_section(attr_name)
+            full_attr_name = f'{self.class_name}.{attr_name}'
             document_attribute(
                 section=attribute_section,
                 service_name=self._service_name,
@@ -217,6 +220,7 @@ class ResourceDocumenter(BaseDocumenter):
                 attr_name=attr_name,
                 event_emitter=self._resource.meta.client.meta.events,
                 attr_model=attr_shape,
+                full_attr_name=full_attr_name,
             )
             # Write attributes in individual/nested files.
             # Path: <root>/reference/services/<service>/<resource_name>/<attribute_name>.rst
@@ -251,8 +255,11 @@ class ResourceDocumenter(BaseDocumenter):
             reference_doc = DocumentStructure(reference.name, target='html')
             reference_doc.add_title_section(reference.name)
             reference_section = reference_doc.add_new_section(reference.name)
+            full_reference_name = f'{self.class_name}.{reference.name}'
             document_reference(
-                section=reference_section, reference_model=reference
+                section=reference_section,
+                reference_model=reference,
+                full_reference_name=full_reference_name,
             )
             # Write references in individual/nested files.
             # Path: <root>/reference/services/<service>/<resource_name>/<reference_name>.rst

--- a/boto3/docs/resource.py
+++ b/boto3/docs/resource.py
@@ -156,12 +156,11 @@ class ResourceDocumenter(BaseDocumenter):
         for identifier in identifiers:
             member_list.append(identifier.name)
             # Create a new DocumentStructure for each identifier and add contents.
-            full_identifier_name = f'{self.class_name}.{identifier.name}'
             identifier_doc = DocumentStructure(identifier.name, target='html')
             identifier_doc.add_title_section(identifier.name)
             identifier_section = identifier_doc.add_new_section(
                 identifier.name,
-                context={'full_identifier_name': full_identifier_name},
+                context={'qualifier': f'{self.class_name}.'},
             )
             document_identifier(
                 section=identifier_section,
@@ -209,12 +208,11 @@ class ResourceDocumenter(BaseDocumenter):
             _, attr_shape = attributes[attr_name]
             attribute_list.append(attr_name)
             # Create a new DocumentStructure for each attribute and add contents.
-            full_attr_name = f'{self.class_name}.{attr_name}'
             attribute_doc = DocumentStructure(attr_name, target='html')
             attribute_doc.add_title_section(attr_name)
             attribute_section = attribute_doc.add_new_section(
                 attr_name,
-                context={'full_attr_name': full_attr_name},
+                context={'qualifier': f'{self.class_name}.'},
             )
             document_attribute(
                 section=attribute_section,
@@ -254,12 +252,11 @@ class ResourceDocumenter(BaseDocumenter):
         for reference in references:
             reference_list.append(reference.name)
             # Create a new DocumentStructure for each reference and add contents.
-            full_reference_name = f'{self.class_name}.{reference.name}'
             reference_doc = DocumentStructure(reference.name, target='html')
             reference_doc.add_title_section(reference.name)
             reference_section = reference_doc.add_new_section(
                 reference.name,
-                context={'full_reference_name': full_reference_name},
+                context={'qualifier': f'{self.class_name}.'},
             )
             document_reference(
                 section=reference_section,

--- a/boto3/docs/subresource.py
+++ b/boto3/docs/subresource.py
@@ -46,14 +46,13 @@ class SubResourceDocumenter(NestedDocumenter):
         for sub_resource in sub_resources:
             sub_resources_list.append(sub_resource.name)
             # Create a new DocumentStructure for each sub_resource and add contents.
-            full_sub_resource_name = f'{self.class_name}.{sub_resource.name}'
             sub_resource_doc = DocumentStructure(
                 sub_resource.name, target='html'
             )
             sub_resource_doc.add_title_section(sub_resource.name)
             sub_resource_section = sub_resource_doc.add_new_section(
                 sub_resource.name,
-                context={'full_sub_resource_name': full_sub_resource_name},
+                context={'qualifier': f'{self.class_name}.'},
             )
             document_sub_resource(
                 section=sub_resource_section,
@@ -101,8 +100,8 @@ def document_sub_resource(
 
     if include_signature:
         signature_args = get_identifier_args_for_signature(identifiers_needed)
-        full_sub_resource_name = section.context.get(
-            'full_sub_resource_name', sub_resource_model.name
+        full_sub_resource_name = (
+            f"{section.context.get('qualifier', '')}{sub_resource_model.name}"
         )
         section.style.start_sphinx_py_method(
             full_sub_resource_name, signature_args

--- a/boto3/docs/subresource.py
+++ b/boto3/docs/subresource.py
@@ -53,11 +53,13 @@ class SubResourceDocumenter(NestedDocumenter):
             sub_resource_section = sub_resource_doc.add_new_section(
                 sub_resource.name
             )
+            full_sub_resource_name = f'{self.class_name}.{sub_resource.name}'
             document_sub_resource(
                 section=sub_resource_section,
                 resource_name=self._resource_name,
                 sub_resource_model=sub_resource,
                 service_model=self._service_model,
+                full_sub_resource_name=full_sub_resource_name,
             )
 
             # Write sub_resources in individual/nested files.
@@ -78,6 +80,7 @@ def document_sub_resource(
     sub_resource_model,
     service_model,
     include_signature=True,
+    full_sub_resource_name=None,
 ):
     """Documents a resource action
 
@@ -99,8 +102,10 @@ def document_sub_resource(
 
     if include_signature:
         signature_args = get_identifier_args_for_signature(identifiers_needed)
+        if full_sub_resource_name is None:
+            full_sub_resource_name = sub_resource_model.name
         section.style.start_sphinx_py_method(
-            sub_resource_model.name, signature_args
+            full_sub_resource_name, signature_args
         )
 
     method_intro_section = section.add_new_section('method-intro')

--- a/boto3/docs/subresource.py
+++ b/boto3/docs/subresource.py
@@ -46,20 +46,20 @@ class SubResourceDocumenter(NestedDocumenter):
         for sub_resource in sub_resources:
             sub_resources_list.append(sub_resource.name)
             # Create a new DocumentStructure for each sub_resource and add contents.
+            full_sub_resource_name = f'{self.class_name}.{sub_resource.name}'
             sub_resource_doc = DocumentStructure(
                 sub_resource.name, target='html'
             )
             sub_resource_doc.add_title_section(sub_resource.name)
             sub_resource_section = sub_resource_doc.add_new_section(
-                sub_resource.name
+                sub_resource.name,
+                context={'full_sub_resource_name': full_sub_resource_name},
             )
-            full_sub_resource_name = f'{self.class_name}.{sub_resource.name}'
             document_sub_resource(
                 section=sub_resource_section,
                 resource_name=self._resource_name,
                 sub_resource_model=sub_resource,
                 service_model=self._service_model,
-                full_sub_resource_name=full_sub_resource_name,
             )
 
             # Write sub_resources in individual/nested files.
@@ -80,7 +80,6 @@ def document_sub_resource(
     sub_resource_model,
     service_model,
     include_signature=True,
-    full_sub_resource_name=None,
 ):
     """Documents a resource action
 
@@ -102,8 +101,9 @@ def document_sub_resource(
 
     if include_signature:
         signature_args = get_identifier_args_for_signature(identifiers_needed)
-        if full_sub_resource_name is None:
-            full_sub_resource_name = sub_resource_model.name
+        full_sub_resource_name = section.context.get(
+            'full_sub_resource_name', sub_resource_model.name
+        )
         section.style.start_sphinx_py_method(
             full_sub_resource_name, signature_args
         )

--- a/boto3/docs/waiter.py
+++ b/boto3/docs/waiter.py
@@ -48,6 +48,7 @@ class WaiterResourceDocumenter(NestedDocumenter):
             waiter_doc = DocumentStructure(waiter.name, target='html')
             waiter_doc.add_title_section(waiter.name)
             waiter_section = waiter_doc.add_new_section(waiter.name)
+            full_waiter_name = f'{self.class_name}.{waiter.name}'
             document_resource_waiter(
                 section=waiter_section,
                 resource_name=self._resource_name,
@@ -55,6 +56,7 @@ class WaiterResourceDocumenter(NestedDocumenter):
                 service_model=self._service_model,
                 resource_waiter_model=waiter,
                 service_waiter_model=self._service_waiter_model,
+                full_waiter_name=full_waiter_name,
             )
             # Write waiters in individual/nested files.
             # Path: <root>/reference/services/<service>/<resource_name>/<waiter_name>.rst
@@ -74,6 +76,7 @@ def document_resource_waiter(
     resource_waiter_model,
     service_waiter_model,
     include_signature=True,
+    full_waiter_name=None,
 ):
     waiter_model = service_waiter_model.get_waiter(
         resource_waiter_model.waiter_name
@@ -101,9 +104,11 @@ def document_resource_waiter(
     example_prefix = '{}.{}'.format(
         xform_name(resource_name), resource_waiter_model.name
     )
+    if full_waiter_name is None:
+        full_waiter_name = resource_waiter_model.name
     document_model_driven_method(
         section=section,
-        method_name=resource_waiter_model.name,
+        method_name=full_waiter_name,
         operation_model=operation_model,
         event_emitter=event_emitter,
         example_prefix=example_prefix,

--- a/boto3/docs/waiter.py
+++ b/boto3/docs/waiter.py
@@ -45,12 +45,11 @@ class WaiterResourceDocumenter(NestedDocumenter):
         for waiter in waiters:
             waiter_list.append(waiter.name)
             # Create a new DocumentStructure for each waiter and add contents.
-            full_waiter_name = f'{self.class_name}.{waiter.name}'
             waiter_doc = DocumentStructure(waiter.name, target='html')
             waiter_doc.add_title_section(waiter.name)
             waiter_section = waiter_doc.add_new_section(
                 waiter.name,
-                context={'full_waiter_name': full_waiter_name},
+                context={'qualifier': f'{self.class_name}.'},
             )
             document_resource_waiter(
                 section=waiter_section,
@@ -105,8 +104,8 @@ def document_resource_waiter(
     example_prefix = '{}.{}'.format(
         xform_name(resource_name), resource_waiter_model.name
     )
-    full_waiter_name = section.context.get(
-        'full_waiter_name', resource_waiter_model.name
+    full_waiter_name = (
+        f"{section.context.get('qualifier', '')}{resource_waiter_model.name}"
     )
     document_model_driven_method(
         section=section,

--- a/boto3/docs/waiter.py
+++ b/boto3/docs/waiter.py
@@ -45,10 +45,13 @@ class WaiterResourceDocumenter(NestedDocumenter):
         for waiter in waiters:
             waiter_list.append(waiter.name)
             # Create a new DocumentStructure for each waiter and add contents.
+            full_waiter_name = f'{self.class_name}.{waiter.name}'
             waiter_doc = DocumentStructure(waiter.name, target='html')
             waiter_doc.add_title_section(waiter.name)
-            waiter_section = waiter_doc.add_new_section(waiter.name)
-            full_waiter_name = f'{self.class_name}.{waiter.name}'
+            waiter_section = waiter_doc.add_new_section(
+                waiter.name,
+                context={'full_waiter_name': full_waiter_name},
+            )
             document_resource_waiter(
                 section=waiter_section,
                 resource_name=self._resource_name,
@@ -56,7 +59,6 @@ class WaiterResourceDocumenter(NestedDocumenter):
                 service_model=self._service_model,
                 resource_waiter_model=waiter,
                 service_waiter_model=self._service_waiter_model,
-                full_waiter_name=full_waiter_name,
             )
             # Write waiters in individual/nested files.
             # Path: <root>/reference/services/<service>/<resource_name>/<waiter_name>.rst
@@ -76,7 +78,6 @@ def document_resource_waiter(
     resource_waiter_model,
     service_waiter_model,
     include_signature=True,
-    full_waiter_name=None,
 ):
     waiter_model = service_waiter_model.get_waiter(
         resource_waiter_model.waiter_name
@@ -104,8 +105,9 @@ def document_resource_waiter(
     example_prefix = '{}.{}'.format(
         xform_name(resource_name), resource_waiter_model.name
     )
-    if full_waiter_name is None:
-        full_waiter_name = resource_waiter_model.name
+    full_waiter_name = section.context.get(
+        'full_waiter_name', resource_waiter_model.name
+    )
     document_model_driven_method(
         section=section,
         method_name=full_waiter_name,

--- a/tests/functional/docs/test_dynamodb.py
+++ b/tests/functional/docs/test_dynamodb.py
@@ -47,7 +47,7 @@ class TestDynamoDBCustomizations(BaseDocsFunctionalTests):
         self.assert_contains_lines_in_order(
             [
                 '************\nbatch_writer\n************',
-                '.. py:method:: batch_writer(overwrite_by_pkeys=None)',
+                '.. py:method:: DynamoDB.Table.batch_writer(overwrite_by_pkeys=None)',
             ],
             self.get_nested_file_contents('dynamodb', 'table', 'batch_writer'),
         )
@@ -61,7 +61,7 @@ class TestDynamoDBCustomizations(BaseDocsFunctionalTests):
                 '********',
                 'put_item',
                 '********',
-                '.. py:method:: put_item(**kwargs)',
+                '.. py:method:: DynamoDB.Table.put_item(**kwargs)',
                 # Make sure the request syntax is as expected.
                 'response = table.put_item(',
                 'Item={',

--- a/tests/functional/docs/test_ec2.py
+++ b/tests/functional/docs/test_ec2.py
@@ -47,7 +47,7 @@ class TestInstanceDeleteTags(BaseDocsFunctionalTests):
         self.assert_contains_lines_in_order(
             [
                 'delete_tags',
-                '.. py:method:: delete_tags(**kwargs)',
+                '.. py:method:: EC2.Instance.delete_tags(**kwargs)',
                 'response = instance.delete_tags(',
                 'DryRun=True|False,',
                 'Tags=[',

--- a/tests/functional/docs/test_s3.py
+++ b/tests/functional/docs/test_s3.py
@@ -48,14 +48,14 @@ class TestS3Customizations(BaseDocsFunctionalTests):
         self.assert_contains_lines_in_order(
             [
                 'download_file',
-                '.. py:method:: download_file(',
+                '.. py:method:: S3.Client.download_file(',
             ],
             self.get_nested_file_contents('s3', 'client', 'download_file'),
         )
         self.assert_contains_lines_in_order(
             [
                 'upload_file',
-                '.. py:method:: upload_file(',
+                '.. py:method:: S3.Client.upload_file(',
             ],
             self.get_nested_file_contents('s3', 'client', 'upload_file'),
         )

--- a/tests/functional/docs/test_smoke.py
+++ b/tests/functional/docs/test_smoke.py
@@ -133,7 +133,7 @@ def _assert_has_client_documentation(generated_docs, service_name, client):
         _assert_contains_lines_in_order(
             [
                 f'{method_name}',
-                f'.. py:method:: {method_name}(',
+                f'.. py:method:: {client.__class__.__name__}.Client.{method_name}(',
             ],
             get_nested_file_contents(service_name, 'client', method_name),
         )

--- a/tests/unit/docs/test_action.py
+++ b/tests/unit/docs/test_action.py
@@ -32,7 +32,7 @@ class TestActionDocumenter(BaseDocsTest):
         self.assert_contains_lines_in_order(
             [
                 'sample_operation',
-                '.. py:method:: sample_operation(**kwargs)',
+                '.. py:method:: MyService.ServiceResource.sample_operation(**kwargs)',
                 '  **Request Syntax**',
                 '  ::',
                 '    response = myservice.sample_operation(',
@@ -79,7 +79,7 @@ class TestActionDocumenter(BaseDocsTest):
         self.assert_contains_lines_in_order(
             [
                 'load',
-                '.. py:method:: load()',
+                '.. py:method:: MyService.Sample.load()',
                 (
                     '  Calls :py:meth:`MyService.Client.sample_operation` to update '
                     'the attributes of the Sample resource'
@@ -94,7 +94,7 @@ class TestActionDocumenter(BaseDocsTest):
         self.assert_contains_lines_in_order(
             [
                 'operate',
-                '.. py:method:: operate(**kwargs)',
+                '.. py:method:: MyService.Sample.operate(**kwargs)',
                 '  **Request Syntax** ',
                 '  ::',
                 '    response = sample.operate(',
@@ -121,7 +121,7 @@ class TestActionDocumenter(BaseDocsTest):
         self.assert_contains_lines_in_order(
             [
                 'reload',
-                '.. py:method:: reload()',
+                '.. py:method:: MyService.Sample.reload()',
                 (
                     '  Calls :py:meth:`MyService.Client.sample_operation` to update '
                     'the attributes of the Sample resource'
@@ -136,7 +136,7 @@ class TestActionDocumenter(BaseDocsTest):
         self.assert_contains_lines_in_order(
             [
                 'get_available_subresources',
-                '.. py:method:: get_available_subresources()',
+                '.. py:method:: MyService.Sample.get_available_subresources()',
                 'Returns a list of all the available sub-resources for this',
                 ':returns: A list containing the name of each sub-resource for this',
                 ':rtype: list of str',

--- a/tests/unit/docs/test_client.py
+++ b/tests/unit/docs/test_client.py
@@ -46,7 +46,7 @@ class TestBoto3ClientDocumenter(BaseDocsTest):
         self.assert_contains_lines_in_order(
             [
                 'can_paginate',
-                '.. py:method:: can_paginate(operation_name)',
+                '.. py:method:: MyService.Client.can_paginate(operation_name)',
             ],
             self.get_nested_service_contents(
                 'myservice', 'client', 'can_paginate'
@@ -55,7 +55,7 @@ class TestBoto3ClientDocumenter(BaseDocsTest):
         self.assert_contains_lines_in_order(
             [
                 'get_paginator',
-                '.. py:method:: get_paginator(operation_name)',
+                '.. py:method:: MyService.Client.get_paginator(operation_name)',
             ],
             self.get_nested_service_contents(
                 'myservice', 'client', 'get_paginator'
@@ -64,7 +64,7 @@ class TestBoto3ClientDocumenter(BaseDocsTest):
         self.assert_contains_lines_in_order(
             [
                 'get_waiter',
-                '.. py:method:: get_waiter(waiter_name)',
+                '.. py:method:: MyService.Client.get_waiter(waiter_name)',
             ],
             self.get_nested_service_contents(
                 'myservice', 'client', 'get_waiter'
@@ -73,7 +73,7 @@ class TestBoto3ClientDocumenter(BaseDocsTest):
         self.assert_contains_lines_in_order(
             [
                 'sample_operation',
-                '.. py:method:: sample_operation(**kwargs)',
+                '.. py:method:: MyService.Client.sample_operation(**kwargs)',
                 '  **Request Syntax**',
                 '  ::',
                 '    response = client.sample_operation(',

--- a/tests/unit/docs/test_collection.py
+++ b/tests/unit/docs/test_collection.py
@@ -31,7 +31,7 @@ class TestCollectionDocumenter(BaseDocsTest):
         self.assert_contains_lines_in_order(
             [
                 'samples',
-                '.. py:attribute:: samples',
+                '.. py:attribute:: MyService.ServiceResource.samples',
                 '  A collection of Sample resources.'
                 'A Sample Collection will include all resources by default, '
                 'and extreme caution should be taken when performing actions '

--- a/tests/unit/docs/test_resource.py
+++ b/tests/unit/docs/test_resource.py
@@ -66,14 +66,14 @@ class TestResourceDocumenter(BaseDocsTest):
         self.assert_contains_lines_in_order(
             [
                 'name',
-                '.. py:attribute:: name',
+                '.. py:attribute:: MyService.Sample.name',
             ],
             self.get_nested_service_contents('myservice', 'sample', 'name'),
         )
         self.assert_contains_lines_in_order(
             [
                 'bar',
-                '.. py:attribute:: bar',
+                '.. py:attribute:: MyService.Sample.bar',
                 '  - *(string) --* Documents Bar',
             ],
             self.get_nested_service_contents('myservice', 'sample', 'bar'),
@@ -81,14 +81,14 @@ class TestResourceDocumenter(BaseDocsTest):
         self.assert_contains_lines_in_order(
             [
                 'load',
-                '.. py:method:: load()',
+                '.. py:method:: MyService.Sample.load()',
             ],
             self.get_nested_service_contents('myservice', 'sample', 'load'),
         )
         self.assert_contains_lines_in_order(
             [
                 'wait_until_complete',
-                '.. py:method:: wait_until_complete(**kwargs)',
+                '.. py:method:: MyService.Sample.wait_until_complete(**kwargs)',
             ],
             self.get_nested_service_contents(
                 'myservice', 'sample', 'wait_until_complete'
@@ -137,7 +137,7 @@ class TestServiceResourceDocumenter(BaseDocsTest):
         self.assert_contains_lines_in_order(
             [
                 'sample_operation',
-                '.. py:method:: sample_operation(**kwargs)',
+                '.. py:method:: MyService.ServiceResource.sample_operation(**kwargs)',
             ],
             self.get_nested_service_contents(
                 'myservice', 'service-resource', 'sample_operation'
@@ -146,7 +146,7 @@ class TestServiceResourceDocumenter(BaseDocsTest):
         self.assert_contains_lines_in_order(
             [
                 'Sample',
-                '.. py:method:: Sample(name)',
+                '.. py:method:: MyService.ServiceResource.Sample(name)',
             ],
             self.get_nested_service_contents(
                 'myservice', 'service-resource', 'Sample'
@@ -155,7 +155,7 @@ class TestServiceResourceDocumenter(BaseDocsTest):
         self.assert_contains_lines_in_order(
             [
                 'samples',
-                '.. py:attribute:: samples',
+                '.. py:attribute:: MyService.ServiceResource.samples',
                 '  .. py:method:: all()',
                 '  .. py:method:: filter(**kwargs)',
                 '  .. py:method:: limit(**kwargs)',

--- a/tests/unit/docs/test_service.py
+++ b/tests/unit/docs/test_service.py
@@ -125,7 +125,7 @@ class TestServiceDocumenter(BaseDocsTest):
         self.assert_contains_lines_in_order(
             [
                 'sample_operation',
-                '.. py:method:: sample_operation(**kwargs)',
+                '.. py:method:: MyService.Client.sample_operation(**kwargs)',
                 '  **Examples** ',
                 '  Sample Description.',
                 '  ::',
@@ -158,7 +158,7 @@ class TestServiceDocumenter(BaseDocsTest):
         self.assert_contains_lines_in_order(
             [
                 'sample_operation',
-                '.. py:method:: sample_operation(**kwargs)',
+                '.. py:method:: MyService.ServiceResource.sample_operation(**kwargs)',
             ],
             self.get_nested_service_contents(
                 'myservice', 'service-resource', 'sample_operation'
@@ -167,7 +167,7 @@ class TestServiceDocumenter(BaseDocsTest):
         self.assert_contains_lines_in_order(
             [
                 'Sample',
-                '.. py:method:: Sample(name)',
+                '.. py:method:: MyService.ServiceResource.Sample(name)',
             ],
             self.get_nested_service_contents(
                 'myservice', 'service-resource', 'Sample'
@@ -176,7 +176,7 @@ class TestServiceDocumenter(BaseDocsTest):
         self.assert_contains_lines_in_order(
             [
                 'samples',
-                '.. py:attribute:: samples',
+                '.. py:attribute:: MyService.ServiceResource.samples',
                 '  .. py:method:: all()',
                 '  .. py:method:: filter(**kwargs)',
                 '  .. py:method:: limit(**kwargs)',
@@ -189,35 +189,35 @@ class TestServiceDocumenter(BaseDocsTest):
         self.assert_contains_lines_in_order(
             [
                 'name',
-                '.. py:attribute:: name',
+                '.. py:attribute:: MyService.Sample.name',
             ],
             self.get_nested_service_contents('myservice', 'sample', 'name'),
         )
         self.assert_contains_lines_in_order(
             [
                 'name',
-                '.. py:attribute:: name',
+                '.. py:attribute:: MyService.Sample.name',
             ],
             self.get_nested_service_contents('myservice', 'sample', 'name'),
         )
         self.assert_contains_lines_in_order(
             [
                 'bar',
-                '.. py:attribute:: bar',
+                '.. py:attribute:: MyService.Sample.bar',
             ],
             self.get_nested_service_contents('myservice', 'sample', 'bar'),
         )
         self.assert_contains_lines_in_order(
             [
                 'load',
-                '.. py:method:: load()',
+                '.. py:method:: MyService.Sample.load()',
             ],
             self.get_nested_service_contents('myservice', 'sample', 'load'),
         )
         self.assert_contains_lines_in_order(
             [
                 'wait_until_complete',
-                '.. py:method:: wait_until_complete(**kwargs)',
+                '.. py:method:: MyService.Sample.wait_until_complete(**kwargs)',
             ],
             self.get_nested_service_contents(
                 'myservice', 'sample', 'wait_until_complete'

--- a/tests/unit/docs/test_subresource.py
+++ b/tests/unit/docs/test_subresource.py
@@ -32,7 +32,7 @@ class TestSubResourceDocumenter(BaseDocsTest):
         self.assert_contains_lines_in_order(
             [
                 'Sample',
-                '.. py:method:: Sample(name)',
+                '.. py:method:: MyService.ServiceResource.Sample(name)',
                 '  Creates a Sample resource.::',
                 "    sample = myservice.Sample('name')",
                 '  :type name: string',

--- a/tests/unit/docs/test_waiter.py
+++ b/tests/unit/docs/test_waiter.py
@@ -35,7 +35,7 @@ class TestWaiterResourceDocumenter(BaseDocsTest):
         self.assert_contains_lines_in_order(
             [
                 'wait_until_complete',
-                '.. py:method:: wait_until_complete(**kwargs)',
+                '.. py:method:: MyService.Sample.wait_until_complete(**kwargs)',
                 (
                     '  Waits until this Sample is complete. This method calls '
                     ':py:meth:`MyService.Waiter.sample_operation_complete.wait` '


### PR DESCRIPTION
> Note: Should be merged after botocore's [#2880](https://github.com/boto/botocore/pull/2880). Before this happens, tests are expected to fail.
## Overview
We previously had all class and method documentation on the same service page, however, we implemented nested docs to decrease page size. In doing so, we broke the way sphinx handles cross-references since methods on individual pages (not in the `py:class` body) should have the full class name attached as explained [here](https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#:~:text=Methods%20and%20attributes%20belonging%20to%20the%20class%20should%20be%20placed%20in%20this%20directive%E2%80%99s%20body.%20If%20they%20are%20placed%20outside%2C%20the%20supplied%20name%20should%20contain%20the%20class%20name%20so%20that%20cross%2Dreferences%20still%20work.).

## Examples
Before Nested Docs:
```
# Page: <service>.html
.. py:class:: Foo
   .. py:method:: bar()
```

Current:
```
# Page: <service>.html
.. py:class:: Foo.Client

# Page: <method>.html
.. py:method:: bar()
```

New:
```
# Page: <service>.html
.. py:class:: Foo.Client

# Page: <method>.html
.. py:method:: Foo.Client.bar()
```