### PR TITLE
fix(dynamodb): reject empty sets and non-string map keys in TypeSerializer

### DIFF
--- a/boto3/dynamodb/types.py
+++ b/boto3/dynamodb/types.py
@@ -189,7 +189,7 @@ class TypeSerializer:
         return False
 
     def _is_type_set(self, value, type_validator):
-        if self._is_set(value):
+        if self._is_set(value) and len(value) > 0:
             if False not in map(type_validator, value):
                 return True
         return False
@@ -237,6 +237,11 @@ class TypeSerializer:
         return [self.serialize(v) for v in value]
 
     def _serialize_m(self, value):
+        for k in value:
+            if not isinstance(k, str):
+                raise TypeError(
+                    f'Map keys must be strings, got {type(k).__name__}: {k!r}'
+                )
         return {k: self.serialize(v) for k, v in value.items()}
 
 

--- a/tests/unit/dynamodb/test_types.py
+++ b/tests/unit/dynamodb/test_types.py
@@ -143,6 +143,14 @@ class TestSerializer(unittest.TestCase):
             'M': {'foo': {'S': 'bar'}, 'baz': {'M': {'biz': {'N': '1'}}}}
         }
 
+    def test_serialize_empty_set_raises_error(self):
+        with pytest.raises(TypeError, match=r'Unsupported type'):
+            self.serializer.serialize(set())
+
+    def test_serialize_map_with_non_string_key_raises_error(self):
+        with pytest.raises(TypeError, match=r'Map keys must be strings'):
+            self.serializer.serialize({1: 'a'})
+
 
 class TestDeserializer(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Fixes

- Fixes #4738: TypeSerializer.serialize(set()) produced {"NS": []} which DynamoDB rejects. Now raises TypeError with a clear message.
- Fixes #4739: TypeSerializer accepted non-string map keys, producing output that silently converts keys or fails with confusing errors. Now raises TypeError before serialization.

## Changes

### boto3/dynamodb/types.py
- _is_type_set: Added len(value) > 0 check to prevent vacuous truth matching empty sets
- _serialize_m: Added validation that all map keys are str before serialization

### tests/unit/dynamodb/test_types.py
- Added test_serialize_empty_set_raises_error
- Added test_serialize_map_with_non_string_key_raises_error

## Testing
All 41 tests in test_types.py pass.