### PR TITLE
Fixed style consistency in the set up part example of readme.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ Then, set up a default region (in e.g. ``~/.aws/config``):
 .. code-block:: ini
 
    [default]
-   region=us-east-1
+   region = us-east-1
 
 Other credential configuration methods can be found `here <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html>`__
 


### PR DESCRIPTION
<img width="795" alt="Screenshot 2024-11-14 at 6 33 18 PM" src="https://github.com/user-attachments/assets/c6cab45e-04e4-4c4c-88f7-7c743a8c8d9b">
It isn't have a problem with the example describing the action, but I think it is better to style is the same.