### PR TITLE
Remove DocumentModifiedShape and re-export it from botocore

### DIFF
--- a/boto3/docs/utils.py
+++ b/boto3/docs/utils.py
@@ -83,5 +83,3 @@ def add_resource_type_overview(
             f':ref:`Resources Introduction Guide<{intro_link}>`.'
         )
         section.style.new_line()
-
-

--- a/boto3/docs/utils.py
+++ b/boto3/docs/utils.py
@@ -13,6 +13,7 @@
 import inspect
 
 import jmespath
+from botocore.docs.utils import DocumentModifiedShape  # noqa: F401
 
 
 def get_resource_ignore_params(params):
@@ -84,63 +85,3 @@ def add_resource_type_overview(
         section.style.new_line()
 
 
-class DocumentModifiedShape:
-    def __init__(
-        self, shape_name, new_type, new_description, new_example_value
-    ):
-        self._shape_name = shape_name
-        self._new_type = new_type
-        self._new_description = new_description
-        self._new_example_value = new_example_value
-
-    def replace_documentation_for_matching_shape(
-        self, event_name, section, **kwargs
-    ):
-        if self._shape_name == section.context.get('shape'):
-            self._replace_documentation(event_name, section)
-        for section_name in section.available_sections:
-            sub_section = section.get_section(section_name)
-            if self._shape_name == sub_section.context.get('shape'):
-                self._replace_documentation(event_name, sub_section)
-            else:
-                self.replace_documentation_for_matching_shape(
-                    event_name, sub_section
-                )
-
-    def _replace_documentation(self, event_name, section):
-        if event_name.startswith(
-            'docs.request-example'
-        ) or event_name.startswith('docs.response-example'):
-            section.remove_all_sections()
-            section.clear_text()
-            section.write(self._new_example_value)
-
-        if event_name.startswith(
-            'docs.request-params'
-        ) or event_name.startswith('docs.response-params'):
-            allowed_sections = (
-                'param-name',
-                'param-documentation',
-                'end-structure',
-                'param-type',
-                'end-param',
-            )
-            for section_name in section.available_sections:
-                # Delete any extra members as a new shape is being
-                # used.
-                if section_name not in allowed_sections:
-                    section.delete_section(section_name)
-
-            # Update the documentation
-            description_section = section.get_section('param-documentation')
-            description_section.clear_text()
-            description_section.write(self._new_description)
-
-            # Update the param type
-            type_section = section.get_section('param-type')
-            if type_section.getvalue().decode('utf-8').startswith(':type'):
-                type_section.clear_text()
-                type_section.write(f':type {section.name}: {self._new_type}')
-            else:
-                type_section.clear_text()
-                type_section.style.italics(f'({self._new_type}) -- ')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 -e git+https://github.com/boto/botocore.git@develop#egg=botocore
 -e git+https://github.com/boto/jmespath.git@develop#egg=jmespath
--e git+file:///Users/aemous/GitHub/s3transfer@callback#egg=s3transfer
-#-e git+https://github.com/boto/s3transfer.git@develop#egg=s3transfer
+-e git+https://github.com/boto/s3transfer.git@develop#egg=s3transfer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 -e git+https://github.com/boto/botocore.git@develop#egg=botocore
 -e git+https://github.com/boto/jmespath.git@develop#egg=jmespath
--e git+https://github.com/boto/s3transfer.git@develop#egg=s3transfer
+-e git+file:///Users/aemous/GitHub/s3transfer@callback#egg=s3transfer
+#-e git+https://github.com/boto/s3transfer.git@develop#egg=s3transfer

--- a/tests/functional/docs/test_dynamodb.py
+++ b/tests/functional/docs/test_dynamodb.py
@@ -89,7 +89,7 @@ class TestDynamoDBCustomizations(BaseDocsFunctionalTests):
                 ':param Item: **[REQUIRED]**',
                 '- *(string) --*',
                 (
-                    '- *(valid DynamoDB type) -- *- The value of the '
+                    '- *(valid DynamoDB type) --* - The value of the '
                     'attribute. The valid value types are listed in the '
                     ':ref:`DynamoDB Reference Guide<ref_valid_dynamodb_types>`.'
                 ),
@@ -106,7 +106,7 @@ class TestDynamoDBCustomizations(BaseDocsFunctionalTests):
                 '- **Attributes** *(dict) --*',
                 '- *(string) --*',
                 (
-                    '- *(valid DynamoDB type) -- *- The value of '
+                    '- *(valid DynamoDB type) --* - The value of '
                     'the attribute. The valid value types are listed in the '
                     ':ref:`DynamoDB Reference Guide<ref_valid_dynamodb_types>`.'
                 ),


### PR DESCRIPTION
*Issue #, if available:*

* Contributes to https://github.com/boto/boto3/issues/229
* Contributes to D95731475 (internal)

*Notes:*

* Must be sim-shipped with https://github.com/boto/botocore/pull/3721.
* Tests are expected to fail in the PR because the PR requires https://github.com/boto/botocore/pull/3721 to be merged.

*Description of changes:*

* Removed `DocumentModifiedShape` class and re-imported it from `botocore` for backwards compatibility.

*Description of tests:*

* Connected local boto3 to a modified botocore with the changes in https://github.com/boto/botocore/pull/3721 staged. Then, I rebuilt the docs, and verified the HTML looks correct:

<img width="772" height="166" alt="image" src="https://github.com/user-attachments/assets/7a5d59a6-6ad7-448f-8a2f-5bd0f9ac8e05" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
