### PR TITLE
Add CRT Transfer option to Boto3 on select instance types

### DIFF
--- a/.github/workflows/run-crt-test.yml
+++ b/.github/workflows/run-crt-test.yml
@@ -1,0 +1,31 @@
+name: Run CRT tests
+ 
+on:
+  push:
+  pull_request:
+    branches-ignore: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: '${{ matrix.os }}'
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+      - name: 'Set up Python ${{ matrix.python-version }}'
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
+        with:
+          python-version: '${{ matrix.python-version }}'
+      - name: Install dependencies and CRT
+        run: |
+          python scripts/ci/install --extras crt
+      - name: Run tests
+        run: |
+          python scripts/ci/run-crt-tests --with-cov --with-xdist

--- a/boto3/crt.py
+++ b/boto3/crt.py
@@ -1,0 +1,161 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# https://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""
+This file contains private functionality for interacting with the AWS
+Common Runtime library (awscrt) in boto3.
+
+All code contained within this file is for internal usage within this
+project and is not intended for external consumption. All interfaces
+contained within are subject to abrupt breaking changes.
+"""
+
+import threading
+
+import botocore.exceptions
+from botocore.session import Session
+from s3transfer.crt import (
+    BotocoreCRTCredentialsWrapper,
+    BotocoreCRTRequestSerializer,
+    CRTTransferManager,
+    acquire_crt_s3_process_lock,
+    create_s3_crt_client,
+)
+
+# Singletons for CRT-backed transfers
+_CRT_S3_CLIENT = None
+_BOTOCORE_CRT_SERIALIZER = None
+
+CLIENT_CREATION_LOCK = threading.Lock()
+PROCESS_LOCK_NAME = 'boto3'
+
+
+def _create_crt_client(session, config, region_name, cred_provider):
+    """Create a CRT S3 Client for file transfer.
+
+    Instantiating many of these may lead to degraded performance or
+    system resource exhaustion.
+    """
+    create_crt_client_kwargs = {
+        'region': region_name,
+        'use_ssl': True,
+        'crt_credentials_provider': cred_provider,
+    }
+    return create_s3_crt_client(**create_crt_client_kwargs)
+
+
+def _create_crt_request_serializer(session, region_name):
+    return BotocoreCRTRequestSerializer(
+        session, {'region_name': region_name, 'endpoint_url': None}
+    )
+
+
+def _create_crt_s3_client(session, config, region_name, credentials, **kwargs):
+    """Create boto3 wrapper class to manage crt lock reference and S3 client."""
+    lock = acquire_crt_s3_process_lock(PROCESS_LOCK_NAME)
+    if lock is None:
+        # If we're unable to acquire the lock, we cannot
+        # use the CRT in this process and should default to
+        # the classic s3transfer manager.
+        return None
+
+    cred_wrapper = BotocoreCRTCredentialsWrapper(credentials)
+    cred_provider = cred_wrapper.to_crt_credentials_provider()
+    return CRTS3Client(
+        _create_crt_client(session, config, region_name, cred_provider),
+        lock,
+        region_name,
+        cred_wrapper,
+    )
+
+
+def _initialize_crt_transfer_primatives(client, config):
+    session = Session()
+    region_name = client.meta.region_name
+    credentials = client._get_credentials()
+
+    serializer = _create_crt_request_serializer(session, region_name)
+    s3_client = _create_crt_s3_client(
+        session, config, region_name, credentials
+    )
+    return serializer, s3_client
+
+
+def get_crt_s3_client(client, config):
+    global _CRT_S3_CLIENT
+    global _BOTOCORE_CRT_SERIALIZER
+
+    with CLIENT_CREATION_LOCK:
+        if _CRT_S3_CLIENT is None:
+            serializer, s3_client = _initialize_crt_transfer_primatives(
+                client, config
+            )
+            _BOTOCORE_CRT_SERIALIZER = serializer
+            _CRT_S3_CLIENT = s3_client
+
+    return _CRT_S3_CLIENT
+
+
+class CRTS3Client:
+    """
+    This wrapper keeps track of our underlying CRT client, the lock used to
+    acquire it and the region we've used to instantiate the client.
+
+    Due to limitations in the existing CRT interfaces, we can only make calls
+    in a single region and does not support redirects. We track the region to
+    ensure we don't use the CRT client when a successful request cannot be made.
+    """
+
+    def __init__(self, crt_client, process_lock, region, cred_provider):
+        self.crt_client = crt_client
+        self.process_lock = process_lock
+        self.region = region
+        self.cred_provider = cred_provider
+
+
+def is_crt_compatible_request(client, crt_s3_client):
+    """
+    Boto3 client must use same signing region and credentials
+    as the _CRT_S3_CLIENT singleton. Otherwise fallback to classic.
+    """
+    if crt_s3_client is None:
+        return False
+
+    is_same_region = client.meta.region_name == crt_s3_client.region
+    is_same_identity = compare_identity(
+        client._get_credentials(), crt_s3_client.cred_provider
+    )
+    return is_same_region and is_same_identity
+
+
+def compare_identity(boto3_creds, crt_s3_creds):
+    try:
+        crt_creds = crt_s3_creds()
+    except botocore.exceptions.NoCredentialsError:
+        return False
+
+    is_matching_identity = (
+        boto3_creds.access_key == crt_creds.access_key_id
+        and boto3_creds.secret_key == crt_creds.secret_access_key
+        and boto3_creds.token == crt_creds.session_token
+    )
+    return is_matching_identity
+
+
+def create_crt_transfer_manager(client, config):
+    """Create a CRTTransferManager for optimized data transfer."""
+    crt_s3_client = get_crt_s3_client(client, config)
+    if is_crt_compatible_request(client, crt_s3_client):
+        return CRTTransferManager(
+            crt_s3_client.crt_client, _BOTOCORE_CRT_SERIALIZER
+        )
+    return None

--- a/boto3/s3/constants.py
+++ b/boto3/s3/constants.py
@@ -1,0 +1,17 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# https://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+
+# TransferConfig preferred_transfer_client settings
+CLASSIC_TRANSFER_CLIENT = "classic"
+AUTO_RESOLVE_TRANSFER_CLIENT = "auto"

--- a/boto3/s3/inject.py
+++ b/boto3/s3/inject.py
@@ -10,6 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import copy as python_copy
+
 from botocore.exceptions import ClientError
 
 from boto3 import utils
@@ -432,7 +434,11 @@ def copy(
     if config is None:
         config = TransferConfig()
 
-    with create_transfer_manager(self, config) as manager:
+    # copy is not supported in the CRT
+    new_config = python_copy.copy(config)
+    new_config.preferred_transfer_client = "classic"
+
+    with create_transfer_manager(self, new_config) as manager:
         future = manager.copy(
             copy_source=CopySource,
             bucket=Bucket,

--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -232,7 +232,7 @@ class TransferConfig(S3TransferConfig):
         io_chunksize=256 * KB,
         use_threads=True,
         max_bandwidth=None,
-        preferred_transfer_client="auto",
+        preferred_transfer_client=constants.AUTO_RESOLVE_TRANSFER_CLIENT,
     ):
         """Configuration object for managed S3 transfers
 

--- a/scripts/ci/install
+++ b/scripts/ci/install
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import argparse
 import os
 import shutil
 from contextlib import contextmanager
@@ -25,6 +26,14 @@ def run(command):
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        '-e',
+        '--extras',
+        help='Install extras_require along with normal install',
+    )
+    args = parser.parse_args()
     with cd(REPO_ROOT):
         run("pip install -r requirements.txt")
         run("python scripts/ci/install-dev-deps")
@@ -32,4 +41,7 @@ if __name__ == "__main__":
             shutil.rmtree("dist")
         run("python setup.py bdist_wheel")
         wheel_dist = os.listdir("dist")[0]
-        run("pip install %s" % (os.path.join("dist", wheel_dist)))
+        package = os.path.join('dist', wheel_dist)
+        if args.extras:
+            package = f"\"{package}[{args.extras}]\""
+        run(f"pip install {package}")

--- a/scripts/ci/run-crt-tests
+++ b/scripts/ci/run-crt-tests
@@ -36,4 +36,5 @@ except ImportError:
 
 if __name__ == "__main__":
     with cd(os.path.join(REPO_ROOT, "tests")):
-        run(f"{REPO_ROOT}/scripts/ci/run-tests unit/ functional/")
+        test_script = os.sep.join([REPO_ROOT, 'scripts', 'ci', 'run-tests'])
+        run(f"python {test_script} unit functional")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,6 +16,8 @@ import time
 import unittest
 from unittest import mock
 
+from botocore.compat import HAS_CRT
+
 
 def unique_id(name):
     """
@@ -50,3 +52,13 @@ class BaseTestCase(unittest.TestCase):
 
     def tearDown(self):
         self.bc_session_patch.stop()
+
+
+def requires_crt(reason=None):
+    if reason is None:
+        reason = "Test requires awscrt to be installed"
+
+    def decorator(func):
+        return unittest.skipIf(not HAS_CRT, reason)(func)
+
+    return decorator

--- a/tests/functional/test_crt.py
+++ b/tests/functional/test_crt.py
@@ -1,0 +1,64 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# https://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from contextlib import ContextDecorator
+
+from botocore.compat import HAS_CRT
+from botocore.credentials import Credentials
+
+from boto3.s3.transfer import TransferConfig, create_transfer_manager
+from tests import mock, requires_crt
+
+if HAS_CRT:
+    from s3transfer.crt import CRTTransferManager
+
+
+class MockOptimizedInstance(ContextDecorator):
+    """Helper class to simulate a CRT optimized EC2 instance."""
+
+    DEFAULT_LOCK_MOCK = mock.Mock()
+
+    def __init__(self, lock=DEFAULT_LOCK_MOCK, optimized=True):
+        self.acquire_process_lock = mock.patch(
+            'boto3.crt.acquire_crt_s3_process_lock'
+        )
+        self.acquire_process_lock.return_value = lock
+        self.is_optimized = mock.patch('awscrt.s3.is_optimized_for_system')
+        self.is_optimized.return_value = optimized
+
+    def __enter__(self, *args, **kwargs):
+        self.acquire_process_lock.start()
+        self.is_optimized.start()
+
+    def __exit__(self, *args, **kwargs):
+        self.acquire_process_lock.stop()
+        self.is_optimized.stop()
+
+
+def create_mock_client(region_name='us-west-2'):
+    client = mock.Mock()
+    client.meta.region_name = region_name
+    client._get_credentials.return_value = Credentials(
+        'access', 'secret', 'token'
+    )
+    return client
+
+
+class TestS3TransferWithCRT:
+    @requires_crt()
+    @MockOptimizedInstance()
+    def test_create_transfer_manager_on_optimized_instance(self):
+        client = create_mock_client()
+        config = TransferConfig()
+        transfer_manager = create_transfer_manager(client, config)
+        assert isinstance(transfer_manager, CRTTransferManager)

--- a/tests/unit/test_crt.py
+++ b/tests/unit/test_crt.py
@@ -21,10 +21,42 @@ from boto3.s3.transfer import TransferConfig
 from tests import mock, requires_crt
 
 if HAS_CRT:
-    import awscrt.s3
+    from awscrt.s3 import CrossProcessLock as CrossProcessLockClass
     from s3transfer.crt import BotocoreCRTCredentialsWrapper
 
     import boto3.crt
+
+
+@pytest.fixture
+def mock_crt_process_lock(monkeypatch):
+    # The process lock is cached at the module layer whenever the
+    # cross process lock is successfully acquired. This patch ensures that
+    # test cases will start off with no previously cached process lock and
+    # if a cross process is instantiated/acquired it will be the mock that
+    # can be used for controlling lock behavior.
+    if HAS_CRT:
+        monkeypatch.setattr('s3transfer.crt.CRT_S3_PROCESS_LOCK', None)
+        with mock.patch('awscrt.s3.CrossProcessLock', spec=True) as mock_lock:
+            yield mock_lock
+    else:
+        # We cannot mock or use the lock without CRT support.
+        yield None
+
+
+@pytest.fixture
+def mock_crt_client_singleton(monkeypatch):
+    # Clear CRT state for each test
+    if HAS_CRT:
+        monkeypatch.setattr('boto3.crt.CRT_S3_CLIENT', None)
+    yield None
+
+
+@pytest.fixture
+def mock_serializer_singleton(monkeypatch):
+    # Clear CRT state for each test
+    if HAS_CRT:
+        monkeypatch.setattr('boto3.crt.BOTOCORE_CRT_SERIALIZER', None)
+    yield None
 
 
 def create_test_client(service_name='s3', region_name="us-east-1"):
@@ -43,21 +75,35 @@ USE1_S3_CLIENT = create_test_client(region_name="us-east-1")
 
 class TestCRTTransferManager:
     @requires_crt()
-    def test_create_crt_transfer_manager_with_lock_in_use(self):
-        with mock.patch('boto3.crt.acquire_crt_s3_process_lock') as lock:
-            lock.return_value = None
+    def test_create_crt_transfer_manager_with_lock_in_use(
+        self,
+        mock_crt_process_lock,
+        mock_crt_client_singleton,
+        mock_serializer_singleton,
+    ):
+        mock_crt_process_lock.return_value.acquire.side_effect = RuntimeError
 
-            # Verify we can't create a second CRT client
-            tm = boto3.crt.create_crt_transfer_manager(USW2_S3_CLIENT, None)
-            assert tm is None
+        # Verify we can't create a second CRT client
+        tm = boto3.crt.create_crt_transfer_manager(USW2_S3_CLIENT, None)
+        assert tm is None
 
     @requires_crt()
-    def test_create_crt_transfer_manager(self):
+    def test_create_crt_transfer_manager(
+        self,
+        mock_crt_process_lock,
+        mock_crt_client_singleton,
+        mock_serializer_singleton,
+    ):
         tm = boto3.crt.create_crt_transfer_manager(USW2_S3_CLIENT, None)
         assert isinstance(tm, s3transfer.crt.CRTTransferManager)
 
     @requires_crt()
-    def test_crt_singleton_is_returned_every_call(self):
+    def test_crt_singleton_is_returned_every_call(
+        self,
+        mock_crt_process_lock,
+        mock_crt_client_singleton,
+        mock_serializer_singleton,
+    ):
         first_s3_client = boto3.crt.get_crt_s3_client(USW2_S3_CLIENT, None)
         second_s3_client = boto3.crt.get_crt_s3_client(USW2_S3_CLIENT, None)
 
@@ -66,7 +112,12 @@ class TestCRTTransferManager:
         assert first_s3_client.crt_client is second_s3_client.crt_client
 
     @requires_crt()
-    def test_create_crt_transfer_manager_w_client_in_wrong_region(self):
+    def test_create_crt_transfer_manager_w_client_in_wrong_region(
+        self,
+        mock_crt_process_lock,
+        mock_crt_client_singleton,
+        mock_serializer_singleton,
+    ):
         """Ensure we don't return the crt transfer manager if client is in
         different region. The CRT isn't able to handle region redirects and
         will consistently fail.
@@ -130,20 +181,28 @@ class TestCRTTransferManager:
         )
 
     @requires_crt()
-    def test_get_crt_s3_client(self):
+    def test_get_crt_s3_client(
+        self,
+        mock_crt_process_lock,
+        mock_crt_client_singleton,
+        mock_serializer_singleton,
+    ):
         config = TransferConfig()
         crt_s3_client = boto3.crt.get_crt_s3_client(USW2_S3_CLIENT, config)
         assert isinstance(crt_s3_client, boto3.crt.CRTS3Client)
-        assert isinstance(
-            crt_s3_client.process_lock, awscrt.s3.CrossProcessLock
-        )
+        assert isinstance(crt_s3_client.process_lock, CrossProcessLockClass)
         assert crt_s3_client.region == "us-west-2"
         assert isinstance(
             crt_s3_client.cred_provider, BotocoreCRTCredentialsWrapper
         )
 
     @requires_crt()
-    def test_get_crt_s3_client_w_wrong_region(self):
+    def test_get_crt_s3_client_w_wrong_region(
+        self,
+        mock_crt_process_lock,
+        mock_crt_client_singleton,
+        mock_serializer_singleton,
+    ):
         config = TransferConfig()
         crt_s3_client = boto3.crt.get_crt_s3_client(USW2_S3_CLIENT, config)
         assert isinstance(crt_s3_client, boto3.crt.CRTS3Client)

--- a/tests/unit/test_crt.py
+++ b/tests/unit/test_crt.py
@@ -10,61 +10,147 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-
-import boto3
+import botocore.exceptions
+import pytest
 import s3transfer
 from botocore.compat import HAS_CRT
+from botocore.credentials import Credentials
 
+import boto3
+from boto3.s3.transfer import TransferConfig
 from tests import mock, requires_crt
 
 if HAS_CRT:
+    import awscrt.s3
+    from s3transfer.crt import BotocoreCRTCredentialsWrapper
+
     import boto3.crt
 
 
-USW2_S3_CLIENT = boto3.client('s3', region_name='us-west-2')
-USE1_S3_CLIENT = boto3.client('s3', region_name='us-east-1')
+def create_test_client(service_name='s3', region_name="us-east-1"):
+    return boto3.client(
+        service_name,
+        region_name=region_name,
+        aws_access_key_id="access",
+        aws_secret_access_key="secret",
+        aws_session_token="token",
+    )
 
 
-@requires_crt()
-def test_create_crt_transfer_manager_with_lock_in_use():
-    with mock.patch('boto3.crt.acquire_crt_s3_process_lock') as lock:
-        lock.return_value = None
+USW2_S3_CLIENT = create_test_client(region_name="us-west-2")
+USE1_S3_CLIENT = create_test_client(region_name="us-east-1")
 
-        # Verify we can't create a second CRT client
+
+class TestCRTTransferManager:
+    @requires_crt()
+    def test_create_crt_transfer_manager_with_lock_in_use(self):
+        with mock.patch('boto3.crt.acquire_crt_s3_process_lock') as lock:
+            lock.return_value = None
+
+            # Verify we can't create a second CRT client
+            tm = boto3.crt.create_crt_transfer_manager(USW2_S3_CLIENT, None)
+            assert tm is None
+
+    @requires_crt()
+    def test_create_crt_transfer_manager(self):
         tm = boto3.crt.create_crt_transfer_manager(USW2_S3_CLIENT, None)
-        assert tm is None
+        assert isinstance(tm, s3transfer.crt.CRTTransferManager)
 
+    @requires_crt()
+    def test_crt_singleton_is_returned_every_call(self):
+        first_s3_client = boto3.crt.get_crt_s3_client(USW2_S3_CLIENT, None)
+        second_s3_client = boto3.crt.get_crt_s3_client(USW2_S3_CLIENT, None)
 
-@requires_crt()
-def test_create_crt_transfer_manager():
-    tm = boto3.crt.create_crt_transfer_manager(USW2_S3_CLIENT, None)
-    assert isinstance(tm, s3transfer.crt.CRTTransferManager)
+        assert isinstance(first_s3_client, boto3.crt.CRTS3Client)
+        assert first_s3_client is second_s3_client
+        assert first_s3_client.crt_client is second_s3_client.crt_client
 
+    @requires_crt()
+    def test_create_crt_transfer_manager_w_client_in_wrong_region(self):
+        """Ensure we don't return the crt transfer manager if client is in
+        different region. The CRT isn't able to handle region redirects and
+        will consistently fail.
 
-@requires_crt()
-def test_crt_singleton_is_returned_every_call():
-    first_s3_client = boto3.crt.get_crt_s3_client(USW2_S3_CLIENT, None)
-    second_s3_client = boto3.crt.get_crt_s3_client(USW2_S3_CLIENT, None)
+        We can remove this test once we have this fixed on the CRT side.
+        """
+        usw2_s3_client = boto3.crt.create_crt_transfer_manager(
+            USW2_S3_CLIENT, None
+        )
+        assert isinstance(usw2_s3_client, boto3.crt.CRTTransferManager)
 
-    assert isinstance(first_s3_client, boto3.crt.CRTS3Client)
-    assert first_s3_client is second_s3_client
-    assert first_s3_client.crt_client is second_s3_client.crt_client
+        use1_s3_client = boto3.crt.create_crt_transfer_manager(
+            USE1_S3_CLIENT, None
+        )
+        assert use1_s3_client is None
 
-
-@requires_crt()
-def test_create_crt_transfer_manager_w_client_in_wrong_region():
-    """Ensure we don't return the crt transfer manager if client is in
-    different region. The CRT isn't able to handle region redirects and
-    will consistently fail.
-
-    We can remove this test once we have this fixed on the CRT side.
-    """
-    usw2_s3_client = boto3.crt.create_crt_transfer_manager(
-        USW2_S3_CLIENT, None
+    @pytest.mark.parametrize(
+        "boto3_tuple,crt_tuple,matching",
+        (
+            (
+                ("access", "secret", "token"),
+                ("access", "secret", "token"),
+                True,
+            ),
+            (
+                ("access", "secret", "token"),
+                ("noaccess", "secret", "token"),
+                False,
+            ),
+            (
+                ("access", "secret", "token"),
+                ("access", "nosecret", "token"),
+                False,
+            ),
+            (
+                ("access", "secret", "token"),
+                ("access", "secret", "notoken"),
+                False,
+            ),
+        ),
     )
-    assert isinstance(usw2_s3_client, boto3.crt.CRTTransferManager)
+    @requires_crt()
+    def test_compare_identities(self, boto3_tuple, crt_tuple, matching):
+        boto3_creds = Credentials(*boto3_tuple)
+        crt_creds = Credentials(*crt_tuple)
+        crt_creds_wrapper = BotocoreCRTCredentialsWrapper(crt_creds)
+        assert (
+            boto3.crt.compare_identity(boto3_creds, crt_creds_wrapper)
+            is matching
+        )
 
-    use1_s3_client = boto3.crt.create_crt_transfer_manager(
-        USE1_S3_CLIENT, None
-    )
-    assert use1_s3_client is None
+    @requires_crt()
+    def test_compare_idenities_no_credentials(self):
+        def no_credentials():
+            raise botocore.exceptions.NoCredentialsError()
+
+        boto3_creds = Credentials("access", "secret", "token")
+        crt_creds_wrapper = no_credentials
+        assert (
+            boto3.crt.compare_identity(boto3_creds, crt_creds_wrapper) is False
+        )
+
+    @requires_crt()
+    def test_get_crt_s3_client(self):
+        config = TransferConfig()
+        crt_s3_client = boto3.crt.get_crt_s3_client(USW2_S3_CLIENT, config)
+        assert isinstance(crt_s3_client, boto3.crt.CRTS3Client)
+        assert isinstance(
+            crt_s3_client.process_lock, awscrt.s3.CrossProcessLock
+        )
+        assert crt_s3_client.region == "us-west-2"
+        assert isinstance(
+            crt_s3_client.cred_provider, BotocoreCRTCredentialsWrapper
+        )
+
+    @requires_crt()
+    def test_get_crt_s3_client_w_wrong_region(self):
+        config = TransferConfig()
+        crt_s3_client = boto3.crt.get_crt_s3_client(USW2_S3_CLIENT, config)
+        assert isinstance(crt_s3_client, boto3.crt.CRTS3Client)
+
+        # Ensure we don't create additional CRT clients
+        use1_crt_s3_client = boto3.crt.get_crt_s3_client(
+            USE1_S3_CLIENT, config
+        )
+        assert use1_crt_s3_client is crt_s3_client
+        assert use1_crt_s3_client.region == "us-west-2"

--- a/tests/unit/test_crt.py
+++ b/tests/unit/test_crt.py
@@ -1,0 +1,70 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# https://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import boto3
+import s3transfer
+from botocore.compat import HAS_CRT
+
+from tests import mock, requires_crt
+
+if HAS_CRT:
+    import boto3.crt
+
+
+USW2_S3_CLIENT = boto3.client('s3', region_name='us-west-2')
+USE1_S3_CLIENT = boto3.client('s3', region_name='us-east-1')
+
+
+@requires_crt()
+def test_create_crt_transfer_manager_with_lock_in_use():
+    with mock.patch('boto3.crt.acquire_crt_s3_process_lock') as lock:
+        lock.return_value = None
+
+        # Verify we can't create a second CRT client
+        tm = boto3.crt.create_crt_transfer_manager(USW2_S3_CLIENT, None)
+        assert tm is None
+
+
+@requires_crt()
+def test_create_crt_transfer_manager():
+    tm = boto3.crt.create_crt_transfer_manager(USW2_S3_CLIENT, None)
+    assert isinstance(tm, s3transfer.crt.CRTTransferManager)
+
+
+@requires_crt()
+def test_crt_singleton_is_returned_every_call():
+    first_s3_client = boto3.crt.get_crt_s3_client(USW2_S3_CLIENT, None)
+    second_s3_client = boto3.crt.get_crt_s3_client(USW2_S3_CLIENT, None)
+
+    assert isinstance(first_s3_client, boto3.crt.CRTS3Client)
+    assert first_s3_client is second_s3_client
+    assert first_s3_client.crt_client is second_s3_client.crt_client
+
+
+@requires_crt()
+def test_create_crt_transfer_manager_w_client_in_wrong_region():
+    """Ensure we don't return the crt transfer manager if client is in
+    different region. The CRT isn't able to handle region redirects and
+    will consistently fail.
+
+    We can remove this test once we have this fixed on the CRT side.
+    """
+    usw2_s3_client = boto3.crt.create_crt_transfer_manager(
+        USW2_S3_CLIENT, None
+    )
+    assert isinstance(usw2_s3_client, boto3.crt.CRTTransferManager)
+
+    use1_s3_client = boto3.crt.create_crt_transfer_manager(
+        USE1_S3_CLIENT, None
+    )
+    assert use1_s3_client is None


### PR DESCRIPTION
This PR adds the ability to perform basic upload/download S3 operations using the CRT on select EC2 instance types. Similar to the existing experimental behavior in the CLI, this will give users a notable throughput increase in their data transfers.

While this feature is in its early stages, we will not support user specified configuration that's normally supported through a `TransferConfig` on the `upload_file` and `download_file` APIs. The CRT will determine what settings are best for performance on these select instance types and make those decisions to optimize throughput. In future versions of this feature after we've gather initial feedback, we intend to start supporting a wider set of configuration and instance types.

The full list of current support is for these EC2 Instance Types:
* ``p4d.24xlarge``
* ``p4de.24xlarge``
* ``p5.48xlarge``
* ``trn1n.32xlarge``
* ``trn1.32xlarge``

Users who do not wish to opt into this feature can disabled it by using the new `preferred_transfer_client` configuration in the `TransferConfig`. Setting this to `classic` will opt into the original Boto3 transfer experience.