### PR TITLE
fix: DynamoDB placeholder generation no longer overwrites caller values

### DIFF
--- a/boto3/dynamodb/transform.py
+++ b/boto3/dynamodb/transform.py
@@ -170,6 +170,26 @@ class TransformationInjector:
         values that are generated when transforming the condition expressions.
         """
         self._condition_builder.reset()
+        # Start placeholder numbering after any placeholders the caller
+        # already provided, so generated ones don't overwrite them (#4831).
+        expr_attr_names_input = 'ExpressionAttributeNames'
+        expr_attr_values_input = 'ExpressionAttributeValues'
+        if expr_attr_names_input in params:
+            used = [
+                int(name[2:])
+                for name in params[expr_attr_names_input]
+                if name.startswith("#n")
+            ]
+            if used:
+                self._condition_builder._name_count = max(used) + 1
+        if expr_attr_values_input in params:
+            used = [
+                int(value[2:])
+                for value in params[expr_attr_values_input]
+                if value.startswith(":v")
+            ]
+            if used:
+                self._condition_builder._value_count = max(used) + 1
         generated_names = {}
         generated_values = {}
 


### PR DESCRIPTION
Fixes #4831

**Problem**: ConditionExpressionBuilder restarts placeholder numbering at #n0/:v0 on every request, and the generated placeholders are merged over the caller's with dict.update — so a caller-supplied #n0/:v0 gets silently overwritten and the expression resolves to the wrong value.

**Fix**: after reset(), start placeholder numbering after the highest #n / :v index the caller already provided, so generated placeholders never collide with the caller's ExpressionAttributeNames/ExpressionAttributeValues.