### PR TITLE
workaround fork

### DIFF
--- a/boto3/crt.py
+++ b/boto3/crt.py
@@ -29,6 +29,7 @@ from s3transfer.crt import (
     CRTTransferManager,
     acquire_crt_s3_process_lock,
     create_s3_crt_client,
+    clean_up_s3_crt_client
 )
 
 # Singletons for CRT-backed transfers
@@ -40,6 +41,7 @@ PROCESS_LOCK_NAME = 'boto3'
 
 
 def _create_crt_client(session, config, region_name, cred_provider):
+    print("_create_crt_client")
     """Create a CRT S3 Client for file transfer.
 
     Instantiating many of these may lead to degraded performance or
@@ -74,6 +76,7 @@ def _create_crt_s3_client(
 
 
 def _initialize_crt_transfer_primatives(client, config):
+    print(f"before _initialize_crt_transfer_primatives is {CRT_S3_CLIENT}")
     lock = acquire_crt_s3_process_lock(PROCESS_LOCK_NAME)
     if lock is None:
         # If we're unable to acquire the lock, we cannot
@@ -96,6 +99,28 @@ def get_crt_s3_client(client, config):
     global CRT_S3_CLIENT
     global BOTOCORE_CRT_SERIALIZER
 
+    import os
+    import gc
+    from awscrt.common import join_all_native_threads
+
+    def before_fork():
+        global CRT_S3_CLIENT
+        try:
+            if CRT_S3_CLIENT is not None:
+                # The client is not safe to use after fork, so we need to release it.
+                # make sure the client is shutdown properly before fork
+                # also wait for every thread to be joined, incase of some thread is in the middle of cleanup.
+                CRT_S3_CLIENT = None
+                gc.collect()
+                if join_all_native_threads(timeout_sec=0.5) is False:
+                    # generate warning about the background threads still runnning.
+                    # It's possible when CRT used spearately from user, but it's user's responsbility to clean those up.
+                    print("WARNING: Background threads still running, dead lock or crash could happen. Check for CRT resources held before forking.")
+
+        except:
+            exit(-1)
+
+
     with CLIENT_CREATION_LOCK:
         if CRT_S3_CLIENT is None:
             serializer, s3_client = _initialize_crt_transfer_primatives(
@@ -104,6 +129,10 @@ def get_crt_s3_client(client, config):
             BOTOCORE_CRT_SERIALIZER = serializer
             CRT_S3_CLIENT = s3_client
 
+    os.register_at_fork(before=before_fork)
+    # Only register the handler once.
+    if not getattr(get_crt_s3_client, '_fork_handler_registered', False):
+        get_crt_s3_client._fork_handler_registered = True
     return CRT_S3_CLIENT
 
 

--- a/boto3/crt.py
+++ b/boto3/crt.py
@@ -41,7 +41,6 @@ PROCESS_LOCK_NAME = 'boto3'
 
 
 def _create_crt_client(session, config, region_name, cred_provider):
-    print("_create_crt_client")
     """Create a CRT S3 Client for file transfer.
 
     Instantiating many of these may lead to degraded performance or
@@ -76,7 +75,6 @@ def _create_crt_s3_client(
 
 
 def _initialize_crt_transfer_primatives(client, config):
-    print(f"before _initialize_crt_transfer_primatives is {CRT_S3_CLIENT}")
     lock = acquire_crt_s3_process_lock(PROCESS_LOCK_NAME)
     if lock is None:
         # If we're unable to acquire the lock, we cannot


### PR DESCRIPTION
### Notes:
- A prove of concept, not ready to merge yet.
- Needs adding integration tests and polish the code
  - I guess boto3 try to avoid using awscrt directly, I guess we could have s3transfer to expose `join_all_native_threads`
  - suggestions are welcome

### Issue:
- In CRT, we creates background threads, and fork is not safe with background threads at all.
- From CRT perspective, it's basically impossible to track all threads and recreate them after fork. So, pushing the threads management to boto3 here.
- As boto3 owns the CRT S3 client, which is the only CRT resource boto3 uses with background threads (I am not 100% percent sure, but looked into botocore, the CRT singer depends on static credentials provider, so it's not creating background threads, and it works on my reproduce code.)
- So, boto3 can register a fork handler to clean up the CRT client and wait for threads to join.
- From the forked process, new client will be created if needed, and it will be safe to use.
- Notes: logger can create background threads, but it's not managed thread that will block the call, and it's also kind safe to be used (not lead to a crash at least)