### PR TITLE
Remove redundant blog post link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,12 +20,13 @@ Notices
 On 2026-04-29, support for Python 3.9 will end for Boto3. This follows the
 Python Software Foundation `end of support <https://peps.python.org/pep-0596/#lifespan>`__
 for the runtime which occurred on 2025-10-31.
-For more information, see this `blog post <https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/>`__.
 
 On 2025-04-22, support for Python 3.8 ended for Boto3. This follows the
 Python Software Foundation `end of support <https://peps.python.org/pep-0569/#lifespan>`__
 for the runtime which occurred on 2024-10-07.
-For more information, see this `blog post <https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/>`__.
+
+For more information on deprecations, see this
+`blog post <https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/>`__.
 
 .. _boto: https://docs.pythonboto.org/
 .. _`doc site`: https://boto3.amazonaws.com/v1/documentation/api/latest/index.html


### PR DESCRIPTION
This PR addresses the redundant blog post link by adding it once at the bottom of the `Notices` section.