### PR TITLE
Minor GitHub workflow changes

### DIFF
--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -16,8 +16,6 @@ jobs:
           with:
             # These inputs are both required
             repo-token: "${{ secrets.GITHUB_TOKEN }}"
-            message: |
-                     ### ⚠️COMMENT VISIBILITY WARNING⚠️ 
-                     Comments on closed issues are hard for our team to see. 
+            message: | 
+                     This issue is now closed. Comments on closed issues are hard for our team to see. 
                      If you need more assistance, please either tag a team member or open a new issue that references this one. 
-                     If you wish to keep having a conversation with other community members under this issue feel free to do so.

--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -18,4 +18,4 @@ jobs:
             repo-token: "${{ secrets.GITHUB_TOKEN }}"
             message: | 
                      This issue is now closed. Comments on closed issues are hard for our team to see. 
-                     If you need more assistance, please either tag a team member or open a new issue that references this one. 
+                     If you need more assistance, please open a new issue that references this one. 

--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -37,8 +37,8 @@ jobs:
         closed-for-staleness-label: closed-for-staleness
 
         # Issue timing
-        days-before-stale: 5
-        days-before-close: 2
+        days-before-stale: 10
+        days-before-close: 4
 
         # If you don't want to mark a issue as being ancient based on a
         # threshold of "upvotes", you can set this here. An "upvote" is


### PR DESCRIPTION
Based on customer feedback we are making 2 small changes to our GitHub issue automation:

1. The timelines on issue closure are too short, especially over holidays or weekends.
2. The closed issue message is too loud and too full of emoji.