### PR TITLE
Add account ID to boto3 session and client

### DIFF
--- a/boto3/session.py
+++ b/boto3/session.py
@@ -44,6 +44,8 @@ class Session:
     :type profile_name: string
     :param profile_name: The name of a profile to use. If not given, then
                          the default profile is used.
+    :type aws_account_id: string
+    :param aws_account_id: AWS account ID
     """
 
     def __init__(
@@ -54,6 +56,7 @@ class Session:
         region_name=None,
         botocore_session=None,
         profile_name=None,
+        aws_account_id=None,
     ):
         if botocore_session is not None:
             self._session = botocore_session
@@ -74,9 +77,17 @@ class Session:
         if profile_name is not None:
             self._session.set_config_variable('profile', profile_name)
 
-        if aws_access_key_id or aws_secret_access_key or aws_session_token:
+        if (
+            aws_access_key_id
+            or aws_secret_access_key
+            or aws_session_token
+            or aws_account_id
+        ):
             self._session.set_credentials(
-                aws_access_key_id, aws_secret_access_key, aws_session_token
+                aws_access_key_id,
+                aws_secret_access_key,
+                aws_session_token,
+                aws_account_id,
             )
 
         if region_name is not None:
@@ -224,6 +235,7 @@ class Session:
         aws_secret_access_key=None,
         aws_session_token=None,
         config=None,
+        aws_account_id=None,
     ):
         """
         Create a low-level service client by name.
@@ -291,6 +303,10 @@ class Session:
             <https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html>`_
             for more details.
 
+        :type aws_account_id: string
+        :param aws_account_id: The account id to use when creating
+            the client.  Same semantics as aws_access_key_id above.
+
         :return: Service client instance
 
         """
@@ -305,6 +321,7 @@ class Session:
             aws_secret_access_key=aws_secret_access_key,
             aws_session_token=aws_session_token,
             config=config,
+            aws_account_id=aws_account_id,
         )
 
     def resource(

--- a/boto3/session.py
+++ b/boto3/session.py
@@ -77,12 +77,7 @@ class Session:
         if profile_name is not None:
             self._session.set_config_variable('profile', profile_name)
 
-        if (
-            aws_access_key_id
-            or aws_secret_access_key
-            or aws_session_token
-            or aws_account_id
-        ):
+        if aws_access_key_id or aws_secret_access_key or aws_session_token:
             self._session.set_credentials(
                 aws_access_key_id,
                 aws_secret_access_key,

--- a/boto3/session.py
+++ b/boto3/session.py
@@ -77,7 +77,13 @@ class Session:
         if profile_name is not None:
             self._session.set_config_variable('profile', profile_name)
 
-        if aws_access_key_id or aws_secret_access_key or aws_session_token:
+        creds = (
+            aws_access_key_id,
+            aws_secret_access_key,
+            aws_session_token,
+            aws_account_id,
+        )
+        if any(creds):
             self._session.set_credentials(
                 aws_access_key_id,
                 aws_secret_access_key,

--- a/boto3/session.py
+++ b/boto3/session.py
@@ -16,7 +16,11 @@ import os
 
 import botocore.session
 from botocore.client import Config
-from botocore.exceptions import DataNotFoundError, UnknownServiceError
+from botocore.exceptions import (
+    DataNotFoundError,
+    NoCredentialsError,
+    UnknownServiceError,
+)
 
 import boto3
 import boto3.utils
@@ -84,6 +88,10 @@ class Session:
             aws_account_id,
         )
         if any(creds):
+            if self._account_id_set_without_credentials(
+                aws_account_id, aws_access_key_id, aws_secret_access_key
+            ):
+                raise NoCredentialsError()
             self._session.set_credentials(
                 aws_access_key_id,
                 aws_secret_access_key,
@@ -545,3 +553,10 @@ class Session:
                 event_emitter=self.events,
             ),
         )
+
+    def _account_id_set_without_credentials(
+        self, account_id, access_key, secret_key
+    ):
+        if account_id and access_key is None and secret_key is None:
+            return True
+        return False

--- a/boto3/session.py
+++ b/boto3/session.py
@@ -557,6 +557,8 @@ class Session:
     def _account_id_set_without_credentials(
         self, account_id, access_key, secret_key
     ):
-        if account_id and access_key is None and secret_key is None:
+        if account_id is None:
+            return False
+        elif access_key is None or secret_key is None:
             return True
         return False

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -13,7 +13,7 @@
 import pytest
 from botocore import loaders
 from botocore.client import Config
-from botocore.exceptions import UnknownServiceError
+from botocore.exceptions import NoCredentialsError, UnknownServiceError
 
 from boto3 import __version__
 from boto3.exceptions import ResourceNotExistsError
@@ -90,6 +90,15 @@ class TestSession(BaseTestCase):
         bc_session.set_credentials.assert_called_with(
             'key', 'secret', 'token', 'account'
         )
+
+    def test_account_id_set_without_credentials(self):
+        bc_session = self.bc_session_cls.return_value
+
+        with pytest.raises(NoCredentialsError) as e:
+            Session(aws_account_id='account_id')
+
+        assert not bc_session.set_credentials.called
+        assert 'Unable to locate credentials' in str(e.value)
 
     def test_can_get_credentials(self):
         access_key = 'foo'

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -66,6 +66,22 @@ class TestSession(BaseTestCase):
             aws_access_key_id='key',
             aws_secret_access_key='secret',
             aws_session_token='token',
+        )
+
+        assert self.bc_session_cls.called
+        assert bc_session.set_credentials.called
+        bc_session.set_credentials.assert_called_with(
+            'key', 'secret', 'token', None
+        )
+
+    def test_credentials_can_be_set_with_account_id(self):
+        bc_session = self.bc_session_cls.return_value
+
+        # Set values in constructor
+        Session(
+            aws_access_key_id='key',
+            aws_secret_access_key='secret',
+            aws_session_token='token',
             aws_account_id='account',
         )
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -79,11 +79,13 @@ class TestSession(BaseTestCase):
         access_key = 'foo'
         secret_key = 'bar'
         token = 'baz'
+        account_id = 'bin'
 
         creds = mock.Mock()
         creds.access_key = access_key
         creds.secret_key = secret_key
         creds.token = token
+        creds.account_id = account_id
 
         bc_session = self.bc_session_cls.return_value
         bc_session.get_credentials.return_value = creds
@@ -92,12 +94,14 @@ class TestSession(BaseTestCase):
             aws_access_key_id=access_key,
             aws_secret_access_key=secret_key,
             aws_session_token=token,
+            aws_account_id=account_id,
         )
 
         credentials = session.get_credentials()
         assert credentials.access_key == access_key
         assert credentials.secret_key == secret_key
         assert credentials.token == token
+        assert credentials.account_id == account_id
 
     def test_profile_can_be_set(self):
         bc_session = self.bc_session_cls.return_value

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -66,11 +66,14 @@ class TestSession(BaseTestCase):
             aws_access_key_id='key',
             aws_secret_access_key='secret',
             aws_session_token='token',
+            aws_account_id='account',
         )
 
         assert self.bc_session_cls.called
         assert bc_session.set_credentials.called
-        bc_session.set_credentials.assert_called_with('key', 'secret', 'token')
+        bc_session.set_credentials.assert_called_with(
+            'key', 'secret', 'token', 'account'
+        )
 
     def test_can_get_credentials(self):
         access_key = 'foo'
@@ -240,6 +243,7 @@ class TestSession(BaseTestCase):
             region_name='us-west-2',
             api_version=None,
             config=None,
+            aws_account_id=None,
         )
 
     def test_create_resource_with_args(self):


### PR DESCRIPTION
This PR introduces account ID to `Session` and `client`. The update allows users to specify an `aws_account_id` variable when creating a `Session` object or a `client`. The account ID will then be associated with the credentials when they are loaded.

Note: The documentation in credentials [developer guide](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html) will be updated in an upcoming PR.