### PR TITLE
Remove elastictranscoder from documentation

### DIFF
--- a/docs/source/guide/migration.rst
+++ b/docs/source/guide/migration.rst
@@ -28,8 +28,8 @@ Second, while every service now uses the runtime-generated low-level client, som
     import boto, boto3
 
     # Low-level connections
-    conn = boto.connect_elastictranscoder()
-    client = boto3.client('elastictranscoder')
+    conn = boto.connect_dynamodb()
+    client = boto3.client('dynamodb')
 
     # High-level connections & resource objects
     from boto.s3.bucket import Bucket


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
After the merge of https://github.com/boto/botocore/pull/3614, we can remove this example in the documentation here as the client will no longer be functional.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
