### PR TITLE
Bump pytest from 8.1.1 to 9.0.3

### DIFF
--- a/requirements-dev-lock.txt
+++ b/requirements-dev-lock.txt
@@ -93,9 +93,13 @@ pluggy==1.5.0 \
     --hash=sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1 \
     --hash=sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669
     # via pytest
-pytest==8.1.1 \
-    --hash=sha256:2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7 \
-    --hash=sha256:ac978141a75948948817d360297b7aae0fcb9d6ff6bc9ec6d514b85d5a65c044
+pygments==2.20.0 \
+    --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
+    --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
+    # via pytest
+pytest==9.0.3 \
+    --hash=sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9 \
+    --hash=sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c
     # via
     #   -r requirements-dev.txt
     #   pytest-cov

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ setuptools==71.1.0;python_version>="3.12"
 packaging==24.1;python_version>="3.12"  # Requirement for setuptools>=71
 
 # Pytest specific deps
-pytest==8.1.1
+pytest==9.0.3
 pytest-cov==5.0.0
 atomicwrites>=1.0 # Windows requirement
 colorama>0.3.0 # Windows requirement


### PR DESCRIPTION
## Summary

Dependabot is trying to bump our `pytest` version from 8.1.1 to 9.0.3 in https://github.com/boto/boto3/pull/4780 despite. However, the dependabot PR is too targeted and missing an additional pin for `pygments` and causing tests to fail with the following error:

```
ERROR: In --require-hashes mode, all requirements must have their versions pinned with ==. These do not:
    pygments>=2.7.2 from https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl (from pytest==9.0.3->-r requirements-dev-lock.txt (line 96))
```

This PR manually updates the updated `pytest` version from 8.1.1 to 9.0.3 and regenerates the `requirements-dev-lock.txt` file.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
