### PR TITLE
docs: fix typo `writeable` → `writable` in s3-example-download-file.rst

### DIFF
--- a/docs/source/guide/s3-example-download-file.rst
+++ b/docs/source/guide/s3-example-download-file.rst
@@ -27,7 +27,7 @@ download and the filename to save the file to.
     s3.download_file('amzn-s3-demo-bucket', 'OBJECT_NAME', 'FILE_NAME')
 
 
-The ``download_fileobj`` method accepts a writeable file-like object. The file 
+The ``download_fileobj`` method accepts a writable file-like object. The file 
 object must be opened in binary mode, not text mode.
 
 .. code-block:: python


### PR DESCRIPTION
Fixes a single-character typo in a comment.

- File: `docs/source/guide/s3-example-download-file.rst` (line ~30)
- Change: `writeable` → `writable`
- No code or behavior changes; comment-only edit.

Spotted with [`typos-cli`](https://github.com/crate-ci/typos). Happy to close if not useful.
