### PR TITLE
Update s3 `download_file` example

### DIFF
--- a/boto3/s3/inject.py
+++ b/boto3/s3/inject.py
@@ -159,8 +159,8 @@ def download_file(
     Usage::
 
         import boto3
-        s3 = boto3.resource('s3')
-        s3.meta.client.download_file('mybucket', 'hello.txt', '/tmp/hello.txt')
+        s3 = boto3.client('s3')
+        s3.download_file('mybucket', 'hello.txt', '/tmp/hello.txt')
 
     Similar behavior as S3Transfer's download_file() method,
     except that parameters are capitalized. Detailed examples can be found at


### PR DESCRIPTION
Fixes https://github.com/boto/boto3/issues/4127. Updates [download_file](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/download_file.html) example to be consistent with [upload_file](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/upload_file.html).