### PR TITLE
Added bugs to the stale issue automation

### DIFF
--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -29,7 +29,7 @@ jobs:
 
         # These labels are required
         stale-issue-label: closing-soon
-        exempt-issue-labels: automation-exempt,needs-review,bug
+        exempt-issue-labels: automation-exempt,needs-review
         response-requested-label: response-requested
 
         # Don't set closed-for-staleness label to skip closing very old issues


### PR DESCRIPTION
We're adding bugs to the stale issue workflow. This was disabled at some point because we didn't want ancient bugs to be closed. That workflow no longer exists, so this should be fine.