### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# You can configure git to automatically use this file with the following config:
+# git config --global blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Run ruff over codebase
+50d25e9b90a74763d4f2fa411fa6a5092fcaa98c


### PR DESCRIPTION
Add a [.git-blame-ignore-revs](https://github.com/orgs/community/discussions/5033) file like our other repositories to strip our formatting commits from the `git blame` history ([botocore example](https://github.com/boto/botocore/blob/develop/.git-blame-ignore-revs)).