### PR TITLE
Fix typo in ServiceContext docstring (equivalient -> equivalent)

### DIFF
--- a/boto3/utils.py
+++ b/boto3/utils.py
@@ -40,7 +40,7 @@ class ServiceContext(_ServiceContext):
 
     :type resource_json_definitions: dict
     :param resource_json_definitions: The loaded json models of all resource
-        shapes for a service. It is equivalient of loading a
+        shapes for a service. It is equivalent of loading a
         ``resource-1.json`` and retrieving the value at the key "resources".
     """
 


### PR DESCRIPTION

**Repo:** boto/boto3 (⭐ 9000)
**Type:** docs
**Files changed:** 1
**Lines:** +1/-1

## What
Corrects a misspelling ("equivalient") to "equivalent" in the
`ServiceContext.resource_json_definitions` docstring in `boto3/utils.py`.
This docstring is consumed by Sphinx and surfaced in the public boto3
API reference.

## Why
`ServiceContext` is part of boto3's public API and the typo is rendered
verbatim in the published documentation at
docs.aws.amazon.com/boto3/. A single-character fix improves the
quality of the published docs at zero risk to runtime behavior. No
existing search hits anywhere else in the repo (boto3 source, tests,
or rst docs) for this misspelling.

## Testing
Pure docstring change — no behavioral impact. `python -c "import boto3.utils"`
still imports cleanly. No tests needed; `ruff` (the project's only style
gate) is unaffected.

## Risk
Low — single-word docstring fix, no code paths touched.
