### PR TITLE
Remove period in waiter documentation 

### DIFF
--- a/boto3/docs/waiter.py
+++ b/boto3/docs/waiter.py
@@ -90,7 +90,7 @@ def document_resource_waiter(
     service_module_name = get_service_module_name(service_model)
     description = (
         'Waits until this {} is {}. This method calls '
-        ':py:meth:`{}.Waiter.{}.wait` which polls. '
+        ':py:meth:`{}.Waiter.{}.wait` which polls '
         ':py:meth:`{}.Client.{}` every {} seconds until '
         'a successful state is reached. An error is returned '
         'after {} failed checks.'.format(

--- a/tests/unit/docs/test_docstring.py
+++ b/tests/unit/docs/test_docstring.py
@@ -272,7 +272,7 @@ class TestResourceDocstrings(BaseDocsTest):
                 (
                     '    Waits until this Sample is complete. This method calls '
                     ':py:meth:`MyService.Waiter.sample_operation_complete.wait` '
-                    'which polls. :py:meth:`MyService.Client.sample_operation` every '
+                    'which polls :py:meth:`MyService.Client.sample_operation` every '
                     '15 seconds until a successful state is reached. An error '
                     'is returned after 40 failed checks.'
                 ),

--- a/tests/unit/docs/test_waiter.py
+++ b/tests/unit/docs/test_waiter.py
@@ -39,7 +39,7 @@ class TestWaiterResourceDocumenter(BaseDocsTest):
                 (
                     '  Waits until this Sample is complete. This method calls '
                     ':py:meth:`MyService.Waiter.sample_operation_complete.wait` '
-                    'which polls. :py:meth:`MyService.Client.sample_operation` '
+                    'which polls :py:meth:`MyService.Client.sample_operation` '
                     'every 15 seconds until a successful state is reached. An '
                     'error is returned after 40 failed checks.'
                 ),


### PR DESCRIPTION
See auto-generated waiter documentation, for example: https://boto3.amazonaws.com/v1/documentation/api/1.26.130/reference/services/s3/bucket/wait_until_exists.html

<img width="742" alt="image" src="https://github.com/boto/boto3/assets/87778557/31915dac-36ec-4d76-865f-2697a6477f27">

I don't think the period in "which polls." is supposed to be there.