### PR TITLE
Ensure fileobj mode is str when checking for append mode

### DIFF
--- a/boto3/compat.py
+++ b/boto3/compat.py
@@ -85,4 +85,8 @@ def _warn_deprecated_python():
 
 
 def is_append_mode(fileobj):
-    return hasattr(fileobj, 'mode') and _APPEND_MODE_CHAR in fileobj.mode
+    return (
+            hasattr(fileobj, 'mode') and
+            isinstance(fileobj.mode, str) and
+            _APPEND_MODE_CHAR in fileobj.mode
+    )

--- a/boto3/compat.py
+++ b/boto3/compat.py
@@ -86,7 +86,7 @@ def _warn_deprecated_python():
 
 def is_append_mode(fileobj):
     return (
-            hasattr(fileobj, 'mode') and
-            isinstance(fileobj.mode, str) and
-            _APPEND_MODE_CHAR in fileobj.mode
+        hasattr(fileobj, 'mode') and
+        isinstance(fileobj.mode, str) and
+        _APPEND_MODE_CHAR in fileobj.mode
     )

--- a/tests/unit/s3/test_inject.py
+++ b/tests/unit/s3/test_inject.py
@@ -10,6 +10,7 @@
 # distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import gzip
 import io
 
 import pytest
@@ -277,6 +278,18 @@ def test_disable_threading_if_append_mode(caplog, tmp_path):
 def test_threading_not_disabled_if_not_append_mode(caplog, tmp_path):
     config = TransferConfig(use_threads=True)
     with open(tmp_path / 'myfile', 'wb') as f:
+        inject.disable_threading_if_append_mode(config, f)
+    assert config.use_threads is True
+    assert 'A single thread will be used' not in caplog.text
+
+
+def test_threading_not_disabled_if_mode_non_string(caplog, tmp_path):
+    config = TransferConfig(use_threads=True)
+    with gzip.open(tmp_path / 'myfile', 'wb') as f:
+        # In Python 3.13, gzip started assigning strings
+        # instead of integers for mode. Explicitly set
+        # mode to an integer to ensure we test the right behavior.
+        f.mode = 2
         inject.disable_threading_if_append_mode(config, f)
     assert config.use_threads is True
     assert 'A single thread will be used' not in caplog.text


### PR DESCRIPTION
Fixes https://github.com/boto/boto3/issues/4526

If a file-like object with a non-standard interface (eg integer value for `mode` property) is passed to `is_append_mode`, it may cause a runtime error or undefined behavior. We can't make assumptions about unknown interfaces, so always return `False` if `mode` isn't a string. Shutting off threading for every non-string implementation is going to have unknown performance impact.