### PR TITLE
Add upcoming deprecation warning for Python 3.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,14 +17,9 @@ Boto (pronounced boh-toh) was named after the fresh water dolphin native to the 
 Notices
 -------
 
-On 2021-01-15, deprecation for Python 2.7 was announced and support was dropped
-on 2021-07-15. To avoid disruption, customers using Boto3 on Python 2.7 may
-need to upgrade their version of Python or pin the version of Boto3. For
-more information, see this `blog post <https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/>`__.
-
-On 2022-05-30, support for Python 3.6 was ended. This follows the
-Python Software Foundation `end of support <https://www.python.org/dev/peps/pep-0494/#lifespan>`__
-for the runtime which occurred on 2021-12-23.
+On 2023-12-13, support for Python 3.7 will end for Boto3. This follows the
+Python Software Foundation `end of support <https://peps.python.org/pep-0537/#lifespan>`__
+for the runtime which occurred on 2023-06-27.
 For more information, see this `blog post <https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/>`__.
 
 .. _boto: https://docs.pythonboto.org/

--- a/boto3/compat.py
+++ b/boto3/compat.py
@@ -58,8 +58,8 @@ def filter_python_deprecation_warnings():
 
 def _warn_deprecated_python():
     """Use this template for future deprecation campaigns as needed."""
-    py_36_params = {
-        'date': 'May 30, 2022',
+    py_37_params = {
+        'date': 'December 13, 2023',
         'blog_link': (
             'https://aws.amazon.com/blogs/developer/'
             'python-support-policy-updates-for-aws-sdks-and-tools/'
@@ -67,7 +67,7 @@ def _warn_deprecated_python():
     }
     deprecated_versions = {
         # Example template for future deprecations
-        # (3, 6): py_36_params,
+        (3, 7): py_37_params,
     }
     py_version = sys.version_info[:2]
 
@@ -76,7 +76,7 @@ def _warn_deprecated_python():
         warning = (
             "Boto3 will no longer support Python {}.{} "
             "starting {}. To continue receiving service updates, "
-            "bug fixes, and security updates please upgrade to Python 3.7 or "
+            "bug fixes, and security updates please upgrade to Python 3.8 or "
             "later. More information can be found here: {}"
         ).format(py_version[0], py_version[1], params['date'], params['blog_link'])
         warnings.warn(warning, PythonDeprecationWarning)

--- a/docs/source/guide/migrationpy3.rst
+++ b/docs/source/guide/migrationpy3.rst
@@ -14,7 +14,7 @@ module) and Boto3 (which implements the API functionality and higher-level featu
 Timeline
 --------
 Going forward, all projects using Boto3 need to transition to Python 3.8 or later. Boto3 and
-Botocore ended support for Python 3.4 and 3.5 on Feb 21, 2021, and support for Python 2.7
+Botocore will end support for Python 3.7 on December, 13, 2023, and support for Python 2.7
 ended July 15, 2021.
 
 Updating your project to use Python 3

--- a/docs/source/guide/migrationpy3.rst
+++ b/docs/source/guide/migrationpy3.rst
@@ -13,7 +13,7 @@ module) and Boto3 (which implements the API functionality and higher-level featu
 
 Timeline
 --------
-Going forward, all projects using Boto3 need to transition to Python 3.7 or later. Boto3 and
+Going forward, all projects using Boto3 need to transition to Python 3.8 or later. Boto3 and
 Botocore ended support for Python 3.4 and 3.5 on Feb 21, 2021, and support for Python 2.7
 ended July 15, 2021.
 
@@ -21,7 +21,7 @@ Updating your project to use Python 3
 -------------------------------------
 
 Before you begin to update your project and environment, make sure you’ve installed or updated to
-Python 3.7 or later as described in :ref:`upgrade to Python 3 <quickstart_install_python>`. You can
+Python 3.8 or later as described in :ref:`upgrade to Python 3 <quickstart_install_python>`. You can
 get Python from the `PSF web site <https://www.python.org/downloads>`_ or using your local package
 manager.
 

--- a/docs/source/guide/quickstart.rst
+++ b/docs/source/guide/quickstart.rst
@@ -24,11 +24,11 @@ To use Boto3, you first need to install it and its dependencies.
 Install or update Python
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Before installing Boto3, install Python 3.7 or later; support for Python 3.6 and
+Before installing Boto3, install Python 3.8 or later; support for Python 3.6 and
 earlier is deprecated. After the deprecation date listed for each Python
 version, new releases of Boto3 will not include support for that version of
 Python. For details, including the deprecation schedule and how to update your
-project to use Python 3.7, see :ref:`guide_migration_py3`.
+project to use Python 3.8, see :ref:`guide_migration_py3`.
 
 For information about how to get the latest version of Python, see the official `Python
 documentation <https://www.python.org/downloads/>`_. 


### PR DESCRIPTION
Raise a warning for users when Boto3 is run in Python 3.7. This is to provide a preliminary notice to users and gather feedback on migration now that Python 3.7 is officially unsupported by the CPython team ([ref](https://peps.python.org/pep-0537/#lifespan)).

Full information on the long-term SDK support plan for Python versions can be found in this [blog post](https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/).