### PR TITLE
add credential scope

### DIFF
--- a/boto3/session.py
+++ b/boto3/session.py
@@ -46,6 +46,8 @@ class Session:
                          the default profile is used.
     :type aws_account_id: string
     :param aws_account_id: AWS account ID
+    :type aws_credential_scope: string
+    :param aws_credential_scope: AWS credential scope
     """
 
     def __init__(
@@ -57,6 +59,7 @@ class Session:
         botocore_session=None,
         profile_name=None,
         aws_account_id=None,
+        aws_credential_scope=None,
     ):
         if botocore_session is not None:
             self._session = botocore_session
@@ -85,6 +88,7 @@ class Session:
                 aws_secret_access_key,
                 aws_session_token,
                 aws_account_id,
+                aws_credential_scope,
             )
 
         if region_name is not None:
@@ -233,6 +237,7 @@ class Session:
         aws_session_token=None,
         config=None,
         aws_account_id=None,
+        aws_credential_scope=None,
     ):
         """
         Create a low-level service client by name.
@@ -304,6 +309,10 @@ class Session:
         :param aws_account_id: The AWS account ID to use when creating the
             client. Same semantics as aws_access_key_id above.
 
+        :type aws_credential_scope: string
+        :param aws_credential_scope: The AWS credential scope to use when
+            creating the client. Same semantics as aws_access_key_id above.
+
         :return: Service client instance
 
         """
@@ -319,6 +328,7 @@ class Session:
             aws_session_token=aws_session_token,
             config=config,
             aws_account_id=aws_account_id,
+            aws_credential_scope=aws_credential_scope,
         )
 
     def resource(
@@ -334,6 +344,7 @@ class Session:
         aws_session_token=None,
         config=None,
         aws_account_id=None,
+        aws_credential_scope=None,
     ):
         """
         Create a resource service client by name.
@@ -407,6 +418,10 @@ class Session:
         :param aws_account_id: The AWS account ID to use when creating the
             client. Same semantics as aws_access_key_id above.
 
+        :type aws_credential_scope: string
+        :param aws_credential_scope: The AWS credential scope to use when
+            creating the client. Same semantics as aws_access_key_id above.
+
         :return: Subclass of :py:class:`~boto3.resources.base.ServiceResource`
         """
         try:
@@ -472,6 +487,7 @@ class Session:
             aws_session_token=aws_session_token,
             config=config,
             aws_account_id=aws_account_id,
+            aws_credential_scope=aws_credential_scope,
         )
         service_model = client.meta.service_model
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -67,12 +67,13 @@ class TestSession(BaseTestCase):
             aws_secret_access_key='secret',
             aws_session_token='token',
             aws_account_id='account_id',
+            aws_credential_scope='scope',
         )
 
         assert self.bc_session_cls.called
         assert bc_session.set_credentials.called
         bc_session.set_credentials.assert_called_with(
-            'key', 'secret', 'token', 'account_id'
+            'key', 'secret', 'token', 'account_id', 'scope'
         )
 
     def test_can_get_credentials(self):
@@ -80,12 +81,14 @@ class TestSession(BaseTestCase):
         secret_key = 'bar'
         token = 'baz'
         account_id = 'account_id'
+        scope = 'scope'
 
         creds = mock.Mock()
         creds.access_key = access_key
         creds.secret_key = secret_key
         creds.token = token
         creds.account_id = account_id
+        creds.scope = scope
 
         bc_session = self.bc_session_cls.return_value
         bc_session.get_credentials.return_value = creds
@@ -95,6 +98,7 @@ class TestSession(BaseTestCase):
             aws_secret_access_key=secret_key,
             aws_session_token=token,
             aws_account_id=account_id,
+            aws_credential_scope=scope,
         )
 
         credentials = session.get_credentials()
@@ -102,6 +106,7 @@ class TestSession(BaseTestCase):
         assert credentials.secret_key == secret_key
         assert credentials.token == token
         assert credentials.account_id == account_id
+        assert credentials.scope == scope
 
     def test_profile_can_be_set(self):
         bc_session = self.bc_session_cls.return_value
@@ -248,6 +253,7 @@ class TestSession(BaseTestCase):
             api_version=None,
             config=None,
             aws_account_id=None,
+            aws_credential_scope=None,
         )
 
     def test_create_resource_with_args(self):
@@ -277,6 +283,7 @@ class TestSession(BaseTestCase):
             api_version='2014-11-02',
             config=mock.ANY,
             aws_account_id=None,
+            aws_credential_scope=None,
         )
         client_config = session.client.call_args[1]['config']
         assert client_config.user_agent_extra == 'Resource'
@@ -310,6 +317,7 @@ class TestSession(BaseTestCase):
             api_version='2014-11-02',
             config=mock.ANY,
             aws_account_id=None,
+            aws_credential_scope=None,
         )
         client_config = session.client.call_args[1]['config']
         assert client_config.user_agent_extra == 'Resource'
@@ -343,6 +351,7 @@ class TestSession(BaseTestCase):
             api_version='2014-11-02',
             config=mock.ANY,
             aws_account_id=None,
+            aws_credential_scope=None,
         )
         client_config = session.client.call_args[1]['config']
         assert client_config.user_agent_extra == 'foo'


### PR DESCRIPTION
Adds `aws_credential_scope` to boto3 `Session` contructor, `client` and `resource` APIs. Please note that CI will not succeed until https://github.com/boto/botocore/pull/3031, https://github.com/boto/botocore/pull/3048 and  https://github.com/boto/boto3/pull/3888 are merged. After merging the other PRs, the base branch of this will be changed to `develop`.