### PR TITLE
Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,21 +6,9 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: 'https://github.com/asottile/pyupgrade'
-    rev: v3.15.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.8
     hooks:
-      - id: pyupgrade
-        args:
-          - '--py38-plus'
-  - repo: 'https://github.com/PyCQA/isort'
-    rev: 5.12.0
-    hooks:
-      - id: isort
-  - repo: 'https://github.com/psf/black'
-    rev: 23.11.0
-    hooks:
-      - id: black
-  - repo: 'https://github.com/pycqa/flake8'
-    rev: 6.1.0
-    hooks:
-      - id: flake8
+      - id: ruff
+        args: [ --fix ]
+      - id: ruff-format

--- a/boto3/docs/action.py
+++ b/boto3/docs/action.py
@@ -147,8 +147,8 @@ def document_action(
     example_resource_name = xform_name(resource_name)
     if service_model.service_name == resource_name:
         example_resource_name = resource_name
-    example_prefix = '{} = {}.{}'.format(
-        example_return_value, example_resource_name, action_model.name
+    example_prefix = (
+        f'{example_return_value} = {example_resource_name}.{action_model.name}'
     )
     full_action_name = (
         f"{section.context.get('qualifier', '')}{action_model.name}"
@@ -193,13 +193,10 @@ def document_load_reload_action(
         It is useful for generating docstrings.
     """
     description = (
-        'Calls :py:meth:`{}.Client.{}` to update the attributes of the '
-        '{} resource. Note that the load and reload methods are '
-        'the same method and can be used interchangeably.'.format(
-            get_service_module_name(service_model),
-            xform_name(load_model.request.operation),
-            resource_name,
-        )
+        f'Calls :py:meth:`{get_service_module_name(service_model)}.Client.'
+        f'{xform_name(load_model.request.operation)}` to update the attributes of the '
+        f'{resource_name} resource. Note that the load and reload methods are '
+        'the same method and can be used interchangeably.'
     )
     example_resource_name = xform_name(resource_name)
     if service_model.service_name == resource_name:

--- a/boto3/docs/client.py
+++ b/boto3/docs/client.py
@@ -20,9 +20,5 @@ class Boto3ClientDocumenter(ClientDocumenter):
         section.write('import boto3')
         section.style.new_line()
         section.style.new_line()
-        section.write(
-            'client = boto3.client(\'{service}\')'.format(
-                service=self._service_name
-            )
-        )
+        section.write(f'client = boto3.client(\'{self._service_name}\')')
         section.style.end_codeblock()

--- a/boto3/docs/collection.py
+++ b/boto3/docs/collection.py
@@ -165,12 +165,7 @@ def document_batch_action(
     example_resource_name = xform_name(resource_name)
     if service_model.service_name == resource_name:
         example_resource_name = resource_name
-    example_prefix = '{} = {}.{}.{}'.format(
-        example_return_value,
-        example_resource_name,
-        collection_model.name,
-        batch_action_model.name,
-    )
+    example_prefix = f'{example_return_value} = {example_resource_name}.{collection_model.name}.{batch_action_model.name}'
     document_model_driven_resource_method(
         section=section,
         method_name=batch_action_model.name,
@@ -229,11 +224,7 @@ def document_collection_method(
                 f'Creates an iterable of all {collection_model.resource.type} '
                 f'resources in the collection.'
             ),
-            'example_prefix': '{}_iterator = {}.{}.all'.format(
-                xform_name(collection_model.resource.type),
-                example_resource_name,
-                collection_model.name,
-            ),
+            'example_prefix': f'{xform_name(collection_model.resource.type)}_iterator = {example_resource_name}.{collection_model.name}.all',
             'exclude_input': underlying_operation_members,
         },
         'filter': {
@@ -245,11 +236,7 @@ def document_collection_method(
                 f'and extreme caution should be taken when performing actions '
                 f'on all resources.'
             ),
-            'example_prefix': '{}_iterator = {}.{}.filter'.format(
-                xform_name(collection_model.resource.type),
-                example_resource_name,
-                collection_model.name,
-            ),
+            'example_prefix': f'{xform_name(collection_model.resource.type)}_iterator = {example_resource_name}.{collection_model.name}.filter',
             'exclude_input': get_resource_ignore_params(
                 collection_model.request.params
             ),
@@ -259,11 +246,7 @@ def document_collection_method(
                 f'Creates an iterable up to a specified amount of '
                 f'{collection_model.resource.type} resources in the collection.'
             ),
-            'example_prefix': '{}_iterator = {}.{}.limit'.format(
-                xform_name(collection_model.resource.type),
-                example_resource_name,
-                collection_model.name,
-            ),
+            'example_prefix': f'{xform_name(collection_model.resource.type)}_iterator = {example_resource_name}.{collection_model.name}.limit',
             'include_input': [
                 DocumentedShape(
                     name='count',
@@ -282,11 +265,7 @@ def document_collection_method(
                 f'resources in the collection, but limits the number of '
                 f'items returned by each service call by the specified amount.'
             ),
-            'example_prefix': '{}_iterator = {}.{}.page_size'.format(
-                xform_name(collection_model.resource.type),
-                example_resource_name,
-                collection_model.name,
-            ),
+            'example_prefix': f'{xform_name(collection_model.resource.type)}_iterator = {example_resource_name}.{collection_model.name}.page_size',
             'include_input': [
                 DocumentedShape(
                     name='count',

--- a/boto3/docs/method.py
+++ b/boto3/docs/method.py
@@ -51,8 +51,8 @@ def document_model_driven_resource_method(
         resource_type = resource_action_model.resource.type
 
         new_return_section = section.add_new_section('return')
-        return_resource_type = '{}.{}'.format(
-            operation_model.service_model.service_name, resource_type
+        return_resource_type = (
+            f'{operation_model.service_model.service_name}.{resource_type}'
         )
 
         return_type = f':py:class:`{return_resource_type}`'

--- a/boto3/docs/resource.py
+++ b/boto3/docs/resource.py
@@ -91,9 +91,7 @@ class ResourceDocumenter(BaseDocumenter):
     def _add_description(self, section):
         official_service_name = get_official_service_name(self._service_model)
         section.write(
-            'A resource representing an {} {}'.format(
-                official_service_name, self._resource_name
-            )
+            f'A resource representing an {official_service_name} {self._resource_name}'
         )
 
     def _add_example(self, section, identifier_names):
@@ -103,19 +101,12 @@ class ResourceDocumenter(BaseDocumenter):
         section.style.new_line()
         section.style.new_line()
         section.write(
-            '{} = boto3.resource(\'{}\')'.format(
-                self._service_name, self._service_name
-            )
+            f'{self._service_name} = boto3.resource(\'{self._service_name}\')'
         )
         section.style.new_line()
         example_values = get_identifier_values_for_example(identifier_names)
         section.write(
-            '{} = {}.{}({})'.format(
-                xform_name(self._resource_name),
-                self._service_name,
-                self._resource_name,
-                example_values,
-            )
+            f'{xform_name(self._resource_name)} = {self._service_name}.{self._resource_name}({example_values})'
         )
         section.style.end_codeblock()
 

--- a/boto3/docs/subresource.py
+++ b/boto3/docs/subresource.py
@@ -118,12 +118,7 @@ def document_sub_resource(
     example_resource_name = xform_name(resource_name)
     if service_model.service_name == resource_name:
         example_resource_name = resource_name
-    example = '{} = {}.{}({})'.format(
-        xform_name(sub_resource_model.resource.type),
-        example_resource_name,
-        sub_resource_model.name,
-        example_values,
-    )
+    example = f'{xform_name(sub_resource_model.resource.type)} = {example_resource_name}.{sub_resource_model.name}({example_values})'
     example_section.style.start_codeblock()
     example_section.write(example)
     example_section.style.end_codeblock()
@@ -141,10 +136,7 @@ def document_sub_resource(
     return_section = section.add_new_section('return')
     return_section.style.new_line()
     return_section.write(
-        ':rtype: :py:class:`{}.{}`'.format(
-            get_service_module_name(service_model),
-            sub_resource_model.resource.type,
-        )
+        f':rtype: :py:class:`{get_service_module_name(service_model)}.{sub_resource_model.resource.type}`'
     )
     return_section.style.new_line()
     return_section.write(

--- a/boto3/docs/waiter.py
+++ b/boto3/docs/waiter.py
@@ -104,8 +104,8 @@ def document_resource_waiter(
             waiter_model.max_attempts,
         )
     )
-    example_prefix = '{}.{}'.format(
-        xform_name(resource_name), resource_waiter_model.name
+    example_prefix = (
+        f'{xform_name(resource_name)}.{resource_waiter_model.name}'
     )
     full_waiter_name = (
         f"{section.context.get('qualifier', '')}{resource_waiter_model.name}"

--- a/boto3/resources/base.py
+++ b/boto3/resources/base.py
@@ -48,9 +48,7 @@ class ResourceMeta:
         self.resource_model = resource_model
 
     def __repr__(self):
-        return 'ResourceMeta(\'{}\', identifiers={})'.format(
-            self.service_name, self.identifiers
-        )
+        return f'ResourceMeta(\'{self.service_name}\', identifiers={self.identifiers})'
 
     def __eq__(self, other):
         # Two metas are equal if their components are all equal

--- a/boto3/resources/collection.py
+++ b/boto3/resources/collection.py
@@ -54,9 +54,7 @@ class ResourceCollection:
         return '{}({}, {})'.format(
             self.__class__.__name__,
             self._parent,
-            '{}.{}'.format(
-                self._parent.meta.service_name, self._model.resource.type
-            ),
+            f'{self._parent.meta.service_name}.{self._model.resource.type}',
         )
 
     def __iter__(self):
@@ -154,7 +152,7 @@ class ResourceCollection:
             paginator = client.get_paginator(self._py_operation_name)
             pages = paginator.paginate(
                 PaginationConfig={'MaxItems': limit, 'PageSize': page_size},
-                **params
+                **params,
             )
         else:
             logger.debug(
@@ -327,9 +325,7 @@ class CollectionManager:
         return '{}({}, {})'.format(
             self.__class__.__name__,
             self._parent,
-            '{}.{}'.format(
-                self._parent.meta.service_name, self._model.resource.type
-            ),
+            f'{self._parent.meta.service_name}.{self._model.resource.type}',
         )
 
     def iterator(self, **kwargs):
@@ -424,13 +420,11 @@ class CollectionFactory:
         )
 
         if service_context.service_name == resource_name:
-            cls_name = '{}.{}Collection'.format(
-                service_context.service_name, collection_name
+            cls_name = (
+                f'{service_context.service_name}.{collection_name}Collection'
             )
         else:
-            cls_name = '{}.{}.{}Collection'.format(
-                service_context.service_name, resource_name, collection_name
-            )
+            cls_name = f'{service_context.service_name}.{resource_name}.{collection_name}Collection'
 
         collection_cls = type(str(cls_name), (ResourceCollection,), attrs)
 

--- a/boto3/resources/model.py
+++ b/boto3/resources/model.py
@@ -374,9 +374,7 @@ class ResourceModel:
                 # This isn't good, let's raise instead of trying to keep
                 # renaming this value.
                 raise ValueError(
-                    'Problem renaming {} {} to {}!'.format(
-                        self.name, category, name
-                    )
+                    f'Problem renaming {self.name} {category} to {name}!'
                 )
 
         names.add(name)

--- a/boto3/resources/response.py
+++ b/boto3/resources/response.py
@@ -110,9 +110,7 @@ def build_empty_response(search_path, operation_name, service_model):
                 shape = shape.member
             else:
                 raise NotImplementedError(
-                    'Search path hits shape type {} from {}'.format(
-                        shape.type_name, item
-                    )
+                    f'Search path hits shape type {shape.type_name} from {item}'
                 )
 
     # Anything not handled here is set to None

--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -122,6 +122,7 @@ transfer.  For example:
 
 
 """
+
 import logging
 import threading
 from os import PathLike, fspath, getpid

--- a/boto3/session.py
+++ b/boto3/session.py
@@ -63,9 +63,7 @@ class Session:
 
         # Setup custom user-agent string if it isn't already customized
         if self._session.user_agent_name == 'Botocore':
-            botocore_info = 'Botocore/{}'.format(
-                self._session.user_agent_version
-            )
+            botocore_info = f'Botocore/{self._session.user_agent_version}'
             if self._session.user_agent_extra:
                 self._session.user_agent_extra += ' ' + botocore_info
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,12 +3,63 @@ markers = [
     "slow: marks tests as slow",
 ]
 
-[tool.isort]
-profile = "black"
-line_length = 79
-honor_noqa = true
-src_paths = ["boto3", "tests"]
+[tool.ruff]
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
 
-[tool.black]
+# Format same as Black.
 line-length = 79
-skip_string_normalization = true
+indent-width = 4
+
+target-version = "py38"
+
+[tool.ruff.lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = ["E4", "E7", "E9", "F", "I", "UP"]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings, spaces for indents
+# and trailing commas.
+quote-style = "preserve"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+
+docstring-code-format = false
+docstring-code-line-length = "dynamic"

--- a/scripts/new-change
+++ b/scripts/new-change
@@ -36,6 +36,7 @@ You can then use the ``scripts/gen-changelog`` to generate the
 CHANGELOG.rst file.
 
 """
+
 import argparse
 import json
 import os
@@ -132,9 +133,7 @@ def replace_issue_references(parsed, repo_name):
 
     def linkify(match):
         number = match.group()[1:]
-        return '`{} <https://github.com/{}/issues/{}>`__'.format(
-            match.group(), repo_name, number
-        )
+        return f'`{match.group()} <https://github.com/{repo_name}/issues/{number}>`__'
 
     new_description = re.sub(r'#\d+', linkify, description)
     parsed['description'] = new_description

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 """
 distutils/setuptools install script.
 """
+
 import os
 import re
 

--- a/tests/functional/docs/__init__.py
+++ b/tests/functional/docs/__init__.py
@@ -34,7 +34,7 @@ class BaseDocsFunctionalTests(unittest.TestCase):
             contents = contents[(beginning + len(line)) :]
 
     def get_class_document_block(self, class_name, contents):
-        start_class_document = '.. py:class:: %s' % class_name
+        start_class_document = f'.. py:class:: {class_name}'
         start_index = contents.find(start_class_document)
         assert start_index != -1, 'Class is not found in contents'
         contents = contents[start_index:]
@@ -42,7 +42,7 @@ class BaseDocsFunctionalTests(unittest.TestCase):
         return contents[:end_index]
 
     def get_method_document_block(self, method_name, contents):
-        start_method_document = '  .. py:method:: %s(' % method_name
+        start_method_document = f'  .. py:method:: {method_name}('
         start_index = contents.find(start_method_document)
         assert start_index != -1, 'Method is not found in contents'
         contents = contents[start_index:]
@@ -68,7 +68,7 @@ class BaseDocsFunctionalTests(unittest.TestCase):
         return contents[:end_index]
 
     def get_request_parameter_document_block(self, param_name, contents):
-        start_param_document = ':type %s:' % param_name
+        start_param_document = f':type {param_name}:'
         start_index = contents.find(start_param_document)
         assert start_index != -1, 'Param is not found in contents'
         contents = contents[start_index:]
@@ -80,7 +80,7 @@ class BaseDocsFunctionalTests(unittest.TestCase):
         start_index = contents.find(start_param_document)
         assert start_index != -1, 'There is no response structure'
 
-        start_param_document = '- **%s**' % param_name
+        start_param_document = f'- **{param_name}**'
         start_index = contents.find(start_param_document)
         assert start_index != -1, 'Param is not found in contents'
         contents = contents[start_index:]

--- a/tests/functional/docs/test_smoke.py
+++ b/tests/functional/docs/test_smoke.py
@@ -119,13 +119,13 @@ def _assert_has_client_documentation(generated_docs, service_name, client):
         '======',
         'Client',
         '======',
-        '.. py:class:: %s.Client' % class_name,
+        f'.. py:class:: {class_name}.Client',
         '  A low-level client representing',
         '    import boto3',
-        '    client = boto3.client(\'%s\')' % service_name,
+        f'    client = boto3.client(\'{service_name}\')',
         'These are the available methods:',
-        '  %s/client/get_paginator' % service_name,
-        '  %s/client/get_waiter' % service_name,
+        f'  {service_name}/client/get_paginator',
+        f'  {service_name}/client/get_waiter',
     ]
     _assert_contains_lines_in_order(ref_lines, generated_docs)
     for method_name in ['get_paginator', 'get_waiter']:
@@ -153,9 +153,7 @@ def _assert_has_paginator_documentation(
     for paginator_name in paginator_names:
         _assert_contains_lines_in_order(
             [
-                '.. py:class:: {}.Paginator.{}'.format(
-                    client.__class__.__name__, paginator_name
-                ),
+                f'.. py:class:: {client.__class__.__name__}.Paginator.{paginator_name}',
                 '  .. py:method:: paginate(',
             ],
             get_nested_file_contents(
@@ -176,11 +174,8 @@ def _assert_has_waiter_documentation(
     for waiter_name in waiter_model.waiter_names:
         _assert_contains_lines_in_order(
             [
-                '.. py:class:: {}.Waiter.{}'.format(
-                    client.__class__.__name__, waiter_name
-                ),
-                '    waiter = client.get_waiter(\'%s\')'
-                % xform_name(waiter_name),
+                f'.. py:class:: {client.__class__.__name__}.Waiter.{waiter_name}',
+                f'    waiter = client.get_waiter(\'{xform_name(waiter_name)}\')',
                 '  .. py:method:: wait(',
             ],
             get_nested_file_contents(service_name, 'waiter', waiter_name),
@@ -203,8 +198,7 @@ def _assert_has_resource_documentation(generated_docs, service_name, resource):
         '================',
         'Service Resource',
         '================',
-        '.. py:class:: %s.ServiceResource'
-        % (resource.meta.client.__class__.__name__),
+        f'.. py:class:: {resource.meta.client.__class__.__name__}.ServiceResource',
         '  A resource representing',
         '    import boto3',
         f'    {service_name} = boto3.resource(\'{service_name}\')',

--- a/tests/functional/test_s3.py
+++ b/tests/functional/test_s3.py
@@ -147,8 +147,8 @@ class TestCopy(BaseTransferTest):
         for i in range(num_parts):
             # Fill in the parts
             part_number = i + 1
-            copy_range = "bytes={}-{}".format(
-                i * part_size, i * part_size + (part_size - 1)
+            copy_range = (
+                f"bytes={i * part_size}-{i * part_size + (part_size - 1)}"
             )
             self.stub_copy_part(part_number=part_number, copy_range=copy_range)
             parts.append({'ETag': self.etag, 'PartNumber': part_number})
@@ -389,8 +389,8 @@ class TestDownloadFileobj(BaseTransferTest):
         if end_byte is not None:
             contents = full_contents[start_byte : end_byte + 1]
             part_range = f'bytes={start_byte}-{end_byte_range}'
-            content_range = 'bytes={}-{}/{}'.format(
-                start_byte, end_byte, len(full_contents)
+            content_range = (
+                f'bytes={start_byte}-{end_byte}/{len(full_contents)}'
             )
             get_object_response['ContentRange'] = content_range
             expected_params['Range'] = part_range

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -210,7 +210,7 @@ class TestDynamodbBatchWrite(BaseDynamoDBTest):
         num_elements = 1000
         items = []
         for i in range(num_elements):
-            items.append({'MyHashKey': 'foo%s' % i, 'OtherKey': 'bar%s' % i})
+            items.append({'MyHashKey': f'foo{i}', 'OtherKey': f'bar{i}'})
         with self.table.batch_writer() as batch:
             for item in items:
                 batch.put_item(Item=item)

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -38,9 +38,7 @@ def assert_files_equal(first, second):
     second_md5 = md5_checksum(second)
     if first_md5 != second_md5:
         raise AssertionError(
-            "Files are not equal: {}(md5={}) != {}(md5={})".format(
-                first, first_md5, second, second_md5
-            )
+            f"Files are not equal: {first}(md5={first_md5}) != {second}(md5={second_md5})"
         )
 
 
@@ -270,7 +268,7 @@ class TestS3Resource(unittest.TestCase):
         # Create several versions of an object
         obj = self.bucket.Object('test.txt')
         for i in range(10):
-            obj.put(Body="Version %s" % i)
+            obj.put(Body=f"Version {i}")
 
             # Delete all the versions of the object
             bucket.object_versions.all().delete()

--- a/tests/unit/resources/test_action.py
+++ b/tests/unit/resources/test_action.py
@@ -126,9 +126,7 @@ class TestServiceActionCall(BaseTestCase):
     def test_service_action_call_positional_argument(self):
         def _api_call(*args, **kwargs):
             if args:
-                raise TypeError(
-                    "%s() only accepts keyword arguments." % 'get_frobs'
-                )
+                raise TypeError("get_frobs() only accepts keyword arguments.")
 
         resource = mock.Mock()
         resource.meta = ResourceMeta('test', client=mock.Mock())
@@ -304,9 +302,7 @@ class TestBatchActionCall(BaseTestCase):
 
         def _api_call(*args, **kwargs):
             if args:
-                raise TypeError(
-                    "%s() only accepts keyword arguments." % 'get_frobs'
-                )
+                raise TypeError("get_frobs() only accepts keyword arguments.")
 
         crp_mock.side_effect = side_effect
 

--- a/tests/unit/resources/test_factory.py
+++ b/tests/unit/resources/test_factory.py
@@ -379,7 +379,7 @@ class TestResourceFactory(BaseTestResourceFactory):
     def test_resource_lazy_properties_missing_load(self, action_cls):
         model = {
             'shape': 'TestShape',
-            'identifiers': [{'name': 'Url'}]
+            'identifiers': [{'name': 'Url'}],
             # Note the lack of a `load` method. These resources
             # are usually loaded via a call on a parent resource.
         }


### PR DESCRIPTION
This is the first in an upcoming set of changes to move our repos to use [`ruff`](https://github.com/astral-sh/ruff) in favor of our existing `pre-commit` cocktail.

This should be largely inline with our existing configuration with some minor changes to fix f-string upgrades missed with our previous setup and some newline fixes. This PR keeps our existing quote preservation behavior until we get all projects moved to `ruff`. At that point, we can look at turning it to "double".