### PR TITLE
Add caveat about default session

### DIFF
--- a/docs/source/guide/clients.rst
+++ b/docs/source/guide/clients.rst
@@ -133,7 +133,7 @@ need to use these interfaces, but those that do should no longer
 consider their clients thread-safe without careful review.
 
 .. note::
-    `boto3.client('<client_name>')` is an alias for creating a client with a
+    ``boto3.client('<service_name>')`` is an alias for creating a client with a
     shared default session. Invoking `boto3.client()` inside of a concurrent
     context may result in response ordering issues or interpreter failures
     from underlying SSL modules.

--- a/docs/source/guide/clients.rst
+++ b/docs/source/guide/clients.rst
@@ -134,7 +134,7 @@ consider their clients thread-safe without careful review.
 
 .. note::
     ``boto3.client('<service_name>')`` is an alias for creating a client with a
-    shared default session. Invoking `boto3.client()` inside of a concurrent
+    shared default session. Invoking ``boto3.client()`` inside of a concurrent
     context may result in response ordering issues or interpreter failures
     from underlying SSL modules.
 

--- a/docs/source/guide/clients.rst
+++ b/docs/source/guide/clients.rst
@@ -132,6 +132,12 @@ which may interact with boto3’s client. The majority of users will not
 need to use these interfaces, but those that do should no longer
 consider their clients thread-safe without careful review.
 
+.. note::
+    `boto3.client('<client_name>')` is an alias for creating a client with a
+    shared default session. Invoking `boto3.client()` inside of a concurrent
+    context may result in response ordering issues or interpreter failures
+    from underlying SSL modules.
+
 General Example
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This PR clarifies that `boto3.client` is not a thread-safe method and should be avoided in concurrent contexts.