### PR TITLE
Changed description for after-call Boto3 specific events

### DIFF
--- a/docs/source/guide/events.rst
+++ b/docs/source/guide/events.rst
@@ -223,7 +223,7 @@ information about each event can be found in the corresponding sections below:
 
   ``2 *`` - ``creating-resource-class`` is emitted ONLY when using a service resource.
 
-  ``8 *`` - ``after-call`` is emitted when a successful API response is received.
+  ``8 *`` - ``after-call`` is emitted once the API response is received.
 
   ``9 *`` - ``after-call-error`` is emitted when an unsuccessful API response is received.
 


### PR DESCRIPTION
As per the Issue: https://github.com/boto/boto3/issues/4344 , corrected the documentation to properly explains the behavior of after-call operation. after-call is not just only emitted from a successful API response, but its also emitted for unsuccessful API response.  