### PR TITLE
`Metric.put_data` Docs Override

### DIFF
--- a/boto3/docs/action.py
+++ b/boto3/docs/action.py
@@ -38,6 +38,12 @@ PUT_DATA_WARNING_MESSAGE = """
     the metric resource's ``name`` attribute.
 """
 
+WARNING_MESSAGES = {
+    "Metric": {"put_data": PUT_DATA_WARNING_MESSAGE},
+}
+
+IGNORE_PARAMS = {"Metric": {"put_data": ["Namespace"]}}
+
 
 class ActionDocumenter(NestedDocumenter):
     def document_actions(self, section):
@@ -59,7 +65,7 @@ class ActionDocumenter(NestedDocumenter):
             ),
             intro_link='actions_intro',
         )
-
+        resource_warnings = WARNING_MESSAGES.get(self._resource_name, {})
         for action_name in sorted(resource_actions):
             # Create a new DocumentStructure for each action and add contents.
             action_doc = DocumentStructure(action_name, target='html')
@@ -67,10 +73,9 @@ class ActionDocumenter(NestedDocumenter):
             breadcrumb_section.style.ref(self._resource_class_name, 'index')
             breadcrumb_section.write(f' / Action / {action_name}')
             action_doc.add_title_section(action_name)
-            if self._resource_name == "Metric" and action_name == "put_data":
-                action_doc.add_new_section("warning").write(
-                    PUT_DATA_WARNING_MESSAGE
-                )
+            warning_message = resource_warnings.get(action_name)
+            if warning_message is not None:
+                action_doc.add_new_section("warning").write(warning_message)
             action_section = action_doc.add_new_section(
                 action_name,
                 context={'qualifier': f'{self.class_name}.'},
@@ -132,10 +137,10 @@ def document_action(
     operation_model = service_model.operation_model(
         action_model.request.operation
     )
-    if resource_name == "Metric" and action_model.name == "put_data":
-        ignore_params = ["Namespace"]
-    else:
-        ignore_params = get_resource_ignore_params(action_model.request.params)
+    ignore_params = IGNORE_PARAMS.get(resource_name, {}).get(
+        action_model.name,
+        get_resource_ignore_params(action_model.request.params),
+    )
     example_return_value = 'response'
     if action_model.resource:
         example_return_value = xform_name(action_model.resource.type)

--- a/boto3/docs/action.py
+++ b/boto3/docs/action.py
@@ -31,7 +31,7 @@ from boto3.docs.utils import (
 
 WARNING_MESSAGE_TEMPLATE = """
 .. warning::
-    Please note that it is recommended to use the :py:meth:`{suggested_py_method_name}`
+    It is recommended to use the :py:meth:`{suggested_py_method_name}`
     :doc:`client method <{suggested_py_method_rel_path}>` instead. {extra}
 """
 DOCUMENT_ACTION_OVERRIDES = {
@@ -44,9 +44,9 @@ DOCUMENT_ACTION_OVERRIDES = {
                     "../../cloudwatch/client/put_metric_data"
                 ),
                 extra=(
-                    "If you would still like to use this method, please make sure "
-                    "that ``MetricData[].MetricName`` is equal to the metric resource's "
-                    "``name`` attribute."
+                    "If you would still like to use this resource method, please "
+                    "make sure that ``MetricData[].MetricName`` is equal to the "
+                    "metric resource's ``name`` attribute."
                 ),
             ),
         }

--- a/boto3/docs/action.py
+++ b/boto3/docs/action.py
@@ -31,10 +31,8 @@ from boto3.docs.utils import (
 
 WARNING_MESSAGE_TEMPLATE = """
 .. warning::
-    Please note that this method does not function as expected. It is
-    recommended to use the :py:meth:`{suggested_py_method_name}`
-    :doc:`client method <{suggested_py_method_rel_path}>` instead.
-    {extra}
+    Please note that it is recommended to use the :py:meth:`{suggested_py_method_name}`
+    :doc:`client method <{suggested_py_method_rel_path}>` instead. {extra}
 """
 DOCUMENT_ACTION_OVERRIDES = {
     "Metric": {

--- a/boto3/docs/action.py
+++ b/boto3/docs/action.py
@@ -33,9 +33,8 @@ WARNING_MESSAGE_TEMPLATE = """
     .. warning::
         Please note that this method does not function as expected. It is
         recommended to use the :py:meth:`{suggested_py_method_name}`
-        :doc:`client method <{suggested_py_method_docs_relative_path}>` instead.
-        If you would still like to use this method, please make sure that
-        {instruction_string}.
+        :doc:`client method <{suggested_py_method_rel_path}>` instead.
+        {extra}
 """
 DOCUMENT_ACTION_OVERRIDES = {
     "Metric": {
@@ -43,11 +42,12 @@ DOCUMENT_ACTION_OVERRIDES = {
             "ignore_params": ["Namespace"],
             "warning": WARNING_MESSAGE_TEMPLATE.format(
                 suggested_py_method_name="put_metric_data",
-                suggested_py_method_docs_relative_path=(
+                suggested_py_method_rel_path=(
                     "../../cloudwatch/client/put_metric_data"
                 ),
-                instruction_string=(
-                    "`MetricData[].MetricName` is equal to the metric resource's "
+                extra=(
+                    "If you would still like to use this method, please make sure "
+                    "that `MetricData[].MetricName` is equal to the metric resource's "
                     "`name` attribute"
                 ),
             ),

--- a/boto3/docs/action.py
+++ b/boto3/docs/action.py
@@ -30,11 +30,11 @@ from boto3.docs.utils import (
 )
 
 WARNING_MESSAGE_TEMPLATE = """
-    .. warning::
-        Please note that this method does not function as expected. It is
-        recommended to use the :py:meth:`{suggested_py_method_name}`
-        :doc:`client method <{suggested_py_method_rel_path}>` instead.
-        {extra}
+.. warning::
+    Please note that this method does not function as expected. It is
+    recommended to use the :py:meth:`{suggested_py_method_name}`
+    :doc:`client method <{suggested_py_method_rel_path}>` instead.
+    {extra}
 """
 DOCUMENT_ACTION_OVERRIDES = {
     "Metric": {

--- a/boto3/docs/action.py
+++ b/boto3/docs/action.py
@@ -47,8 +47,8 @@ DOCUMENT_ACTION_OVERRIDES = {
                 ),
                 extra=(
                     "If you would still like to use this method, please make sure "
-                    "that `MetricData[].MetricName` is equal to the metric resource's "
-                    "`name` attribute."
+                    "that ``MetricData[].MetricName`` is equal to the metric resource's "
+                    "``name`` attribute."
                 ),
             ),
         }

--- a/boto3/docs/action.py
+++ b/boto3/docs/action.py
@@ -48,7 +48,7 @@ DOCUMENT_ACTION_OVERRIDES = {
                 extra=(
                     "If you would still like to use this method, please make sure "
                     "that `MetricData[].MetricName` is equal to the metric resource's "
-                    "`name` attribute"
+                    "`name` attribute."
                 ),
             ),
         }

--- a/tests/functional/docs/test_cloudwatch.py
+++ b/tests/functional/docs/test_cloudwatch.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+from boto3.docs.action import PUT_DATA_WARNING_MESSAGE
 from boto3.docs.service import ServiceDocumenter
 from boto3.session import Session
 from tests.functional.docs import BaseDocsFunctionalTests
@@ -31,15 +32,9 @@ class TestCloudWatchMetricPutActionOverrides(BaseDocsFunctionalTests):
         put_action_contents = self.get_nested_file_contents(
             "cloudwatch", "metric", "put_data"
         )
+        # first line is an empty string
         self.assert_contains_lines_in_order(
-            [
-                ".. warning::",
-                "It is recommended to use the :py:meth:`put_metric_data`",
-                ":doc:`client method <../../cloudwatch/client/put_metric_data>`",
-                "instead. If you would still like to use this resource method,",
-                "please make sure that ``MetricData[].MetricName`` is equal to",
-                "the metric resource's ``name`` attribute.",
-            ],
+            PUT_DATA_WARNING_MESSAGE.splitlines()[1:],
             put_action_contents,
         )
 
@@ -47,12 +42,5 @@ class TestCloudWatchMetricPutActionOverrides(BaseDocsFunctionalTests):
         put_alarm_contents = self.get_nested_file_contents(
             "cloudwatch", "metric", "put_alarm"
         )
-        lines = [
-            ".. warning::",
-            "It is recommended to use the :py:meth:`put_metric_data`",
-            ":doc:`client method <../../cloudwatch/client/put_metric_data>` instead.",
-            "If you would still like to use this resource method, please make sure that",
-            "``MetricData[].MetricName`` is equal to the metric resource's ``name`` attribute.",
-        ]
-        for line in lines:
+        for line in PUT_DATA_WARNING_MESSAGE.splitlines()[1:]:
             self.assertNotIn(line, put_alarm_contents)

--- a/tests/functional/docs/test_cloudwatch.py
+++ b/tests/functional/docs/test_cloudwatch.py
@@ -1,0 +1,69 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# https://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from boto3.docs.service import ServiceDocumenter
+from boto3.session import Session
+from tests.functional.docs import BaseDocsFunctionalTests
+
+
+class TestCloudWatchMetricPutActionOverrides(BaseDocsFunctionalTests):
+    def setUp(self):
+        super().setUp()
+        self.documenter = ServiceDocumenter(
+            'cloudwatch',
+            session=Session(region_name='us-east-1'),
+            root_docs_path=self.root_services_path,
+        )
+        self.generated_contents = self.documenter.document_service()
+        self.generated_contents = self.generated_contents.decode('utf-8')
+
+    def test_put_action_overrides(self):
+        put_action_contents = self.get_nested_file_contents(
+            "cloudwatch", "metric", "put_data"
+        )
+        self.assert_contains_lines_in_order(
+            [
+                ".. warning::",
+                "Please note that this method does not function as expected. It is",
+                "recommended to use the :py:meth:`put_metric_data`",
+                ":doc:`client method <../../cloudwatch/client/put_metric_data>` instead.",
+                "If you would still like to use this method, please make sure that",
+                "`MetricData[].MetricName` is equal to the metric resource's `name` attribute",
+            ],
+            put_action_contents,
+        )
+
+    def test_put_action_override_not_present_in_other_action(self):
+        put_alarm_contents = self.get_nested_file_contents(
+            "cloudwatch", "metric", "put_alarm"
+        )
+        try:
+            self.assert_contains_lines_in_order(
+                [
+                    ".. warning::",
+                    "Please note that this method does not function as expected. It is",
+                    "recommended to use the :py:meth:`put_metric_data`",
+                    ":doc:`client method <../../cloudwatch/client/put_metric_data>` instead.",
+                    "If you would still like to use this method, please make sure that",
+                    "`MetricData[].MetricName` is equal to the metric resource's `name` attribute",
+                ],
+                put_alarm_contents,
+            )
+        except AssertionError:
+            # We expect this to fail because the put_alarms action does not have
+            # the same override as the put_data action.
+            pass
+        else:
+            self.fail(
+                "The put_alarms action should not have the put_data override."
+            )

--- a/tests/functional/docs/test_cloudwatch.py
+++ b/tests/functional/docs/test_cloudwatch.py
@@ -34,8 +34,7 @@ class TestCloudWatchMetricPutActionOverrides(BaseDocsFunctionalTests):
         self.assert_contains_lines_in_order(
             [
                 ".. warning::",
-                "Please note that this method does not function as expected. It is",
-                "recommended to use the :py:meth:`put_metric_data`",
+                "Please note that it is recommended to use the :py:meth:`put_metric_data`",
                 ":doc:`client method <../../cloudwatch/client/put_metric_data>` instead.",
                 "If you would still like to use this method, please make sure that",
                 "``MetricData[].MetricName`` is equal to the metric resource's ``name`` attribute.",
@@ -49,8 +48,7 @@ class TestCloudWatchMetricPutActionOverrides(BaseDocsFunctionalTests):
         )
         lines = [
             ".. warning::",
-            "Please note that this method does not function as expected. It is",
-            "recommended to use the :py:meth:`put_metric_data`",
+            "Please note that it is recommended to use the :py:meth:`put_metric_data`",
             ":doc:`client method <../../cloudwatch/client/put_metric_data>` instead.",
             "If you would still like to use this method, please make sure that",
             "``MetricData[].MetricName`` is equal to the metric resource's ``name`` attribute.",

--- a/tests/functional/docs/test_cloudwatch.py
+++ b/tests/functional/docs/test_cloudwatch.py
@@ -34,9 +34,9 @@ class TestCloudWatchMetricPutActionOverrides(BaseDocsFunctionalTests):
         self.assert_contains_lines_in_order(
             [
                 ".. warning::",
-                "Please note that it is recommended to use the :py:meth:`put_metric_data`",
+                "It is recommended to use the :py:meth:`put_metric_data`",
                 ":doc:`client method <../../cloudwatch/client/put_metric_data>` instead.",
-                "If you would still like to use this method, please make sure that",
+                "If you would still like to use this resource method, please make sure that",
                 "``MetricData[].MetricName`` is equal to the metric resource's ``name`` attribute.",
             ],
             put_action_contents,
@@ -48,9 +48,9 @@ class TestCloudWatchMetricPutActionOverrides(BaseDocsFunctionalTests):
         )
         lines = [
             ".. warning::",
-            "Please note that it is recommended to use the :py:meth:`put_metric_data`",
+            "It is recommended to use the :py:meth:`put_metric_data`",
             ":doc:`client method <../../cloudwatch/client/put_metric_data>` instead.",
-            "If you would still like to use this method, please make sure that",
+            "If you would still like to use this resource method, please make sure that",
             "``MetricData[].MetricName`` is equal to the metric resource's ``name`` attribute.",
         ]
         for line in lines:

--- a/tests/functional/docs/test_cloudwatch.py
+++ b/tests/functional/docs/test_cloudwatch.py
@@ -35,9 +35,10 @@ class TestCloudWatchMetricPutActionOverrides(BaseDocsFunctionalTests):
             [
                 ".. warning::",
                 "It is recommended to use the :py:meth:`put_metric_data`",
-                ":doc:`client method <../../cloudwatch/client/put_metric_data>` instead.",
-                "If you would still like to use this resource method, please make sure that",
-                "``MetricData[].MetricName`` is equal to the metric resource's ``name`` attribute.",
+                ":doc:`client method <../../cloudwatch/client/put_metric_data>`",
+                "instead. If you would still like to use this resource method,",
+                "please make sure that ``MetricData[].MetricName`` is equal to",
+                "the metric resource's ``name`` attribute.",
             ],
             put_action_contents,
         )

--- a/tests/functional/docs/test_cloudwatch.py
+++ b/tests/functional/docs/test_cloudwatch.py
@@ -38,7 +38,7 @@ class TestCloudWatchMetricPutActionOverrides(BaseDocsFunctionalTests):
                 "recommended to use the :py:meth:`put_metric_data`",
                 ":doc:`client method <../../cloudwatch/client/put_metric_data>` instead.",
                 "If you would still like to use this method, please make sure that",
-                "`MetricData[].MetricName` is equal to the metric resource's `name` attribute",
+                "``MetricData[].MetricName`` is equal to the metric resource's ``name`` attribute.",
             ],
             put_action_contents,
         )
@@ -55,7 +55,7 @@ class TestCloudWatchMetricPutActionOverrides(BaseDocsFunctionalTests):
                     "recommended to use the :py:meth:`put_metric_data`",
                     ":doc:`client method <../../cloudwatch/client/put_metric_data>` instead.",
                     "If you would still like to use this method, please make sure that",
-                    "`MetricData[].MetricName` is equal to the metric resource's `name` attribute",
+                    "``MetricData[].MetricName`` is equal to the metric resource's ``name`` attribute.",
                 ],
                 put_alarm_contents,
             )

--- a/tests/functional/docs/test_cloudwatch.py
+++ b/tests/functional/docs/test_cloudwatch.py
@@ -47,23 +47,13 @@ class TestCloudWatchMetricPutActionOverrides(BaseDocsFunctionalTests):
         put_alarm_contents = self.get_nested_file_contents(
             "cloudwatch", "metric", "put_alarm"
         )
-        try:
-            self.assert_contains_lines_in_order(
-                [
-                    ".. warning::",
-                    "Please note that this method does not function as expected. It is",
-                    "recommended to use the :py:meth:`put_metric_data`",
-                    ":doc:`client method <../../cloudwatch/client/put_metric_data>` instead.",
-                    "If you would still like to use this method, please make sure that",
-                    "``MetricData[].MetricName`` is equal to the metric resource's ``name`` attribute.",
-                ],
-                put_alarm_contents,
-            )
-        except AssertionError:
-            # We expect this to fail because the put_alarms action does not have
-            # the same override as the put_data action.
-            pass
-        else:
-            self.fail(
-                "The put_alarms action should not have the put_data override."
-            )
+        lines = [
+            ".. warning::",
+            "Please note that this method does not function as expected. It is",
+            "recommended to use the :py:meth:`put_metric_data`",
+            ":doc:`client method <../../cloudwatch/client/put_metric_data>` instead.",
+            "If you would still like to use this method, please make sure that",
+            "``MetricData[].MetricName`` is equal to the metric resource's ``name`` attribute.",
+        ]
+        for line in lines:
+            self.assertNotIn(line, put_alarm_contents)


### PR DESCRIPTION
This pr addresses https://github.com/boto/boto3/issues/1396.

It provides a manual override for the `Metric.put_data` documentation page. It currently does not display `kwargs`/input arguments for the API call because it correctly ignores `MetricNamespace` and incorrectly ignores `MetricName`. Both of these parameters are attached to the resource object, but `MetricName` is nested within `MetricData`. This list requires at least one other parameter, for example a `dimension` to be passed to the call.

This is confusing and incorrect behavior. However, fixing it would constitute a breaking change. So instead, a warning label has been added to the top of the page pointing users to the lower level client's `put_metric_data` API instead. If they still would like to use `put_data` though, the `MetricData` object is now correctly displayed so they can do so with more ease. I tested the hyperlink in the warning message by spinning up a local server and it sends you to the correct page.

New  page is below. Existing one is here: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudwatch/metric/put_data.html
<img width="1239" alt="put_data_updated1" src="https://user-images.githubusercontent.com/45697098/234984502-e068fb32-1893-46d5-8696-d19de3938f5c.png">
![put_data_updated2](https://user-images.githubusercontent.com/45697098/233118640-7fa2fd5a-37e4-4f7e-84a6-a894b4a4b40b.png)
![put_data_updated3](https://user-images.githubusercontent.com/45697098/233118642-cdf47e78-7df0-4d79-b324-45d818f62791.png)
![put_data_updated4](https://user-images.githubusercontent.com/45697098/233118645-f69d1a9d-55bd-4e00-b3b9-4c6b61a4d4a3.png)