### PR TITLE
[Documentation] Add endpoint_url parameter guidance with warning for S3 clients and resources

### DIFF
--- a/docs/source/guide/s3-examples.rst
+++ b/docs/source/guide/s3-examples.rst
@@ -25,7 +25,7 @@ This section demonstrates how to use the AWS SDK for Python to access Amazon S3
 services.
 
 .. note::
-   Boto3 clients and resources have an option to use a custom endpoint using the ``endpoint_url`` parameter.
+   Boto3 clients and resources have an option to use a custom endpoint using the ``endpoint_url`` parameter as shown in the `Session Reference <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html>`_ guide.
    This overrides the default endpoint the client or resource will use.
    Use caution when configuring this parameter as it can cause unintended behavior including S3 redirect issues.
    See `Service-specific endpoints <https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html>`_ page in the *AWS SDK reference guide* for more information.


### PR DESCRIPTION
## Summary
Adds documentation improvements to S3 documentation for the endpoint_url parameter in boto3 clients and resources:

Add note explaining the endpoint_url parameter usage for boto3.client() and boto3.resource(). Includes warning with caution about unintended behavior including S3 redirect issues. References the AWS SDK reference guide for additional endpoint configuration information.

## Testing

<img width="1183" height="1153" alt="Screenshot 2025-12-30 at 1 20 46 PM" src="https://github.com/user-attachments/assets/29e06cb7-eb40-42f8-9086-1b3b0333dd6e" />
