### PR TITLE
Remove shortbread domain override

### DIFF
--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -207,10 +207,7 @@ function setupKeyboardFriendlyNavigation() {
 
 function loadShortbread() {
 	if (typeof AWSCShortbread !== "undefined") {
-		const shortbread = AWSCShortbread({
-			// If you're testing in your dev environment, use ".cloudfront.net" for domain, else "boto3.amazonaws.com"
-			domain: "boto3.amazonaws.com",
-		});
+		const shortbread = AWSCShortbread();
 
 		// Check for cookie consent
 		shortbread.checkForCookieConsent();


### PR DESCRIPTION
> [!NOTE]
> This is the Boto3 version of https://github.com/boto/botocore/pull/3634

### Overview 
This PR removes the `domain` parameter passed to `AWSCShortbread` as part of the migration to `docs.aws.amazon.com`. Shortbread guidance specifies that the domain should not be set when running on `.aws.amazon.com`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
