### PR TITLE
Quality: Fragile version parsing can crash with unclear error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,10 @@ requires = [
 
 def get_version():
     init = open(os.path.join(ROOT, 'boto3', '__init__.py')).read()
-    return VERSION_RE.search(init).group(1)
+    match = VERSION_RE.search(init)
+    if match is None:
+        raise RuntimeError('Unable to find __version__ in boto3/__init__.py')
+    return match.group(1)
 
 
 setup(


### PR DESCRIPTION
## Problem

`get_version()` assumes the regex always matches and calls `.group(1)` directly. If `__version__` format changes or file contents differ, setup fails with an unhelpful `AttributeError`.

**Severity**: `medium`
**File**: `setup.py`

## Solution

Validate regex match before dereferencing and raise a clear exception (e.g., `RuntimeError('Unable to find __version__ in boto3/__init__.py')`).

## Changes

- `setup.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
