### PR TITLE
Fix boto3 resource reference docs

### DIFF
--- a/boto3/docs/resource.py
+++ b/boto3/docs/resource.py
@@ -255,7 +255,6 @@ class ResourceDocumenter(BaseDocumenter):
                 intro_link='references_intro',
             )
             self.member_map['references'] = reference_list
-            self._add_overview_of_member_type(section, 'references')
         for reference in references:
             reference_list.append(reference.name)
             # Create a new DocumentStructure for each reference and add contents.


### PR DESCRIPTION
## Overview
This PR fixes a small bug with boto3 resource documentation generation (addresses https://github.com/boto/boto3/issues/4030).

Specifically, if a boto3 resources has references, there is duplicate text generated in the "References" section as shown in the example below.

## Example 

<img width="857" alt="Screenshot 2024-03-12 at 3 24 23 PM" src="https://github.com/boto/boto3/assets/43360731/961cf2e3-9b6e-4b03-80a9-b03ac1c5c2a6">

Reference: https://boto3.amazonaws.com/v1/documentation/api/1.34.61/reference/services/opsworks/layer/index.html#references

## Testing
To test this change, I generated boto3 docs with and without the changes and compared the two. There are 17 changes that are all identical to the one below:
**Before**
```
----------
References
----------



References are related resource instances that have a belongs-to relationship.
For more information about references refer to the :ref:`Resources Introduction Guide<references_intro>`.

These are the resource's available references:

.. toctree::
  :maxdepth: 1
  :titlesonly:


These are the resource's available references:

.. toctree::
  :maxdepth: 1
  :titlesonly:

  stack

```

**After**
```
----------
References
----------



References are related resource instances that have a belongs-to relationship.
For more information about references refer to the :ref:`Resources Introduction Guide<references_intro>`.

These are the resource's available references:

.. toctree::
  :maxdepth: 1
  :titlesonly:

  stack

```

