### PR TITLE
Removed dead link from kms-example-encrypt-decrypt-file.rst

### DIFF
--- a/docs/source/guide/kms-example-encrypt-decrypt-file.rst
+++ b/docs/source/guide/kms-example-encrypt-decrypt-file.rst
@@ -29,9 +29,6 @@ example, with the ``pip`` command.
 
     pip install cryptography
 
-Each section describes a single function from the example's `entire
-source file <https://github.com/awsdocs/aws-doc-sdk-examples/tree/master/python/example_code/kms/encrypt_decrypt_file.py>`_.
-
 
 Retrieve an existing master key
 ===============================


### PR DESCRIPTION
Resolves #4450, remaking https://github.com/boto/boto3/pull/4452 because I accidently closed it.

Removed dead link to a file that no longer exists