### PR TITLE
Remove macOS fallback now that setup-python issue is resolved

### DIFF
--- a/.github/workflows/run-crt-test.yml
+++ b/.github/workflows/run-crt-test.yml
@@ -16,15 +16,6 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        # Python 3.8 and 3.9 do not run on m1 hardware which is now standard for
-        # macOS-latest.
-        # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
-        exclude:
-        - { python-version: "3.8", os: "macos-latest" }
-        - { python-version: "3.9", os: "macos-latest" }
-        include:
-        - { python-version: "3.8", os: "macos-13" }
-        - { python-version: "3.9", os: "macos-13" }
 
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,15 +17,6 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        # Python 3.8 and 3.9 do not run on m1 hardware which is now standard for
-        # macOS-latest.
-        # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
-        exclude:
-        - { python-version: "3.8", os: "macos-latest" }
-        - { python-version: "3.9", os: "macos-latest" }
-        include:
-        - { python-version: "3.8", os: "macos-13" }
-        - { python-version: "3.9", os: "macos-13" }
 
     steps:
     - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938


### PR DESCRIPTION
Now that the original underlying issue appears to have been solved in setup-python in August. We can remove these special cased runners on the older hardware.