### PR TITLE
docs: fix broken hyperlink to examples

### DIFF
--- a/docs/source/guide/examples.rst
+++ b/docs/source/guide/examples.rst
@@ -23,7 +23,7 @@ To propose a new code example for the AWS documentation team to consider produci
 The team is looking to produce code examples that cover broader scenarios and use cases,
 versus simple code snippets that cover only individual API calls. For instructions, see
 the "Proposing new code examples" section in the
-`Readme on GitHub <https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/README.rst>`_.
+`Readme on GitHub <https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/README.md>`_.
 
 Before running an example, your AWS credentials must be configured as
 described in :doc:`quickstart`.

--- a/docs/source/guide/examples.rst
+++ b/docs/source/guide/examples.rst
@@ -17,13 +17,13 @@ Code Examples
 This section describes code examples that demonstrate how to use the AWS SDK
 for Python to call various AWS services. The source files for the examples,
 plus additional example programs, are available in the `AWS Code
-Catalog <https://github.com/awsdocs/aws-doc-sdk-examples/tree/master/python/example_code>`_.
+Catalog <https://github.com/awsdocs/aws-doc-sdk-examples/tree/main/python/example_code>`_.
 
 To propose a new code example for the AWS documentation team to consider producing, create a new request.
 The team is looking to produce code examples that cover broader scenarios and use cases,
 versus simple code snippets that cover only individual API calls. For instructions, see
 the "Proposing new code examples" section in the
-`Readme on GitHub <https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/README.md>`_.
+`Readme on GitHub <https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/README.md>`_.
 
 Before running an example, your AWS credentials must be configured as
 described in :doc:`quickstart`.


### PR DESCRIPTION
**PR Summary**:
This PR addresses a broken hyperlink present in the documentation that should direct users to the README file within the `aws-doc-sdk-examples` repository. The issue arose from a change in the README file's format (note this [PR](https://github.com/awsdocs/aws-doc-sdk-examples/pull/3715)) - it was transitioned from `README.rst` to `README.md`. Therefore, this PR modifies the hyperlink to correctly direct to the updated `README.md` file.