### PR TITLE
fix: ensure generated DynamoDB placeholder names do not overwrite caller's (#4831)

### DIFF
--- a/boto3/dynamodb/conditions.py
+++ b/boto3/dynamodb/conditions.py
@@ -316,10 +316,16 @@ class ConditionExpressionBuilder:
     def _get_value_placeholder(self):
         return f":{self._value_placeholder}{self._value_count}"
 
-    def reset(self):
-        """Resets the placeholder name and values"""
-        self._name_count = 0
-        self._value_count = 0
+    def reset(self, name_count=0, value_count=0):
+        """Resets the placeholder name and values
+
+        ``name_count`` and ``value_count`` allow the caller to resume
+        placeholder numbering from a specific index, so generated
+        placeholders do not collide with placeholders the caller has
+        already provided (see boto3 issue #4831).
+        """
+        self._name_count = name_count
+        self._value_count = value_count
 
     def build_expression(self, condition, is_key_condition=False):
         """Builds the condition expression and the dictionary of placeholders.

--- a/boto3/dynamodb/transform.py
+++ b/boto3/dynamodb/transform.py
@@ -162,6 +162,27 @@ class TransformationInjector:
         if deserializer is None:
             self._deserializer = TypeDeserializer()
 
+    @staticmethod
+    def _next_placeholder_count(user_placeholders, prefix):
+        """Return the first placeholder index not used by the caller.
+
+        Generated placeholders use the form ``#n<k>`` / ``:v<k>``. If the
+        caller already supplies placeholders with that exact shape (e.g.
+        ``#n0``, ``:v3``) in ``ExpressionAttributeNames`` /
+        ``ExpressionAttributeValues``, the builder must start counting one
+        past the highest such index so ``dict.update()`` does not silently
+        overwrite the caller's values.
+        """
+        highest = -1
+        for placeholder in user_placeholders or {}:
+            if placeholder.startswith(prefix):
+                try:
+                    highest = max(highest, int(placeholder[len(prefix):]))
+                except ValueError:
+                    # Not a generated-style placeholder (e.g. '#a', ':c').
+                    continue
+        return highest + 1
+
     def inject_condition_expressions(self, params, model, **kwargs):
         """Injects the condition expression transformation into the parameters
 
@@ -169,7 +190,20 @@ class TransformationInjector:
         and KeyExpression shapes. It also handles any placeholder names and
         values that are generated when transforming the condition expressions.
         """
-        self._condition_builder.reset()
+        # Start placeholder counters above any user-supplied placeholders
+        # that share the generated naming scheme (#n<k> / :v<k>), so that
+        # the subsequent dict.update() does not silently overwrite the
+        # caller's values (see boto3 issue #4831).
+        starting_name_count = self._next_placeholder_count(
+            params.get('ExpressionAttributeNames', {}), '#n'
+        )
+        starting_value_count = self._next_placeholder_count(
+            params.get('ExpressionAttributeValues', {}), ':v'
+        )
+        self._condition_builder.reset(
+            name_count=starting_name_count,
+            value_count=starting_value_count,
+        )
         generated_names = {}
         generated_values = {}
 

--- a/tests/unit/dynamodb/test_transform.py
+++ b/tests/unit/dynamodb/test_transform.py
@@ -571,6 +571,38 @@ class TestTransformConditionExpression(BaseTransformationTest):
             },
         }
 
+    def test_key_and_attr_conditon_expression_colliding_placeholders(self):
+        # When the caller supplies placeholders that share the generated
+        # naming scheme (#n<k> / :v<k>), generated placeholders must
+        # start counting above the highest existing index so they do not
+        # silently overwrite the caller's values via dict.update().
+        # See boto3 issue #4831.
+        params = {
+            'KeyCondition': Key('foo').eq('bar'),
+            'AttrCondition': Attr('biz').eq('baz'),
+            'ExpressionAttributeNames': {'#n0': 'user_attr', '#other': 'x'},
+            'ExpressionAttributeValues': {':v0': 'user_val', ':custom': 'y'},
+        }
+        self.injector.inject_condition_expressions(
+            params, self.operation_model
+        )
+        assert params == {
+            'KeyCondition': '#n2 = :v2',
+            'AttrCondition': '#n1 = :v1',
+            'ExpressionAttributeNames': {
+                '#n1': 'biz',
+                '#n2': 'foo',
+                '#n0': 'user_attr',
+                '#other': 'x',
+            },
+            'ExpressionAttributeValues': {
+                ':v1': 'baz',
+                ':v2': 'bar',
+                ':v0': 'user_val',
+                ':custom': 'y',
+            },
+        }
+
 
 class TestCopyDynamoDBParams(unittest.TestCase):
     def test_copy_dynamodb_params(self):


### PR DESCRIPTION
## Summary

Fixes #4831

`ConditionExpressionBuilder` generates `#n<k>` / `:v<k>` placeholders starting from index 0 on every request. When the caller already provides `ExpressionAttributeNames` / `ExpressionAttributeValues` with keys that follow this pattern (e.g. `#n0`, `:v1`), the subsequent `dict.update()` in `inject_condition_expressions` silently overwrites the caller's values with generated ones, causing the caller's data to be replaced in the DynamoDB request.

## Fix

Scan the caller's existing `ExpressionAttributeNames` / `ExpressionAttributeValues` before building placeholders, and start the builder's counter at `max_index + 1` so generated placeholders never collide with user-provided ones.

## Changes

- `boto3/dynamodb/conditions.py`: `reset()` now accepts optional `name_count` / `value_count` parameters to resume from a specific index.
- `boto3/dynamodb/transform.py`: `inject_condition_expressions` computes the starting placeholder index from the caller's existing placeholders before calling `reset()`.
- `tests/unit/dynamodb/test_transform.py`: new test case `test_key_and_attr_conditon_expression_colliding_placeholders` verifies that user-provided `#n0` / `:v0` are preserved when generated ones start at `#n1` / `:v1`.

## Testing

All 179 existing tests pass. New test case added.