### PR TITLE
Start testing Python 3.15 Alpha

### DIFF
--- a/.github/workflows/run-crt-test.yml
+++ b/.github/workflows/run-crt-test.yml
@@ -11,10 +11,11 @@ permissions:
 jobs:
   build:
     runs-on: '${{ matrix.os }}'
+    continue-on-error: ${{ matrix.python-version == '3.15-dev' }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.15-dev']
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,10 +12,11 @@ jobs:
   build:
 
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.python-version == '3.15-dev' }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15-dev"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
> [!NOTE]
> This is the Boto3 version of https://github.com/boto/botocore/pull/3628

## Overview
This PR adds Python 3.15 canary coverage in CI to give us early signal for Python 3.15 regressions.

## Testing
```
# Create Python 3.15 virtual environment
uv venv -p 3.15
source .venv/bin/activate

# Install package and dev requirements
uv pip install -e .
uv pip install -r requirements-dev-lock.txt

# Run unit and functional tests
python -m pytest tests/unit tests/functional

# Run integration tests
python -m pytest tests/integration
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
