### PR TITLE
Group Dependabot updates by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,17 @@ updates:
         update-types: ["version-update:semver-patch"]
     cooldown:
       default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      pre-commit:
+        patterns:
+          - "*"


### PR DESCRIPTION
This groups Dependabot updates for GitHub Actions and pre-commit so Dependabot opens fewer PRs. Each ecosystem now has a group matching all dependencies, while preserving the existing weekly schedule, cooldown, and GitHub Actions patch-version ignore rule.