### PR TITLE
fix CRT debug log

### DIFF
--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -199,11 +199,8 @@ def _should_use_crt(config):
 
     logger.debug(
         "Opting out of CRT Transfer Manager. Preferred client: "
-        "{pref_transfer_client}, CRT available: {HAS_CRT}, "
-        "Instance Optimized: {is_optimized_instance}.",
-        pref_transfer_client,
-        HAS_CRT,
-        is_optimized_instance,
+        f"{pref_transfer_client}, CRT available: {HAS_CRT}, "
+        f"Instance Optimized: {is_optimized_instance}."
     )
     return False
 


### PR DESCRIPTION
I was curious about the "new" CRT support and while trying it out it results in some ugly logs, which this PR fixes 🙂 

```
--- Logging error ---
Traceback (most recent call last):
  File "/Users/agruebel/.pyenv/versions/3.8.16/lib/python3.8/logging/__init__.py", line 1085, in emit
    msg = self.format(record)
  File "/Users/agruebel/.pyenv/versions/3.8.16/lib/python3.8/logging/__init__.py", line 929, in format
    return fmt.format(record)
  File "/Users/agruebel/.pyenv/versions/3.8.16/lib/python3.8/logging/__init__.py", line 668, in format
    record.message = record.getMessage()
  File "/Users/agruebel/.pyenv/versions/3.8.16/lib/python3.8/logging/__init__.py", line 373, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Call stack:
  File "/Users/agruebel/.pyenv/versions/3.8.16/lib/python3.8/threading.py", line 890, in _bootstrap
    self._bootstrap_inner()
  File "/Users/agruebel/.pyenv/versions/3.8.16/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/Users/agruebel/.pyenv/versions/3.8.16/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/agruebel/.pyenv/versions/3.8.16/lib/python3.8/concurrent/futures/thread.py", line 80, in _worker
    work_item.run()
  File "/Users/agruebel/.pyenv/versions/3.8.16/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/agruebel/repos/checkov/checkov/common/bridgecrew/platform_integration.py", line 760, in _persist_file
    self.s3_client.upload_file(full_file_path, self.bucket, file_object_key)
  File "/Users/agruebel/.local/share/virtualenvs/checkov-AbwIpdqr/lib/python3.8/site-packages/boto3/s3/inject.py", line 144, in upload_file
    with S3Transfer(self, Config) as transfer:
  File "/Users/agruebel/.local/share/virtualenvs/checkov-AbwIpdqr/lib/python3.8/site-packages/boto3/s3/transfer.py", line 335, in __init__
    self._manager = create_transfer_manager(client, config, osutil)
  File "/Users/agruebel/.local/share/virtualenvs/checkov-AbwIpdqr/lib/python3.8/site-packages/boto3/s3/transfer.py", line 169, in create_transfer_manager
    if _should_use_crt(config):
  File "/Users/agruebel/.local/share/virtualenvs/checkov-AbwIpdqr/lib/python3.8/site-packages/boto3/s3/transfer.py", line 201, in _should_use_crt
    logger.debug(
Message: 'Opting out of CRT Transfer Manager. Preferred client: {pref_transfer_client}, CRT available: {HAS_CRT}, Instance Optimized: {is_optimized_instance}.'
Arguments: ('auto', True, False)
```