### PR TITLE
Add note on circuit-breaking in standard retry mode to boto3

### DIFF
--- a/boto3_main.py
+++ b/boto3_main.py
@@ -1,0 +1,28 @@
+import time
+
+
+def benchmark_with_realistic_expectations():
+    # Original version
+    start = time.time()
+    index = 99
+    for i in range(100):
+        for j in range(100):
+            if j == index:
+                print(j)  # This I/O dominates the runtime
+                index = index - 1
+    original_time = time.time() - start
+
+    print("\n" + "=" * 50 + "\n")
+
+    # Optimized version  
+    start = time.time()
+    for i in range(99, -1, -1):
+        print(i)  # Same I/O cost
+    optimized_time = time.time() - start
+
+    print(f"Original time: {original_time:.4f} seconds")
+    print(f"Optimized time: {optimized_time:.4f} seconds")
+    print(f"Actual speedup: {original_time / optimized_time:.1f}x")
+
+
+benchmark_with_realistic_expectations()

--- a/docs/source/guide/retries.rst
+++ b/docs/source/guide/retries.rst
@@ -56,6 +56,7 @@ Standard mode is a retry mode that was introduced with the updated retry handler
 **Standard mode’s functionality includes:**
 
 * A default value of 3 for maximum attempts (including the initial request). See `Available configuration options`_ for more information on overwriting this value.
+* Circuit-breaking functionality to prevent retry attempts during service outages.
 * Retry attempts for an expanded list of errors/exceptions::
 
    # Transient errors/exceptions


### PR DESCRIPTION
Adds a note to our retries documentation to clarify that we will stop retries during service outages.  This is similar to what is in [the SDK-wide retry behavior docs](https://docs.aws.amazon.com/sdkref/latest/guide/feature-retry-behavior.html).

Here is a screenshot of the generated docs with the newly added text: 
<img width="822" height="181" alt="image" src="https://github.com/user-attachments/assets/9ffa734b-74db-4993-9494-76ca0143791a" />
