### PR TITLE
import OrderedDict without going through botocore.compat shim

### DIFF
--- a/boto3/docs/base.py
+++ b/boto3/docs/base.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from botocore.compat import OrderedDict
+from collections import OrderedDict
 
 
 class BaseDocumenter:

--- a/tests/unit/docs/__init__.py
+++ b/tests/unit/docs/__init__.py
@@ -14,9 +14,9 @@ import json
 import os
 import shutil
 import tempfile
+from collections import OrderedDict
 
 import botocore.session
-from botocore.compat import OrderedDict
 from botocore.docs.bcdoc.restdoc import DocumentStructure
 from botocore.loaders import Loader
 


### PR DESCRIPTION
This remove a now unneeded indirrection and makes it easier to audit the remaining valid uses of botocore.compat

https://github.com/boto/botocore/blob/c70be78172757a3e2ff2b4b4f794164fd678d6ba/botocore/compat.py#L25