### PR TITLE
docs: fix typo `availabe` → `available` in test_collection.py

### DIFF
--- a/tests/unit/resources/test_collection.py
+++ b/tests/unit/resources/test_collection.py
@@ -158,7 +158,7 @@ class TestResourceCollection(BaseTestCase):
         # the collection is expecting to be required from its
         # definition. This saves a bunch of repetitive typing
         # and lets you just define a collection in the tests
-        # below. Any identifiers you expect to be availabe in
+        # below. Any identifiers you expect to be available in
         # the resource definition will automatically be there.
         resource_def = self.collection_def.get('resource', {})
         for identifier in resource_def.get('identifiers', []):


### PR DESCRIPTION
Fixes a single-character typo in a comment.

- File: `tests/unit/resources/test_collection.py` (line ~161)
- Change: `availabe` → `available`
- No code or behavior changes; comment-only edit.

Spotted with [`typos-cli`](https://github.com/crate-ci/typos). Happy to close if not useful.
