### PR TITLE
Address that Sigv4 presigned URLs are not properly generated, but SigV2 (default for S3) signatures are valid.

### DIFF
--- a/docs/source/guide/s3-presigned-urls.rst
+++ b/docs/source/guide/s3-presigned-urls.rst
@@ -24,6 +24,12 @@ used by the presigned URL are those of the AWS user who generated the URL.
 A presigned URL remains valid for a limited period of time which is specified 
 when the URL is generated.
 
+..  note::
+    Buckets which require the ``X-Amzn-Payer: Requestor`` header must use the (default) Signature V2 used in S3 for presigned URLs.
+    You will receive a ``SignatureDoesNotMatch`` exception if you attempt to use the non-default ``v4`` or ``s3v4`` signature methods
+    when performing the action. 
+    
+
 .. code-block:: python
 
     import logging


### PR DESCRIPTION
This is a small documentation fix to the bug #3685. The issue is known: Sigv4 doesn't preserve the list of headers properly and misses signing some critical headers for some reason.