### PR TITLE
Ignore .venv directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ tests/.coverage
 coverage.xml
 
 # Common virtualenv names
+.venv
 venv
 env2
 env3


### PR DESCRIPTION
Add .venv and venv to our .gitignore file to avoid accidental inclusion.