### PR TITLE
Fix flaky integration tests from resource name collisions

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,9 +11,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import random
-import time
 import unittest
+import uuid
 from unittest import mock
 
 from botocore.compat import HAS_CRT
@@ -21,12 +20,10 @@ from botocore.compat import HAS_CRT
 
 def unique_id(name):
     """
-    Generate a unique ID that includes the given name,
-    a timestamp and a random number. This helps when running
-    integration tests in parallel that must create remote
-    resources.
+    Generate a unique ID for integration tests
+    that create remote resources in parallel.
     """
-    return f'{name}-{int(time.time())}-{random.randint(0, 10000)}'
+    return f"{name}-{uuid.uuid4().hex}"
 
 
 class BaseTestCase(unittest.TestCase):


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This PR updates `unique_id()` to generate resource names using UUIDs instead of a timestamp + random integer. The previous approach could produce collisions when integration tests run in parallel, which occasionally led to `ResourceInUseException` errors (in `test_dynamodb.py`)when creating resources that were already in the process of being created.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
