### PR TITLE
Add internal links to S3 upload/download args

### DIFF
--- a/boto3/s3/inject.py
+++ b/boto3/s3/inject.py
@@ -129,7 +129,7 @@ def upload_file(
     :type ExtraArgs: dict
     :param ExtraArgs: Extra arguments that may be passed to the
         client operation. For allowed upload arguments see
-        boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS.
+        :py:attr:`boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS`.
 
     :type Callback: function
     :param Callback: A method which takes a number of bytes transferred to
@@ -176,7 +176,7 @@ def download_file(
     :type ExtraArgs: dict
     :param ExtraArgs: Extra arguments that may be passed to the
         client operation. For allowed download arguments see
-        boto3.s3.transfer.S3Transfer.ALLOWED_DOWNLOAD_ARGS.
+        :py:attr:`boto3.s3.transfer.S3Transfer.ALLOWED_DOWNLOAD_ARGS`.
 
     :type Callback: function
     :param Callback: A method which takes a number of bytes transferred to
@@ -220,7 +220,7 @@ def bucket_upload_file(
     :type ExtraArgs: dict
     :param ExtraArgs: Extra arguments that may be passed to the
         client operation. For allowed upload arguments see
-        boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS.
+        :py:attr:`boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS`.
 
     :type Callback: function
     :param Callback: A method which takes a number of bytes transferred to
@@ -264,7 +264,7 @@ def bucket_download_file(
     :type ExtraArgs: dict
     :param ExtraArgs: Extra arguments that may be passed to the
         client operation. For allowed download arguments see
-        boto3.s3.transfer.S3Transfer.ALLOWED_DOWNLOAD_ARGS.
+        :py:attr:`boto3.s3.transfer.S3Transfer.ALLOWED_DOWNLOAD_ARGS`.
 
     :type Callback: function
     :param Callback: A method which takes a number of bytes transferred to
@@ -305,7 +305,7 @@ def object_upload_file(
     :type ExtraArgs: dict
     :param ExtraArgs: Extra arguments that may be passed to the
         client operation. For allowed upload arguments see
-        boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS.
+        :py:attr:`boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS`.
 
     :type Callback: function
     :param Callback: A method which takes a number of bytes transferred to
@@ -346,7 +346,7 @@ def object_download_file(
     :type ExtraArgs: dict
     :param ExtraArgs: Extra arguments that may be passed to the
         client operation. For allowed download arguments see
-        boto3.s3.transfer.S3Transfer.ALLOWED_DOWNLOAD_ARGS.
+        :py:attr:`boto3.s3.transfer.S3Transfer.ALLOWED_DOWNLOAD_ARGS`.
 
     :type Callback: function
     :param Callback: A method which takes a number of bytes transferred to
@@ -407,7 +407,7 @@ def copy(
     :type ExtraArgs: dict
     :param ExtraArgs: Extra arguments that may be passed to the
         client operation. For allowed download arguments see
-        boto3.s3.transfer.S3Transfer.ALLOWED_DOWNLOAD_ARGS.
+        :py:attr:`boto3.s3.transfer.S3Transfer.ALLOWED_DOWNLOAD_ARGS`.
 
     :type Callback: function
     :param Callback: A method which takes a number of bytes transferred to
@@ -482,7 +482,7 @@ def bucket_copy(
     :type ExtraArgs: dict
     :param ExtraArgs: Extra arguments that may be passed to the
         client operation. For allowed download arguments see
-        boto3.s3.transfer.S3Transfer.ALLOWED_DOWNLOAD_ARGS.
+        :py:attr:`boto3.s3.transfer.S3Transfer.ALLOWED_DOWNLOAD_ARGS`.
 
     :type Callback: function
     :param Callback: A method which takes a number of bytes transferred to
@@ -545,7 +545,7 @@ def object_copy(
     :type ExtraArgs: dict
     :param ExtraArgs: Extra arguments that may be passed to the
         client operation. For allowed download arguments see
-        boto3.s3.transfer.S3Transfer.ALLOWED_DOWNLOAD_ARGS.
+        :py:attr:`boto3.s3.transfer.S3Transfer.ALLOWED_DOWNLOAD_ARGS`.
 
     :type Callback: function
     :param Callback: A method which takes a number of bytes transferred to
@@ -604,7 +604,7 @@ def upload_fileobj(
     :type ExtraArgs: dict
     :param ExtraArgs: Extra arguments that may be passed to the
         client operation. For allowed upload arguments see
-        boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS.
+        :py:attr:`boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS`.
 
     :type Callback: function
     :param Callback: A method which takes a number of bytes transferred to
@@ -665,7 +665,7 @@ def bucket_upload_fileobj(
     :type ExtraArgs: dict
     :param ExtraArgs: Extra arguments that may be passed to the
         client operation. For allowed upload arguments see
-        boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS.
+        :py:attr:`boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS`.
 
     :type Callback: function
     :param Callback: A method which takes a number of bytes transferred to
@@ -712,7 +712,7 @@ def object_upload_fileobj(
     :type ExtraArgs: dict
     :param ExtraArgs: Extra arguments that may be passed to the
         client operation. For allowed upload arguments see
-        boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS.
+        :py:attr:`boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS`.
 
     :type Callback: function
     :param Callback: A method which takes a number of bytes transferred to
@@ -763,7 +763,7 @@ def download_fileobj(
     :type ExtraArgs: dict
     :param ExtraArgs: Extra arguments that may be passed to the
         client operation. For allowed download arguments see
-        boto3.s3.transfer.S3Transfer.ALLOWED_DOWNLOAD_ARGS.
+        :py:attr:`boto3.s3.transfer.S3Transfer.ALLOWED_DOWNLOAD_ARGS`.
 
     :type Callback: function
     :param Callback: A method which takes a number of bytes transferred to
@@ -824,7 +824,7 @@ def bucket_download_fileobj(
     :type ExtraArgs: dict
     :param ExtraArgs: Extra arguments that may be passed to the
         client operation. For allowed download arguments see
-        boto3.s3.transfer.S3Transfer.ALLOWED_DOWNLOAD_ARGS.
+        :py:attr:`boto3.s3.transfer.S3Transfer.ALLOWED_DOWNLOAD_ARGS`.
 
     :type Callback: function
     :param Callback: A method which takes a number of bytes transferred to
@@ -871,7 +871,7 @@ def object_download_fileobj(
     :type ExtraArgs: dict
     :param ExtraArgs: Extra arguments that may be passed to the
         client operation. For allowed download arguments see
-        boto3.s3.transfer.S3Transfer.ALLOWED_DOWNLOAD_ARGS.
+        :py:attr:`boto3.s3.transfer.S3Transfer.ALLOWED_DOWNLOAD_ARGS`.
 
     :type Callback: function
     :param Callback: A method which takes a number of bytes transferred to


### PR DESCRIPTION
See: https://github.com/boto/boto3/issues/3787

Currently looks like:

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/upload_file.html
![image](https://github.com/boto/boto3/assets/87778557/d9413eba-474c-4f8c-a3b9-b5b708ed0257)

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/download_file.html
![image](https://github.com/boto/boto3/assets/87778557/b8e95ab8-8cb9-4686-8964-9e79ee2e1f13)

After changes:

![image](https://github.com/boto/boto3/assets/87778557/37694142-0e3c-4ff1-9931-1e3c01ed7ef4)
![image](https://github.com/boto/boto3/assets/87778557/ce69a23d-f642-4bfb-906d-286ca359d47e)