### PR TITLE
Add MRAP section to developer guide

### DIFF
--- a/docs/source/guide/s3-example-mrap.rst
+++ b/docs/source/guide/s3-example-mrap.rst
@@ -1,0 +1,27 @@
+.. Copyright 2010-2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   This work is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0
+   International License (the "License"). You may not use this file except in compliance with the
+   License. A copy of the License is located at http://creativecommons.org/licenses/by-nc-sa/4.0/.
+
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+   either express or implied. See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+##########################
+Multi-Region Access Points
+##########################
+
+Amazon S3 Multi-Region Access Points (MRAPs) provide global endpoints that
+applications can use to fulfill requests from Amazon S3 buckets located in
+multiple AWS Regions. You can use them to build multi-Region applications
+with the same architecture used by single-Region applications, then run those
+applications anywhere in the world.
+
+To learn more about using Multi-Region Access Points in your Boto3
+application, see `Using Multi-Region Access Points with supported API
+operations <https://docs.aws.amazon.com/AmazonS3/latest/userguide/MrapOperations.html>`_,
+which offers a thorough explanation as well as examples for the CLI and for
+the SDK for Python.
+

--- a/docs/source/guide/s3-example-mrap.rst
+++ b/docs/source/guide/s3-example-mrap.rst
@@ -1,4 +1,4 @@
-.. Copyright 2010-2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+.. Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
    This work is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0
    International License (the "License"). You may not use this file except in compliance with the

--- a/docs/source/guide/s3-examples.rst
+++ b/docs/source/guide/s3-examples.rst
@@ -38,4 +38,5 @@ services.
    s3-example-access-permissions
    s3-example-static-web-host
    s3-example-configuring-buckets
+   s3-example-mrap
    s3-example-privatelink


### PR DESCRIPTION
This PR adds a section to the dev guide that briefly says what MRAP is and points to the content in the S3 developer guide, which includes Python examples.