### PR TITLE
Add support for Python 3.15

### DIFF
--- a/.changes/next-release/enhancement-Python-48661.json
+++ b/.changes/next-release/enhancement-Python-48661.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Python",
+  "description": "Added support for Python 3.15"
+}

--- a/.github/workflows/run-crt-test.yml
+++ b/.github/workflows/run-crt-test.yml
@@ -11,11 +11,10 @@ permissions:
 jobs:
   build:
     runs-on: '${{ matrix.os }}'
-    continue-on-error: ${{ matrix.python-version == '3.15-dev' }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t', '3.15-dev']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t', '3.15', '3.15t']
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,11 +12,10 @@ jobs:
   build:
 
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.python-version == '3.15-dev' }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15-dev"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
         'Programming Language :: Python :: 3.14',
+        'Programming Language :: Python :: 3.15',
         'Programming Language :: Python :: Free Threading :: 2 - Beta',
     ],
     project_urls={

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py310,py311,py312,py313,py314
+envlist = py310,py311,py312,py313,py314,py315
 
 # Comment to build sdist and install into virtualenv
 # This is helpful to test installation but takes extra time


### PR DESCRIPTION
<!--*Issue #, if available:*
-->
*Description of changes:* The first release candidate for Python 3.15 has been out for quite some time. I think it's time to officially declare support for it (and add it to the testing matrix). I have ran tests on both 3.15 and 3.15t locally, and both suites pass.

See also:
- https://github.com/boto/s3transfer/pull/416
- https://github.com/boto/botocore/pull/3785

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
