### PR TITLE
[Documentation] Add virtual-hosted-style addressing to presigned URL documentation examples

### DIFF
--- a/docs/source/guide/s3-presigned-urls.rst
+++ b/docs/source/guide/s3-presigned-urls.rst
@@ -25,7 +25,7 @@ A presigned URL remains valid for a limited period of time which is specified
 when the URL is generated.
 
 It is recommended to configure the S3 client with Signature Version 4 
-(``s3v4``) and the AWS region of the bucket when generating presigned URLs.
+(``s3v4``), the AWS region of the bucket and to use virtual-hosted style addressing ``s3={'addressing_style': 'virtual'}`` when generating presigned URLs.
 
 .. code-block:: python
 
@@ -51,7 +51,10 @@ It is recommended to configure the S3 client with Signature Version 4
         s3_client = boto3.client(
             's3',
             region_name=region_name,
-            config=Config(signature_version='s3v4'),
+            config=Config(
+                signature_version='s3v4',
+                s3={'addressing_style': 'virtual'},
+            ),
         )
         try:
             response = s3_client.generate_presigned_url(
@@ -129,7 +132,10 @@ the appropriate method so this argument is not normally required.
         s3_client = boto3.client(
             's3',
             region_name=region_name,
-            config=Config(signature_version='s3v4'),
+            config=Config(
+                signature_version='s3v4',
+                s3={'addressing_style': 'virtual'},
+            ),
         )
         try:
             response = s3_client.generate_presigned_url(
@@ -187,7 +193,10 @@ request and requires additional parameters to be sent as part of the request.
         s3_client = boto3.client(
             's3',
             region_name=region_name,
-            config=Config(signature_version='s3v4'),
+            config=Config(
+                signature_version='s3v4',
+                s3={'addressing_style': 'virtual'},
+            ),
         )
         try:
             response = s3_client.generate_presigned_post(


### PR DESCRIPTION
## Description

Presigned URLs generated without `addressing_style='virtual'` use the legacy
global endpoint (`bucket.s3.amazonaws.com`), which returns
`SignatureDoesNotMatch` or `IllegalLocationConstraintException` errors for S3
buckets in newer Regions  (e.g., `eu-north-1`, `il-central-1`).

## Changes

- Updated the [recommendation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html) text to include virtual-hosted-style addressing 
- Added `s3={'addressing_style': 'virtual'}` to the `Config` in all three
  code examples: `create_presigned_url`, `create_presigned_url_expanded`,
  and `create_presigned_post`

## Testing

<img width="1200" height="1043" alt="Screenshot 2026-04-15 at 2 08 51 PM" src="https://github.com/user-attachments/assets/39af48aa-9906-4ded-9a05-0a3bf1f5552f" />

<img width="1478" height="862" alt="Screenshot 2026-04-15 at 2 09 07 PM" src="https://github.com/user-attachments/assets/26555d4b-adf9-4a5d-9430-8ce594bd1d41" />

<img width="1477" height="871" alt="Screenshot 2026-04-15 at 2 09 18 PM" src="https://github.com/user-attachments/assets/6ffc7c7e-7fb5-418e-a23e-51433355ec0a" />
