### PR TITLE
refactor: rename "_get_default_session" to support use as public method

### DIFF
--- a/boto3/__init__.py
+++ b/boto3/__init__.py
@@ -69,7 +69,7 @@ def set_stream_logger(name='boto3', level=logging.DEBUG, format_string=None):
     logger.addHandler(handler)
 
 
-def _get_default_session():
+def get_default_session():
     """
     Get the default session, creating one if needed.
 
@@ -81,6 +81,9 @@ def _get_default_session():
     _warn_deprecated_python()
 
     return DEFAULT_SESSION
+
+
+_get_default_session = get_default_session
 
 
 def client(*args, **kwargs):


### PR DESCRIPTION
Closes #2707

I find myself sharing the following article with colleagues:
https://ben11kehoe.medium.com/boto3-sessions-and-why-you-should-use-them-9b094eb5ca8e

The article makes a better argument than I could about why `get_default_session()` should be public. 
Is there a good reason not to do this?