### PR TITLE
fix: normalize decimal before DynamoDB context conversion

### DIFF
--- a/boto3/dynamodb/types.py
+++ b/boto3/dynamodb/types.py
@@ -286,7 +286,7 @@ class TypeDeserializer:
         return value
 
     def _deserialize_n(self, value):
-        return DYNAMODB_CONTEXT.create_decimal(value)
+        return DYNAMODB_CONTEXT.create_decimal(Decimal(value).normalize())
 
     def _deserialize_s(self, value):
         return value


### PR DESCRIPTION
## Summary
Fixes #4693.
**Root cause:** `DYNAMODB_CONTEXT.create_decimal(value)` failed for large numbers with trailing zeros because they were treated as significant digits, exceeding the context precision and raising `decimal.Rounded`.
**Fix:** Normalize the decimal value before passing it to the DynamoDB context, removing insignificant trailing zeros.
## Changes
- `boto3/dynamodb/types.py`: Added `Decimal(value).normalize()` before context conversion
## Testing
- Verified fix handles large numbers like `1234567895171680000000000000000000000000`
- Change is minimal and follows existing decimal handling patterns

Made with [Cursor](https://cursor.com)