### PR TITLE
docs: fix typo `corresponsing` → `corresponding` in custom.js

### DIFF
--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -90,7 +90,7 @@ function isValidResource(name, serviceDocName) {
 		window.location.assign(newPath);
 	}
 })();
-// Given a service name, we apply the html classes which indicate a current page to the corresponsing list item.
+// Given a service name, we apply the html classes which indicate a current page to the corresponding list item.
 // Before: <li class="toctree-l2"><a class="reference internal" href="../../acm.html">ACM</a></li>
 // After: <li class="toctree-l2 current current-page"><a class="reference internal" href="../../acm.html">ACM</a></li>
 function makeServiceLinkCurrent(serviceName) {


### PR DESCRIPTION
Fixes a single-character typo in a comment.

- File: `docs/source/_static/js/custom.js` (line ~93)
- Change: `corresponsing` → `corresponding`
- No code or behavior changes; comment-only edit.

Spotted with [`typos-cli`](https://github.com/crate-ci/typos). Happy to close if not useful.
