### PR TITLE
Fix broken docs fragment

### DIFF
--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -40,7 +40,7 @@ function isValidFragment(splitFragment) {
 }
 // Checks if a name is a possible resource name.
 function isValidResource(name, serviceDocName) {
-	return name.replaceAll('-', '') !== serviceDocName && !nonResourceSubHeadings.includes(name);
+	return name !== serviceDocName.replaceAll('-', '') && !nonResourceSubHeadings.includes(name);
 }
 // Reroutes previously existing links to the new path.
 // Old: <root_url>/reference/services/s3.html#S3.Client.delete_bucket

--- a/docs/source/_templates/page.html
+++ b/docs/source/_templates/page.html
@@ -183,7 +183,7 @@ furnished to do so, subject to the following conditions:
             });
                         shortbread.checkForCookieConsent();
                 </script>
-                <a href="http://aws.amazon.com/privacy">Privacy</a> | <a href="http://aws.amazon.com/terms">Site Terms</a> | <a
+                <a href="https://aws.amazon.com/privacy">Privacy</a> | <a href="https://aws.amazon.com/terms">Site Terms</a> | <a
                     href="#" onclick="shortbread.customizeCookies();">Cookie preferences</a>
             </div>
             {# end of AWS modification of Furo template #}


### PR DESCRIPTION
Currently there's an issue where the docs page automatically redirects some fragments to a non-existent web page.  This occurs when the fragment is pointing to the title of the page and only for services with a hyphen in their service name.  One example of a broken fragment is for [sagemaker-metrics](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker-metrics.html#sagemakermetrics).  