### PR TITLE
Explain how MaxItems affects pagination in boto3

### DIFF
--- a/docs/source/guide/paginators.rst
+++ b/docs/source/guide/paginators.rst
@@ -117,7 +117,7 @@ With that in mind, consider what happens when the following code runs:
     paginator = s3.get_paginator('list_objects_v2')
 
     for result in paginator.paginate(
-                Bucket='pagination-test-ericsh', Delimiter='/',
+                Bucket='bucket-name', Delimiter='/',
                 PaginationConfig={'MaxItems': 2000}):
         for prefix in result.get('CommonPrefixes', []):
             num_prefixes += 1


### PR DESCRIPTION
This update to the boto3 docs adds to the paginators chapter information explaining that the `CommonPrefixes` list doesn't count toward the limit set by `MaxItems`, with example code.

I have a [build of this on my cloud desktop](http://sheppycloud.aka.corp.amazon.com:4006/guide/paginators.html).