### PR TITLE
Add official Python 3.14 support with first release candidate

### DIFF
--- a/.changes/next-release/enhancement-Python-69244.json
+++ b/.changes/next-release/enhancement-Python-69244.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Python",
+  "description": "Added provisional support for the upcoming Python 3.14 release"
+}

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
     ],
     project_urls={
         'Documentation': 'https://boto3.amazonaws.com/v1/documentation/api/latest/index.html',


### PR DESCRIPTION
The first release candidate for Python 3.14 is tentatively scheduled for July 22nd ([ref](https://peps.python.org/pep-0745/)). We've been stable through the beta process and since we're entering feature lock, we should be good to start advertising support to enable other tools to onboard early.