### PR TITLE
Add missing changelog entry

### DIFF
--- a/.changes/1.34.90.json
+++ b/.changes/1.34.90.json
@@ -40,6 +40,11 @@
     "type": "api-change"
   },
   {
+    "category": "``sqs``",
+    "description": "[``botocore``] This release enables customers to call SQS using AWS JSON-1.0 protocol",
+    "type": "api-change"
+  },
+  {
     "category": "``workspaces-web``",
     "description": "[``botocore``] Added InstanceType and MaxConcurrentSessions parameters on CreatePortal and UpdatePortal Operations as well as the ability to read Customer Managed Key & Additional Encryption Context parameters on supported resources (Portal, BrowserSettings, UserSettings, IPAccessSettings)",
     "type": "api-change"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ CHANGELOG
 * api-change:``ec2``: [``botocore``] This release introduces EC2 AMI Deregistration Protection, a new AMI property that can be enabled by customers to protect an AMI against an unintended deregistration. This release also enables the AMI owners to view the AMI 'LastLaunchedTime' in DescribeImages API.
 * api-change:``pi``: [``botocore``] Clarifies how aggregation works for GetResourceMetrics in the Performance Insights API.
 * api-change:``rds``: [``botocore``] Fix the example ARN for ModifyActivityStreamRequest
+* api-change:``sqs``: [``botocore``] This release enables customers to call SQS using AWS JSON-1.0 protocol
 * api-change:``workspaces-web``: [``botocore``] Added InstanceType and MaxConcurrentSessions parameters on CreatePortal and UpdatePortal Operations as well as the ability to read Customer Managed Key & Additional Encryption Context parameters on supported resources (Portal, BrowserSettings, UserSettings, IPAccessSettings)
 
 


### PR DESCRIPTION
The changelog snippet was missing from the previous SQS change. This adds it and amends the entry in the changelog.
