### PR TITLE
Add BOTOCORE_TCP_KEEPALIVE environment variable documentation

### DIFF
--- a/docs/source/guide/configuration.rst
+++ b/docs/source/guide/configuration.rst
@@ -249,6 +249,8 @@ You can set configuration settings using system-wide environment variables. Thes
     Toggles the TCP Keep-Alive socket option used when creating connections.
     Valid values are ``true`` or ``false``. By default, TCP Keep-Alive is disabled.
     When set to ``true``, TCP Keep-Alive will be enabled with the system default configurations.
+    This is the environment variable equivalent of the ``tcp_keepalive`` configuration file
+    setting and ``Config`` option.
 
 Using a configuration file
 --------------------------


### PR DESCRIPTION
## Description
Adds documentation for the `BOTOCORE_TCP_KEEPALIVE` environment variable that was introduced in boto/botocore#3579.

## Changes
- Added `BOTOCORE_TCP_KEEPALIVE` to the environment variables section in the configuration guide
- Documents that it accepts `true` or `false` values (case insensitive)
- Notes that TCP Keep-Alive is disabled by default
- Explains that when enabled, it uses system default configurations

## Related
- boto/botocore#3579