### PR TITLE
Update set_credentials to no longer pass aws_account_id

### DIFF
--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -70,9 +70,7 @@ class TestSession(BaseTestCase):
 
         assert self.bc_session_cls.called
         assert bc_session.set_credentials.called
-        bc_session.set_credentials.assert_called_with(
-            'key', 'secret', 'token', None
-        )
+        bc_session.set_credentials.assert_called_with('key', 'secret', 'token')
 
     def test_credentials_can_be_set_with_account_id(self):
         bc_session = self.bc_session_cls.return_value


### PR DESCRIPTION
Update call to set_credentials to only pass `aws_account_id` when explicitly set similar to #4585. 