### PR TITLE
pre-commit: Replace flake8 and pyupgrade with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,15 +3,15 @@ repos:
   - repo: 'https://github.com/pre-commit/pre-commit-hooks'
     rev: v4.3.0
     hooks:
+      - id: check-toml
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: 'https://github.com/asottile/pyupgrade'
-    rev: v2.34.0
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.259
     hooks:
-      - id: pyupgrade
-        args:
-          - '--py36-plus'
+      - id: ruff
+        # args: [--fix, --exit-non-zero-on-fix]
   - repo: 'https://github.com/PyCQA/isort'
     rev: 5.12.0
     hooks:
@@ -20,7 +20,3 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-  - repo: 'https://github.com/pycqa/flake8'
-    rev: 4.0.1
-    hooks:
-      - id: flake8

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -40,7 +40,7 @@ ideal report includes:
 
 Codestyle
 ---------
-This project uses flake8 to enforce codstyle requirements. We've codified this
+This project uses ruff to enforce codstyle requirements. We've codified this
 process using a tool called `pre-commit <https://pre-commit.com/>`__. pre-commit
 allows us to specify a config file with all tools required for code linting,
 and surfaces either a git commit hook, or single command, for enforcing these.
@@ -56,11 +56,11 @@ to automatically perform the codestyle validation:
     $ pre-commit run
 
 This will automatically perform simple updates (such as white space clean up)
-and provide a list of any failing flake8 checks. After these are addressed,
+and provide a list of any failing ruff checks. After these are addressed,
 you can commit the changes prior to publishing the PR.
 These checks are also included in our CI setup under the "Lint" workflow which
 will provide output on Github for anything missed locally.
 
-See the `flake8` section of the
-`setup.cfg <https://github.com/boto/boto3/blob/develop/setup.cfg>`__ for the
+See the `ruff` section of the
+`pyproject.toml <https://github.com/boto/boto3/blob/develop/pyproject.toml>`__ for the
 currently enforced rules.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,37 @@ src_paths = ["boto3", "tests"]
 [tool.black]
 line-length = 79
 skip_string_normalization = true
+
+[tool.ruff]  # https://beta.ruff.rs/docs/rules
+extend-select = [
+    "C4",
+    "C9",
+    "I",
+    "PL",
+    "S",
+    "UP",
+]
+extend-ignore = [
+    "PLR2004",
+    "PLW0603",
+    "PLW2901",
+]
+line-length = 95
+target-version = "py37"
+
+[tool.ruff.mccabe]
+max-complexity = 12
+
+[tool.ruff.pylint]
+max-args = 13
+max-branches = 14
+
+[tool.ruff.per-file-ignores]
+"boto3/compat.py" = ["E402", "F401", "F841", "I001"]
+"boto3/dynamodb/transform.py" = ["PLR5501"]
+"docs/source/conf.py" = ["E501", "I001", "UP009"]
+"scripts/new-change" = ["S311"]
+"tests/*" = ["S"]
+"tests/functional/dynamodb/test_stubber_conditions.py" = ["C408"]
+"tests/unit/resources/test_action.py" = ["UP031"]
+"tests/unit/test_session.py" = ["PLC1901"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,11 +9,3 @@ requires_dist =
 
 [options.extras_require]
 crt = botocore[crt]>=1.21.0,<2.0a0
-
-[flake8]
-ignore = E203,E501,W503,W504
-exclude =
-    docs,
-    boto3/compat.py,
-    boto3/data,
-    .changes


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.