### PR TITLE
Bump requests from 2.32.4 to 2.33.1

### DIFF
--- a/requirements-docs-lock.txt
+++ b/requirements-docs-lock.txt
@@ -204,9 +204,9 @@ pygments==2.20.0 \
     # via
     #   furo
     #   sphinx
-requests==2.32.4 \
-    --hash=sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c \
-    --hash=sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422
+requests==2.33.1 \
+    --hash=sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517 \
+    --hash=sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a
     # via sphinx
 snowballstemmer==2.2.0 \
     --hash=sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1 \


### PR DESCRIPTION
## Summary

Dependabot is trying to bump our `requests` version from 2.32.4 to 2.33.0 in https://github.com/boto/boto3/pull/4779 despite there being a newer 2.33.1 version that's been available for more than 7 days (our configured dependabot cooldown). This PR manually updates us to 2.33.1

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
