### PR TITLE
add client context params to boto3 docs

### DIFF
--- a/boto3/docs/service.py
+++ b/boto3/docs/service.py
@@ -46,6 +46,7 @@ class ServiceDocumenter(BaseServiceDocumenter):
             'waiters',
             'resources',
             'examples',
+            'context-params',
         ]
         self._root_docs_path = root_docs_path
         self._USER_GUIDE_LINK = (
@@ -69,6 +70,8 @@ class ServiceDocumenter(BaseServiceDocumenter):
         if self._service_resource:
             self.resource_section(doc_structure.get_section('resources'))
         self._document_examples(doc_structure.get_section('examples'))
+        context_params_section = doc_structure.get_section('context-params')
+        self.client_context_params(context_params_section)
         return doc_structure.flush_structure()
 
     def client_api(self, section):

--- a/tests/unit/docs/test_service.py
+++ b/tests/unit/docs/test_service.py
@@ -276,3 +276,23 @@ class TestServiceDocumenter(BaseDocsTest):
         contents = service_documenter.document_service().decode('utf-8')
         assert 'This is an example' in contents
         assert 'This is for another service' not in contents
+
+    def test_service_with_context_params(self):
+        self.json_model['clientContextParams'] = {
+            'MyContextParam': {
+                'documentation': 'This is my context param',
+                'type': 'boolean',
+            }
+        }
+        self.setup_client_and_resource()
+        service_documenter = ServiceDocumenter(
+            'myservice', self.session, self.root_services_path
+        )
+        contents = service_documenter.document_service().decode('utf-8')
+        lines = [
+            "=========================",
+            "Client Context Parameters",
+            "=========================",
+            "* ``my_context_param`` (boolean) - This is my context param",
+        ]
+        self.assert_contains_lines_in_order(lines, contents)


### PR DESCRIPTION
Follow up to https://github.com/boto/botocore/pull/3037. Adds Context param doc generation to boto3 docs