### PR TITLE
Use importlib for lazy calls

### DIFF
--- a/boto3/utils.py
+++ b/boto3/utils.py
@@ -10,7 +10,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import sys
 from collections import namedtuple
 from importlib import import_module
 


### PR DESCRIPTION
The `__import__` function is an internal and intended for use by the Python interpreter only - not for general use.

It’s safer to use `importlib.import_module()`, which removes the need for manual handling and reduces potential errors.

