### PR TITLE
Change usage example for boto3.client("s3").upload_file()

### DIFF
--- a/boto3/s3/inject.py
+++ b/boto3/s3/inject.py
@@ -110,11 +110,11 @@ def upload_file(
     Usage::
 
         import boto3
-        s3 = boto3.resource('s3')
-        s3.meta.client.upload_file('/tmp/hello.txt', 'mybucket', 'hello.txt')
+        s3 = boto3.client('s3')
+        s3.upload_file('/tmp/hello.txt', 'mybucket', 'hello.txt')
 
-    Similar behavior as S3Transfer's upload_file() method,
-    except that parameters are capitalized. Detailed examples can be found at
+    Similar behavior as S3Transfer's upload_file() method, except that
+    argument names are capitalized. Detailed examples can be found at
     :ref:`S3Transfer's Usage <ref_s3transfer_usage>`.
 
     :type Filename: str


### PR DESCRIPTION
The `upload_file()` method on boto3's S3 client is an SDK customization and therefore has [hand-written docs content](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/upload_file.html) that gets injected into the auto-generated client docs. This PR changes the usage example on this docs page from the old:

```python
import boto3
s3 = boto3.resource('s3')
s3.meta.client.upload_file('/tmp/hello.txt', 'mybucket', 'hello.txt')
```

to the more direct new:

```python
import boto3
s3 = boto3.client('s3')
s3.upload_file('/tmp/hello.txt', 'mybucket', 'hello.txt')
```

This matches what we already have in the [guide for uploading files](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-uploading-files.html).