### PR TITLE
Use built-in `logging.NullHandler`

### DIFF
--- a/boto3/__init__.py
+++ b/boto3/__init__.py
@@ -101,11 +101,6 @@ def resource(*args, **kwargs):
     return _get_default_session().resource(*args, **kwargs)
 
 
-# Set up logging to ``/dev/null`` like a library is supposed to.
+# Set up do-nothing logging like a library is supposed to.
 # https://docs.python.org/3.3/howto/logging.html#configuring-logging-for-a-library
-class NullHandler(logging.Handler):
-    def emit(self, record):
-        pass
-
-
-logging.getLogger('boto3').addHandler(NullHandler())
+logging.getLogger('boto3').addHandler(logging.NullHandler())


### PR DESCRIPTION
Available since Python 3.1.

Also fixes the comment: `/dev/null` wouldn't be a thing on Windows OSes 😉 