### PR TITLE
Remove unused NoVersionFound exception

### DIFF
--- a/boto3/exceptions.py
+++ b/boto3/exceptions.py
@@ -24,12 +24,6 @@ class ResourceLoadException(Boto3Error):
     pass
 
 
-# NOTE: This doesn't appear to be used anywhere.
-# It's probably safe to remove this.
-class NoVersionFound(Boto3Error):
-    pass
-
-
 # We're subclassing from botocore.exceptions.DataNotFoundError
 # to keep backwards compatibility with anyone that was catching
 # this low level Botocore error before this exception was


### PR DESCRIPTION
## Description

Removes the unused `NoVersionFound` exception class from `boto3/exceptions.py`.

## Motivation

The `NoVersionFound` exception was added in October 2014 (commit 7600fa4c) during a refactoring to use Botocore's data loader, but it was never actually used anywhere in the codebase. The exception class has a comment noting it's safe to remove:

# NOTE: This doesn't appear to be used anywhere.
# It's probably safe to remove this.
class NoVersionFound(Boto3Error):
    pass## Verification

- ✅ Searched the entire codebase: `NoVersionFound` is not imported or referenced anywhere
- ✅ The functionality it was intended for is handled by `UnknownAPIVersionError`, which is actively used in `session.py`
- ✅ No documentation references this exception
- ✅ No tests reference this exception

## Impact

- **Breaking change:** No - this exception was never part of the public API
- **Documentation:** No changes needed - it was never documented
- **Tests:** No test changes needed - it was never tested

This is a simple code cleanup that removes dead code, making the codebase easier to maintain.