### PR TITLE
Updated SHA for stale-issue-cleanup. Updated closed-issue-message with correct node-version.

### DIFF
--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -12,6 +12,9 @@ jobs:
         permissions:
             issues: write
         steps:
+        - uses: actions/setup-node@v3
+          with:
+            node-version: '16'
         - uses: aws-actions/closed-issue-message@37548691e7cc75ba58f85c9f873f9eee43590449
           with:
             # These inputs are both required

--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@119dcadf8036efef52409d94132c9441c346285c
+    - uses: aws-actions/stale-issue-cleanup@dacf26a740f5da654de2c70e7e958dea44000851
       with:
         issue-types: issues
         stale-issue-message: Greetings! It looks like this issue hasn’t been 


### PR DESCRIPTION
The SHA for stale-issue-cleanup was set to the previous major version. It has now been updated to point to the latest version (7.0.0). The closed-issue-message workflow was running on the wrong version of node which was causing it to break. It is has been updated to use v16 which allows the action to run as expected.