### PR TITLE
User agent 2.1: Track S3Transfer usage

### DIFF
--- a/boto3/s3/inject.py
+++ b/boto3/s3/inject.py
@@ -13,9 +13,7 @@
 import copy as python_copy
 from functools import partial
 
-from botocore.context import with_current_context
 from botocore.exceptions import ClientError
-from botocore.useragent import register_feature_id
 
 from boto3 import utils
 from boto3.s3.transfer import (
@@ -24,6 +22,29 @@ from boto3.s3.transfer import (
     TransferConfig,
     create_transfer_manager,
 )
+
+try:
+    from botocore.context import with_current_context
+except ImportError:
+    from functools import wraps
+
+    def with_current_context(hook=None):
+        def decorator(func):
+            @wraps(func)
+            def wrapper(*args, **kwargs):
+                return func(*args, **kwargs)
+
+            return wrapper
+
+        return decorator
+
+
+try:
+    from botocore.useragent import register_feature_id
+except ImportError:
+
+    def register_feature_id(feature_id):
+        pass
 
 
 def inject_s3_transfer_methods(class_attributes, **kwargs):

--- a/boto3/s3/inject.py
+++ b/boto3/s3/inject.py
@@ -11,8 +11,11 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import copy as python_copy
+from functools import partial
 
+from botocore.context import with_current_context
 from botocore.exceptions import ClientError
+from botocore.useragent import register_feature_id
 
 from boto3 import utils
 from boto3.s3.transfer import (
@@ -104,6 +107,7 @@ def object_summary_load(self, *args, **kwargs):
     self.meta.data = response
 
 
+@with_current_context(partial(register_feature_id, 'S3_TRANSFER'))
 def upload_file(
     self, Filename, Bucket, Key, ExtraArgs=None, Callback=None, Config=None
 ):
@@ -151,6 +155,7 @@ def upload_file(
         )
 
 
+@with_current_context(partial(register_feature_id, 'S3_TRANSFER'))
 def download_file(
     self, Bucket, Key, Filename, ExtraArgs=None, Callback=None, Config=None
 ):
@@ -368,6 +373,7 @@ def object_download_file(
     )
 
 
+@with_current_context(partial(register_feature_id, 'S3_TRANSFER'))
 def copy(
     self,
     CopySource,
@@ -579,6 +585,7 @@ def object_copy(
     )
 
 
+@with_current_context(partial(register_feature_id, 'S3_TRANSFER'))
 def upload_fileobj(
     self, Fileobj, Bucket, Key, ExtraArgs=None, Callback=None, Config=None
 ):
@@ -738,6 +745,7 @@ def object_upload_fileobj(
     )
 
 
+@with_current_context(partial(register_feature_id, 'S3_TRANSFER'))
 def download_fileobj(
     self, Bucket, Key, Fileobj, ExtraArgs=None, Callback=None, Config=None
 ):


### PR DESCRIPTION
Companion PR to https://github.com/boto/botocore/pull/3389

#### Description
This PR uses the context variable introduced in the Botocore PR linked above to track usage of S3Transfer. I decorated the functions that serve as the "entrypoint" for a client invocation because there wouldn't be a current Botocore context variable between client creation and invocation. I intentionally excluded Resources from registering features since they're feature-frozen.