### PR TITLE
Fix CI for Python >= 3.12

### DIFF
--- a/scripts/ci/install-dev-deps
+++ b/scripts/ci/install-dev-deps
@@ -27,5 +27,5 @@ def run(command):
 if __name__ == "__main__":
     with cd(REPO_ROOT):
         if sys.version_info[:2] >= (3, 12):
-            run("pip install setuptools")
+            run("pip install setuptools==67.8.0")
         run("pip install -r requirements-dev-lock.txt")


### PR DESCRIPTION
Our CI for Python >= 3.12 has started failing since [setuptools-71.0.0](https://github.com/pypa/setuptools/blob/main/NEWS.rst#v7100) was released on 7/17:
> Now setuptools declares its own dependencies in the core extra. Dependencies are still vendored for bootstrapping purposes, but setuptools will prefer installed dependencies if present. The core extra is used for informational purposes and should not be declared in package metadata (e.g. build-requires). Downstream packagers can de-vendor by simply removing the setuptools/_vendor directory. Since Setuptools now prefers installed dependencies, those installing to an environment with old, incompatible dependencies will not work. In that case, either uninstall the incompatible dependencies or upgrade them to satisfy those declared in core. (#2825)

This CR installs `pip install setuptools==67.8.0` before running CI as opposed to `pip install setuptools`. This matches the following requirement defined in `requirements-dev.txt` and prevents similar issues in the future:
```
setuptools==67.8.0;python_version>="3.12"
```