### PR TITLE
Add Free Threading support to CI

### DIFF
--- a/.github/workflows/run-crt-test.yml
+++ b/.github/workflows/run-crt-test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.15-dev']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t', '3.15-dev']
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15-dev"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15-dev"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
         'Programming Language :: Python :: 3.14',
+        'Programming Language :: Python :: Free Threading :: 2 - Beta',
     ],
     project_urls={
         'Documentation': 'https://docs.aws.amazon.com/boto3/latest/',


### PR DESCRIPTION
*Description of changes:*
The primary blocker for supporting [free threading](https://peps.python.org/pep-0779/) in Boto3/Botocore/Smithy Python was support in the upstream dependency, awscrt. Starting in awscrt 0.32.0 (https://github.com/awslabs/aws-crt-python/pull/725), releases began distributing artifacts for Python 3.13t and 3.14t. While 3.13t was released as experimental, 3.14t is starting to gain adoption.

Given there are no remaining blockers, this PR adds beta support for free threaded builds and makes sure that contract is validated in CI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.