### PR TITLE
Enable Dependabot updates for pre-commit hooks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,9 @@ updates:
         update-types: ["version-update:semver-patch"]
     cooldown:
       default-days: 7
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 exclude: ^(.github|.changes|docs/|boto3/compat.py|boto3/data|CHANGELOG.rst)
 repos:
   - repo: 'https://github.com/pre-commit/pre-commit-hooks'
-    rev: v5.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.8
+    rev: d1b833175a5d08a925900115526febd8fe71c98e  # frozen: v0.15.11
     hooks:
       - id: ruff-check
         args: [ --fix ]


### PR DESCRIPTION
## Summary

Enable Dependabot support for `pre-commit` hook updates and refresh our current hook pins in `.pre-commit-config.yaml`.

## Why

GitHub added native Dependabot support for `pre-commit` hooks on March 10, 2026 ([source](https://github.blog/changelog/2026-03-10-dependabot-now-supports-pre-commit-hooks/)). With this change, Dependabot can now parse `.pre-commit-config.yaml` and open PRs when hook revisions need to be updated.

This lets us keep our pre-commit tooling current through the same automated workflow we already use for other dependency updates, instead of updating hook versions manually.

## Changes

- Add a `pre-commit` update entry to `.github/dependabot.yml`
- Update `.pre-commit-config.yaml` to the latest hook revisions
- Keep hooks pinned using frozen SHAs for reproducibility

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
