### PR TITLE
remove table of contents from example section.

### DIFF
--- a/boto3/docs/service.py
+++ b/boto3/docs/service.py
@@ -195,8 +195,5 @@ class ServiceDocumenter(BaseServiceDocumenter):
         if os.path.isfile(examples_file):
             section.style.h2('Examples')
             section.style.new_line()
-            section.write(".. contents::\n    :local:\n    :depth: 1")
-            section.style.new_line()
-            section.style.new_line()
             with open(examples_file) as f:
                 section.write(f.read())


### PR DESCRIPTION
## Summary
The Furo template displays an error when using a Table of Contents since it's displayed on the right sidebar and redundant. This error only appears on a select few pages and was missed in the initial update. This PR removes the table of contents from this section.

## Before
<img width="1792" alt="Screen Shot 2023-03-22 at 2 19 19 PM" src="https://user-images.githubusercontent.com/43360731/227044774-37424d9d-b7b5-45cf-8c5c-cf95925f628e.png">

## After
<img width="1792" alt="Screen Shot 2023-03-22 at 2 19 24 PM" src="https://user-images.githubusercontent.com/43360731/227044769-f26c9789-b9c8-4435-9340-eafd8e60fd3a.png">