### PR TITLE
Add 3.8 deprecation date

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,9 @@ Boto (pronounced boh-toh) was named after the fresh water dolphin native to the 
 Notices
 -------
 
-On 2023-12-13, support for Python 3.7 ended for Boto3. This follows the
-Python Software Foundation `end of support <https://peps.python.org/pep-0537/#lifespan>`__
-for the runtime which occurred on 2023-06-27.
+On 2025-04-22, support for Python 3.8 will end for Boto3. This follows the
+Python Software Foundation `end of support <https://peps.python.org/pep-0569/#lifespan>`__
+for the runtime which occurred on 2024-10-07.
 For more information, see this `blog post <https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/>`__.
 
 .. _boto: https://docs.pythonboto.org/


### PR DESCRIPTION
This PR adds a notice with target date for end of support of Python 3.8 across Boto3, Botocore and the AWS CLI v1. This follows the originally announced deprecation timeline in [our blog post](https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/).