### PR TITLE
Add new preferred transfer client mode to enable CRT in all environments

### DIFF
--- a/.changes/next-release/feature-s3-53747.json
+++ b/.changes/next-release/feature-s3-53747.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "``s3``",
+  "description": "Added ``crt`` mode to ``preferred_transfer_client`` parameter in ``TransferConfig`` to enable CRT transfer client in all environments."
+}

--- a/boto3/s3/constants.py
+++ b/boto3/s3/constants.py
@@ -14,4 +14,5 @@
 
 # TransferConfig preferred_transfer_client settings
 CLASSIC_TRANSFER_CLIENT = "classic"
+CRT_TRANSFER_CLIENT = "crt"
 AUTO_RESOLVE_TRANSFER_CLIENT = "auto"

--- a/boto3/s3/transfer.py
+++ b/boto3/s3/transfer.py
@@ -184,15 +184,15 @@ def create_transfer_manager(client, config, osutil=None):
 
 def _should_use_crt(config):
     # This feature requires awscrt>=0.19.18
-    if HAS_CRT and has_minimum_crt_version((0, 19, 18)):
-        is_optimized_instance = awscrt.s3.is_optimized_for_system()
-    else:
-        is_optimized_instance = False
+    has_min_crt = HAS_CRT and has_minimum_crt_version((0, 19, 18))
+    is_optimized_instance = has_min_crt and awscrt.s3.is_optimized_for_system()
     pref_transfer_client = config.preferred_transfer_client.lower()
 
     if (
         is_optimized_instance
         and pref_transfer_client == constants.AUTO_RESOLVE_TRANSFER_CLIENT
+    ) or (
+        has_min_crt and pref_transfer_client == constants.CRT_TRANSFER_CLIENT
     ):
         logger.debug(
             "Attempting to use CRTTransferManager. Config settings may be ignored."
@@ -296,6 +296,7 @@ class TransferConfig(S3TransferConfig):
                   are made with supported environment and settings.
               * classic - Only use the origin S3TransferManager with
                   requests. Disables possible CRT upgrade on requests.
+              * crt - Only use the CRTTransferManager with requests.
         """
         super().__init__(
             multipart_threshold=multipart_threshold,

--- a/tests/functional/test_crt.py
+++ b/tests/functional/test_crt.py
@@ -69,6 +69,15 @@ class TestS3TransferWithCRT:
         assert isinstance(transfer_manager, CRTTransferManager)
 
     @requires_crt()
+    def test_create_transfer_manager_with_crt_preferred(self):
+        client = create_mock_client()
+        config = TransferConfig(
+            preferred_transfer_client='crt',
+        )
+        transfer_manager = create_transfer_manager(client, config)
+        assert isinstance(transfer_manager, CRTTransferManager)
+
+    @requires_crt()
     def test_minimum_crt_version(self):
         assert has_minimum_crt_version((0, 16, 12)) is True
 


### PR DESCRIPTION
Currently, `boto3` requires runtime environments in select optimized instance types to use the CRT transfer client (unless users directly interface with the `s3transfer` library). This commit adds a new `crt` mode to `TransferConfig`'s `preferred_transfer_client` parameter. When `crt` mode is used, `boto3` will enable CRT transfers in all environments as long as the minimum required version of CRT is installed.