### PR TITLE
Fix Environment Variable Naming Convention

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,8 +71,8 @@ Next, set up credentials (in e.g. ``~/.aws/credentials``):
 .. code-block:: ini
 
     [default]
-    aws_access_key_id = YOUR_KEY
-    aws_secret_access_key = YOUR_SECRET
+    AWS_ACCESS_KEY_ID = YOUR_KEY
+    AWS_SECRET_ACCESS_KEY = YOUR_SECRET
 
 Then, set up a default region (in e.g. ``~/.aws/config``):
 


### PR DESCRIPTION
- Renamed the AWS access key ID and secret access key environment variables to uppercase.
  - `aws_access_key_id` -> `AWS_ACCESS_KEY_ID`
  - `aws_secret_access_key` -> `AWS_SECRET_ACCESS_KEY`

When running locally,  using `aws_access_key_id` and `aws_secret_access_key` works fine, but when deployed to cloud (Heroku in this case) it results in credential-related errors unless the variables are set as `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` which also works locally.

cloud python  = 3.11.4
local python version = 3.9.8