### PR TITLE
Clear out source directory when running 'make clean'

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -42,7 +42,7 @@ help:
 clean:
 	-rm -rf $(BUILDDIR)/*
 	# Clears out the source directory (excluding 'index.rst').
-	find $(SERVICESDIR) -depth 1 ! -name 'index.rst' -exec rm -rf {} +
+	find $(SERVICESDIR) -depth 1 ! -name 'index.rst' -exec rm -rf '{}' \+ -print
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,6 +6,7 @@ SPHINXOPTS    = -j auto
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build
+SERVICESDIR     = source/reference/services
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
@@ -40,6 +41,8 @@ help:
 
 clean:
 	-rm -rf $(BUILDDIR)/*
+	# Clears out the source directory (excluding 'index.rst').
+	find $(SERVICESDIR) -depth 1 ! -name 'index.rst' -exec rm -rf {} +
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -42,7 +42,7 @@ help:
 clean:
 	-rm -rf $(BUILDDIR)/*
 	# Clears out the source directory (excluding 'index.rst').
-	find $(SERVICESDIR) -depth 1 ! -name 'index.rst' -exec rm -rf '{}' \+ -print
+	find $(SERVICESDIR) -depth 1 ! -name 'index.rst' -exec rm -rf '{}' \+
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,7 +6,7 @@ SPHINXOPTS    = -j auto
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build
-SERVICESDIR     = source/reference/services
+SERVICESDIR   = source/reference/services
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4


### PR DESCRIPTION
## Summary
When working on documentation updates, it's recommended to change [`session.get_available_services()`](https://github.com/boto/boto3/blob/develop/boto3/docs/__init__.py#:~:text=get_available_services) (which generates all 340+ service docs) to a list of specific serviceIds such as `['dynamodb', 'kms', 's3']` or a small number of services like `session.get_available_services[:5]` in order to speed things up. These source files get stored in `docs/source/reference/services` and are never cleared, so when you change which files you want to test, old ones from previous runs will be included. 

## Solution
This PR adds a command to `make clean` that clears out the source file directory (`excluding index.rst`)