### PR TITLE
Use a single thread for download_fileobj for append mode

### DIFF
--- a/.changes/next-release/bugfix-downloadfileobj-69709.json
+++ b/.changes/next-release/bugfix-downloadfileobj-69709.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``download_fileobj``",
+  "description": "Fileobj provided in append mode will no longer allow concurrent writes to preserve data integrity."
+}

--- a/boto3/compat.py
+++ b/boto3/compat.py
@@ -24,6 +24,8 @@ from boto3.exceptions import PythonDeprecationWarning
 # ConnectionError
 SOCKET_ERROR = ConnectionError
 
+_APPEND_MODE_CHAR = 'a'
+
 import collections.abc as collections_abc
 
 
@@ -80,3 +82,7 @@ def _warn_deprecated_python():
             "later. More information can be found here: {}"
         ).format(py_version[0], py_version[1], params['date'], params['blog_link'])
         warnings.warn(warning, PythonDeprecationWarning)
+
+
+def is_append_mode(fileobj):
+    return hasattr(fileobj, 'mode') and _APPEND_MODE_CHAR in fileobj.mode


### PR DESCRIPTION
Fixes https://github.com/boto/boto3/issues/1446 by using a single thread if the provided file-like object for `download_fileobj` is in append mode.