### PR TITLE
Update lint workflow to use ubuntu-latest

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938


### PR DESCRIPTION
### Summary
Full support for `ubuntu-20.04` was dropped on . See https://github.com/actions/runner-images/issues/11101 for more information.

This is resulting in the `lint` workflow failing with the following errors:
```
This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-01. For more details, see https://github.com/actions/runner-images/issues/11101
```

```
GitHub Actions has encountered an internal error when running your job.
```

This PR updates our lint workflow to use `ubuntu-latest`, similar to our other workflows.