### PR TITLE
Updated SourceClient documentation

### DIFF
--- a/boto3/s3/inject.py
+++ b/boto3/s3/inject.py
@@ -448,12 +448,12 @@ def copy(
         be periodically called during the copy.
 
     :type SourceClient: botocore or boto3 Client
-    :param SourceClient: The client to be used for operation that
+    :param SourceClient: The client to be used for operations that
         may happen at the source object. For example, this client is
         used for the head_object that determines the size of the copy.
-        The current client still requires IAM permissions to access 
-        both buckets. If no client is provided, the current client is 
-        used as the client for the source object.
+        If no client is provided, the current client is used as the
+        client for the source object.  The current client still
+        requires IAM permissions to access both buckets.
 
     :type Config: boto3.s3.transfer.TransferConfig
     :param Config: The transfer configuration to be used when performing the
@@ -528,12 +528,12 @@ def bucket_copy(
         be periodically called during the copy.
 
     :type SourceClient: botocore or boto3 Client
-    :param SourceClient: The client to be used for operation that
+    :param SourceClient: The client to be used for operations that
         may happen at the source object. For example, this client is
         used for the head_object that determines the size of the copy.
-        The current client still requires IAM permissions to access 
-        both buckets. If no client is provided, the current client is 
-        used as the client for the source object.
+        If no client is provided, the current client is used as the
+        client for the source object.  The current client still
+        requires IAM permissions to access both buckets.
 
     :type Config: boto3.s3.transfer.TransferConfig
     :param Config: The transfer configuration to be used when performing the
@@ -592,12 +592,12 @@ def object_copy(
         be periodically called during the copy.
 
     :type SourceClient: botocore or boto3 Client
-    :param SourceClient: The client to be used for operation that
+    :param SourceClient: The client to be used for operations that
         may happen at the source object. For example, this client is
         used for the head_object that determines the size of the copy.
-        The current client still requires IAM permissions to access 
-        both buckets. If no client is provided, the current client is 
-        used as the client for the source object.
+        If no client is provided, the current client is used as the
+        client for the source object.  The current client still
+        requires IAM permissions to access both buckets.
 
     :type Config: boto3.s3.transfer.TransferConfig
     :param Config: The transfer configuration to be used when performing the


### PR DESCRIPTION
Updated SourceClient documentation to clarify that the client still needs IAM permissions to access both buckets.

*Issue #, if available:*

N/A, internal ticket

*Description of changes:*

Added "The current client still requires IAM permissions to access both buckets."  to all SourceClient documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
