### PR TITLE
Add reference to post-quantum cryptography in security docs page

### DIFF
--- a/docs/source/guide/security.rst
+++ b/docs/source/guide/security.rst
@@ -236,7 +236,7 @@ Enforcing TLS 1.3
 
 The process of ensuring the AWS SDK for Python uses no TLS version earlier than TLS 1.3 is the same as the instructions in the `Enforcing TLS 1.2`_ section with some minor modifications, primarily adding the ``no-tls1_2`` flag to the openssl build configuration.
 
-TLS 1.3 is the prerequisite to enable post-quantum cryptography, which may require additional actions or configurations. To learn more, see `Enabling hybrid post-quantum TLS <https://docs.aws.amazon.com/sdkref/latest/guide/pqtls-details.html>`_.
+TLS 1.3 is a prerequisite to enable post-quantum cryptography, which may require additional actions or configurations. To learn more, see `Enabling hybrid post-quantum TLS <https://docs.aws.amazon.com/sdkref/latest/guide/pqtls-details.html>`_.
 
 The following are the modified build instructions::
 

--- a/docs/source/guide/security.rst
+++ b/docs/source/guide/security.rst
@@ -236,6 +236,8 @@ Enforcing TLS 1.3
 
 The process of ensuring the AWS SDK for Python uses no TLS version earlier than TLS 1.3 is the same as the instructions in the `Enforcing TLS 1.2`_ section with some minor modifications, primarily adding the ``no-tls1_2`` flag to the openssl build configuration.
 
+TLS 1.3 is the prerequisite to enable post-quantum cryptography, which may require additional actions or configurations. To learn more, see `Enabling hybrid post-quantum TLS <https://docs.aws.amazon.com/sdkref/latest/guide/pqtls-details.html>`_.
+
 The following are the modified build instructions::
 
 


### PR DESCRIPTION
*Issue #, if available:*

* Resolves V2236339343 (internal).

*Description of changes:*

* Add reference to post-quantum cryptography to the security docs page.

*Description of tests:*

* Successfully built the docs locally, and manually verified the expected HTML output.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
