### PR TITLE
Move __file__ references to use importlib.resources.files

### DIFF
--- a/boto3/docs/service.py
+++ b/boto3/docs/service.py
@@ -10,13 +10,13 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import importlib.resources
 import os
 
 from botocore.docs.bcdoc.restdoc import DocumentStructure
 from botocore.docs.service import ServiceDocumenter as BaseServiceDocumenter
 from botocore.exceptions import DataNotFoundError
 
-import boto3
 from boto3.docs.client import Boto3ClientDocumenter
 from boto3.docs.resource import ResourceDocumenter, ServiceResourceDocumenter
 from boto3.utils import ServiceContext
@@ -24,7 +24,7 @@ from boto3.utils import ServiceContext
 
 class ServiceDocumenter(BaseServiceDocumenter):
     # The path used to find examples
-    EXAMPLE_PATH = os.path.join(os.path.dirname(boto3.__file__), 'examples')
+    EXAMPLE_PATH = str(importlib.resources.files('boto3') / 'examples')
 
     def __init__(self, service_name, session, root_docs_path):
         super().__init__(

--- a/boto3/session.py
+++ b/boto3/session.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 import copy
-import os
+import importlib.resources
 
 import botocore.session
 from botocore.client import Config
@@ -147,9 +147,8 @@ class Session:
         Setup loader paths so that we can load resources.
         """
         self._loader = self._session.get_component('data_loader')
-        self._loader.search_paths.append(
-            os.path.join(os.path.dirname(__file__), 'data')
-        )
+        data_path = str(importlib.resources.files('boto3') / 'data')
+        self._loader.search_paths.append(data_path)
 
     def get_available_services(self):
         """


### PR DESCRIPTION
This PR is a proposal to move us off __file__ references and use `importlib.resources.files` now that we've dropped Python 3.8 support. The primary goal of this change is to ensure we're maintaining existing strings, but allowing use of tools like `zipapp` and `PyOxidizer`.

This PR will need some additional testing, but when used in tandem with https://github.com/boto/botocore/pull/3464 _should_ allow users to start packaging this. I'll follow up in https://github.com/boto/boto3/issues/1770 and https://github.com/boto/boto3/issues/2191 for additional feedback.