### PR TITLE
Format examples in presigned urls guide

### DIFF
--- a/docs/source/guide/s3-presigned-urls.rst
+++ b/docs/source/guide/s3-presigned-urls.rst
@@ -43,10 +43,11 @@ when the URL is generated.
         # Generate a presigned URL for the S3 object
         s3_client = boto3.client('s3')
         try:
-            response = s3_client.generate_presigned_url('get_object',
-                                                        Params={'Bucket': bucket_name,
-                                                                'Key': object_name},
-                                                        ExpiresIn=expiration)
+            response = s3_client.generate_presigned_url(
+                'get_object',
+                Params={'Bucket': bucket_name, 'Key': object_name},
+                ExpiresIn=expiration,
+            )
         except ClientError as e:
             logging.error(e)
             return None
@@ -63,7 +64,7 @@ perform a GET request.
 
 .. code-block:: python
 
-    import requests    # To install: pip install requests
+    import requests  # To install: pip install requests
 
     url = create_presigned_url('amzn-s3-demo-bucket', 'OBJECT_NAME')
     if url is not None:
@@ -92,8 +93,9 @@ the appropriate method so this argument is not normally required.
     from botocore.exceptions import ClientError
 
 
-    def create_presigned_url_expanded(client_method_name, method_parameters=None,
-                                      expiration=3600, http_method=None):
+    def create_presigned_url_expanded(
+        client_method_name, method_parameters=None, expiration=3600, http_method=None
+    ):
         """Generate a presigned URL to invoke an S3.Client method
 
         Not all the client methods provided in the AWS Python SDK are supported.
@@ -108,10 +110,12 @@ the appropriate method so this argument is not normally required.
         # Generate a presigned URL for the S3 client method
         s3_client = boto3.client('s3')
         try:
-            response = s3_client.generate_presigned_url(ClientMethod=client_method_name,
-                                                        Params=method_parameters,
-                                                        ExpiresIn=expiration,
-                                                        HttpMethod=http_method)
+            response = s3_client.generate_presigned_url(
+                ClientMethod=client_method_name,
+                Params=method_parameters,
+                ExpiresIn=expiration,
+                HttpMethod=http_method,
+            )
         except ClientError as e:
             logging.error(e)
             return None
@@ -134,8 +138,9 @@ request and requires additional parameters to be sent as part of the request.
     from botocore.exceptions import ClientError
 
 
-    def create_presigned_post(bucket_name, object_name,
-                              fields=None, conditions=None, expiration=3600):
+    def create_presigned_post(
+        bucket_name, object_name, fields=None, conditions=None, expiration=3600
+    ):
         """Generate a presigned URL S3 POST request to upload a file
 
         :param bucket_name: string
@@ -152,11 +157,13 @@ request and requires additional parameters to be sent as part of the request.
         # Generate a presigned S3 POST URL
         s3_client = boto3.client('s3')
         try:
-            response = s3_client.generate_presigned_post(bucket_name,
-                                                         object_name,
-                                                         Fields=fields,
-                                                         Conditions=conditions,
-                                                         ExpiresIn=expiration)
+            response = s3_client.generate_presigned_post(
+                bucket_name,
+                object_name,
+                Fields=fields,
+                Conditions=conditions,
+                ExpiresIn=expiration,
+            )
         except ClientError as e:
             logging.error(e)
             return None
@@ -172,7 +179,7 @@ presigned POST URL to perform a POST request to upload a file to S3.
 
 .. code-block:: python
 
-    import requests    # To install: pip install requests
+    import requests  # To install: pip install requests
 
     # Generate a presigned S3 POST URL
     object_name = 'OBJECT_NAME'


### PR DESCRIPTION
Small PR to format examples in the S3 Presigned URLs dev guide. We should do a follow up to format all examples in our repos.

---

### Testing
Used the following steps to generate docs and verify they generate correctly:
1. Create a venv using `uv venv -p 3.8`
2. Activate the venv `uv pip install -r requirements-docs.txt`
3. Install boto3 `uv pip install -e .`
4. Change into the docs directory using `cd docs`
5. Build the docs using `make clean html`
    - I modified `boto3/docs/__init__.py` to only generate docs for one service to speed the build up.
7. Change into the directory with generated html files `cd build/html`
8. Host the html files locally `python -m http.server`
9. Verify the `http://[::]:8000/guide/s3-presigned-urls.html` page renders correctly.