### PR TITLE
Add version floor for transfer feature

### DIFF
--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -182,7 +182,8 @@ def create_transfer_manager(client, config, osutil=None):
 
 
 def _should_use_crt(config):
-    if HAS_CRT:
+    # This feature requires awscrt>=0.19.17
+    if HAS_CRT and has_minimum_crt_version((0, 19, 17)):
         is_optimized_instance = awscrt.s3.is_optimized_for_system()
     else:
         is_optimized_instance = False
@@ -203,6 +204,21 @@ def _should_use_crt(config):
         f"Instance Optimized: {is_optimized_instance}."
     )
     return False
+
+
+def has_minimum_crt_version(minimum_version):
+    """Not intended for use outside boto3."""
+    if not HAS_CRT:
+        return False
+
+    crt_version_str = awscrt.__version__
+    try:
+        crt_version_ints = map(int, crt_version_str.split("."))
+        crt_version_tuple = tuple(crt_version_ints)
+    except (TypeError, ValueError):
+        return False
+
+    return crt_version_tuple >= minimum_version
 
 
 def _create_default_transfer_manager(client, config, osutil):

--- a/tests/functional/test_crt.py
+++ b/tests/functional/test_crt.py
@@ -16,7 +16,11 @@ from contextlib import ContextDecorator
 from botocore.compat import HAS_CRT
 from botocore.credentials import Credentials
 
-from boto3.s3.transfer import TransferConfig, create_transfer_manager
+from boto3.s3.transfer import (
+    TransferConfig,
+    create_transfer_manager,
+    has_minimum_crt_version,
+)
 from tests import mock, requires_crt
 
 if HAS_CRT:
@@ -62,3 +66,14 @@ class TestS3TransferWithCRT:
         config = TransferConfig()
         transfer_manager = create_transfer_manager(client, config)
         assert isinstance(transfer_manager, CRTTransferManager)
+
+    @requires_crt()
+    def test_minimum_crt_version(self):
+        assert has_minimum_crt_version((0, 16, 12)) is True
+
+    @requires_crt()
+    def test_minimum_crt_version_bad_crt_version(self):
+        with mock.patch("awscrt.__version__") as vers:
+            vers.return_value = None
+
+            assert has_minimum_crt_version((0, 16, 12)) is False


### PR DESCRIPTION
Set a version floor for the CRT transfer feature for cases where customers may be deployed on a platform with an outdated version of `awscrt`.